### PR TITLE
update contrib component PerfectCrystal to version 1.1

### DIFF
--- a/mcstas-comps/contrib/PerfectCrystal.comp
+++ b/mcstas-comps/contrib/PerfectCrystal.comp
@@ -9,11 +9,21 @@
 *
 * %I
 * Written by: Markus Appel
-* Date: 2015-10-19
-* Version: $Revision: 1.0 $
+* Date: 2015-12-21
+* Version: $Revision: 1.1 $
 * Origin: ILL / FAU Erlangen-Nuernberg
 * Release: McStas 2.3
 * Based on a perfect crystal component by: Miguel A. Gonzalez, A. Dianoux June 2013 (ILL)
+*
+* Changelog:
+* Version 1.1
+*  - BUGFIX: correct neutron energy shift in Doppler mode
+*  - added option 'debyescherrer' to select analyzer geometry
+*  - added option 'facette' to approximate analyzer sphere by small, flat crystals
+* 
+* Version 1.0
+*  - inital release
+*
 *
 * %D
 * Perfect crystal component, primarily for use as monochromator and analyzer in
@@ -49,7 +59,7 @@
 *  ttmin:         (deg)
 *  ttmax:         (deg)   analyzer coverage angle in horizontal xz-plane between -180 and 180
 *  phimin:        (deg)   
-*  phimax:        (deg)   vertical analyzer coverage between -90 and 90
+*  phimax:        (deg)   vertical analyzer coverage between -90 and 90 (-180 and 180 if debyescherrer==1)
 * option 2:
 *  tt0:           (deg)   
 *  ttwidth:       (deg)   horizontal coverage as center and full width
@@ -58,8 +68,14 @@
 * option 3:
 *  tt0:           (deg)   angular center position in the horizontal plane (only if centerfocus==1)
 *  width:         (m)     absolute width
-*  tt0:           (deg)   angular vertical position (only if centerfocus==1)
-*  height:        (m)     absolute height
+*  phi0:          (deg)   angular vertical position (only if centerfocus==1)
+*  height:        (m)     absolute height (only if debyescherrer==0)
+*
+* debyescherrer:  (0/1)   bend analyzer following a Debye-Scherrer ring along scattering angle tt (twotheta)
+*                         (phi = [-180...180] in that case). Default: 0
+* facette:        (m)     width of square crystal facettes arranged on the spherical surface (set 0 to disable). Default: 0
+*                         Warning: Facettation will fail at the poles along +-y axis.
+* facette_xi:     (deg)   random misalignemt of each facette. Default: 0
 *
 * (B) Neutron optics:
 * ===================
@@ -69,6 +85,7 @@
 *
 * Ewald/Darwin mode:
 *  dtauovertau:           Plateau width of the Ewald/Darwin curve (see [1])
+*  dtauovertau_ext:       Relative variation of tau (randomized for each trajectory, full width)
 *  ewald:         (0/1)   Use Ewald curve if 1, Darwin curve if 0. Default: 1 (Ewald)
 *
 * Gaussian mode:
@@ -106,7 +123,7 @@
 * xi              (deg)   Reflection angle between neutron trajectory and analyzer surface normal
 * phid            (rad)   Actual doppler phase during reflection [0,2*PI]
 * vd              (m/s)   Actual doppler speed during reflection
-* zd              (m)     Actual doppler displacement during reflection
+* zd              (m)     Actual doppler displacement during reflection (zd>0 => displaced towards inc. beam from -z)
 * v0              (m/s)   Backscattered neutron velocity
 * E0              (meV)   Backscattered neutron energy
 * R               (0...1) Reflectivity value (on Gauss/Darwin/Ewald curve)
@@ -119,26 +136,117 @@
 DEFINE COMPONENT PerfectCrystal
 DEFINITION PARAMETERS ()
 SETTING PARAMETERS ( ttmin=NAN, ttmax=NAN, tt0=NAN, ttwidth=NAN, width=NAN,
-                    phimin=NAN, phimax=NAN, phi0=NAN, phiwidth=NAN, height=NAN,
-                    centerfocus=0, radius=0, tau=NAN, lambda=NAN, R0=1.0, dtauovertau=NAN,
+                    phimin=NAN, phimax=NAN, phi0=NAN, phiwidth=NAN, height=NAN, debyescherrer=0,
+                    facette=0, facette_xi=0, centerfocus=0, radius=0, tau=NAN, lambda=NAN, R0=1.0, 
+                    dtauovertau=NAN, dtauovertau_ext=0,
                     ewald=1,sigma=NAN,ismirror=0,speed=0,amplitude=0,smartphase=0,
                     smartwidth=NAN, exclusive=0, transmit=0, verbose=0 )
-OUTPUT PARAMETERS (tt,phi,xi,phid,vd,zd,v0,vmin,vmax,vperp,E0,R,eps)
+OUTPUT PARAMETERS (
+   // official
+   tt,phi,xi,phid,vd,zd,v0,vmin,vmax,vperp,E0,R,eps,
+   // internal
+   sin_facette_xi
+   )
 SHARE
 %{
-   // convert spherical (r,tt,phi) to cartesian (x,y,z) coordinates (angles in deg)
-   void sph2cart(double *x,double *y,double *z, double r, double tt, double phi)
+   // convert between spherical (r,tt,phi) and cartesian (x,y,z) coordinates (angles in deg)
+   // debyescherrer swaps axes
+   void sph2cart(double *x,double *y,double *z, double r, double tt, double phi, int debyescherrer)
    {
       tt *= DEG2RAD;
       phi *= DEG2RAD;
-      *x = - r * cos(phi) * sin(tt);
-      *y = r * sin(phi);
-      *z = r * cos(phi) * cos(tt);
+      if (debyescherrer) {
+         double sintt = sin(tt);
+         *x = - r * cos(phi) * sintt;
+         *y = r * sin(phi) * sintt;
+         *z = r * cos(tt);
+      } else {
+         double cosphi = cos(phi);
+         *x = - r * cosphi * sin(tt);
+         *y = r * sin(phi);
+         *z = r * cosphi * cos(tt);
+      }
    }
+   
+   /*******************************************************************************
+   * grandvec_target_circle: Choose random direction towards target at (x,y,z)
+   * with given radius and gaussian area distribution.
+   * If radius is zero, choose random direction in full 4PI, no target.
+   ******************************************************************************/
+   void
+   grandvec_target_circle(double *xo, double *yo, double *zo, double *solid_angle,
+                  double xi, double yi, double zi, double radius)
+   {
+     double l2, phi, theta, nx, ny, nz, xt, yt, zt, xu, yu, zu;
+
+     if(radius == 0.0)
+     {
+       /* No target, choose uniformly a direction in full 4PI solid angle. */
+       theta = acos (1 - rand0max(2));
+       phi = rand0max(2 * PI);
+       if(solid_angle)
+         *solid_angle = 4*PI;
+       nx = 1;
+       ny = 0;
+       nz = 0;
+       yi = sqrt(xi*xi+yi*yi+zi*zi);
+       zi = 0;
+       xi = 0;
+     }
+     else
+     {
+       double costheta0;
+       l2 = xi*xi + yi*yi + zi*zi; /* sqr Distance to target. */
+       costheta0 = sqrt(l2/(radius*radius+l2));
+       if (radius < 0) costheta0 *= -1;
+       if(solid_angle)
+       {
+         /* Compute solid angle of target as seen from origin. */
+           *solid_angle = 2*PI*(1 - costheta0);
+       }
+
+       /* Now choose point uniformly on circle surface within angle theta0 */
+       double costheta;
+       costheta = (1 - fabs(randnorm()*(1 - costheta0)) );
+
+       if (costheta < -1)
+         costheta = -1;
+         
+       theta = acos(costheta); /* radius on circle */
+       phi = rand0max(2 * PI); /* rotation on circle at given radius */
+       /* Now, to obtain the desired vector rotate (xi,yi,zi) angle theta around a
+          perpendicular axis u=i x n and then angle phi around i. */
+       if(xi == 0 && zi == 0)
+       {
+         nx = 1;
+         ny = 0;
+         nz = 0;
+       }
+       else
+       {
+         nx = -zi;
+         nz = xi;
+         ny = 0;
+       }
+     }
+
+     /* [xyz]u = [xyz]i x n[xyz] (usually vertical) */
+     vec_prod(xu,  yu,  zu, xi, yi, zi,        nx, ny, nz);
+     /* [xyz]t = [xyz]i rotated theta around [xyz]u */
+     rotate  (xt,  yt,  zt, xi, yi, zi, theta, xu, yu, zu);
+     /* [xyz]o = [xyz]t rotated phi around n[xyz] */
+     rotate (*xo, *yo, *zo, xt, yt, zt, phi, xi, yi, zi);
+   } /* randvec_target_circle */
+
+   
 %}
 DECLARE
 %{
+   // official output variables
    double tt,phi,xi,phid,vd,zd,v0,vmin,vmax,vperp,E0,R,eps;
+   
+   // internal stuff
+   double sin_facette_xi;
 %}
 INITIALIZE
 %{
@@ -338,6 +446,19 @@ INITIALIZE
          "PerfectCrystal: %s WARNING: Using smartphase for ewald/darwin curves is probably a bad idea, because these curves have very long wings which will be cut off!!!\n",
          NAME_CURRENT_COMP););
    }
+   
+   if (facette_xi)
+   {
+      if (facette_xi < 0)
+      {
+         MPI_MASTER(fprintf(stderr,
+            "PerfectCrystal: %s ERROR: facette_xi must be >= 0\n",
+            NAME_CURRENT_COMP););
+         exit(-1);
+      }
+      
+      sin_facette_xi = sin(DEG2RAD*facette_xi);
+   }
 
    // talk to the user ...
    if ( verbose )
@@ -354,12 +475,17 @@ INITIALIZE
          PRINTVAR("phiwidth",phiwidth);
          PRINTVAR("height",height);
          PRINTVAR("centerfocus",centerfocus);
+         PRINTVAR("debyescherrer",debyescherrer);
          PRINTVAR("radius",radius);
+         PRINTVAR("facette",facette);
+         PRINTVAR("facette_xi",facette_xi);
+         PRINTVAR("sin_facette_xi",sin_facette_xi);
          PRINTVAR("tau",tau);
          PRINTVAR("lambda",lambda);
          PRINTVAR("v0",v0);
          PRINTVAR("E0",E0);
          PRINTVAR("dtauovertau",dtauovertau);
+         PRINTVAR("dtauovertau_ext",dtauovertau_ext);
          PRINTVAR("ewald",ewald);
          PRINTVAR("R0",R0);
          PRINTVAR("sigma[m/s]",sigma);
@@ -454,18 +580,54 @@ TRACE
          PROP_DT(dt2);
 
          // tt (twotheta) is calculated as in IN16B, positive values downstream rightwards
-         tt = - RAD2DEG * atan2(x,z+(centerfocus?0:radius)+zd);
-         phi = RAD2DEG * asin( y/sqrt( SQR(x) + SQR(y) + SQR(z+(centerfocus?0:radius)+zd) ) );
+         // select coordinate system depending on 'debyescherrer' switch
+         double zprime = z+(centerfocus?0:radius)+zd;
+         if (debyescherrer) {
+            tt = RAD2DEG * atan2( sqrt(SQR(x)+SQR(y)) , zprime );
+            phi = RAD2DEG * atan2(y,-x);
+         } else {
+            tt = - RAD2DEG * atan2(x,zprime);
+            phi = RAD2DEG * asin( y/sqrt( SQR(x) + SQR(y) + SQR(zprime) ) );
+         }
          
          missed = (tt<ttmin || tt>ttmax || phi<phimin || phi>phimax);
          
          if ( !missed )
          {
             // analyzer surface normal
-            nx = -x;
-            ny = -y;
-            nz = -z-(centerfocus?0:radius)-zd;
-            NORM(nx,ny,nz);
+            if ( facette ) {
+               // calculate center of the facette hit
+               // always use spherical coordinates with y main axis (as in debyescherrer=0),
+               // otherwise the pole will be in the analyzer center!
+               // for the sake of confusion, use radians in this part.
+               double tt1, ttfacette, ttn, phi1, phifacette, phin;
+               if (debyescherrer) {
+                  tt1 = - atan2(x,zprime);
+                  phi1 = asin( y/sqrt( SQR(x) + SQR(y) + SQR(zprime) ) );
+               } else {
+                  tt1 = DEG2RAD * tt;
+                  phi1 = DEG2RAD * phi;
+               }
+               
+               phifacette = facette / radius;
+               phin = floor( phi1 / phifacette + 0.5 ) * phifacette;
+               ttfacette = facette / (radius*cos(phin));
+               ttn = floor( tt1 / ttfacette + 0.5 ) * ttfacette;
+               
+               nx = cos(phin)*sin(ttn);
+               ny = -sin(phin);
+               nz = -cos(phin)*cos(ttn);
+               
+               if (facette_xi)
+               {
+                  grandvec_target_circle(&nx,&ny,&nz,NULL,nx,ny,nz,sin_facette_xi);
+               }
+            } else {
+               nx = -x;
+               ny = -y;
+               nz = -z-(centerfocus?0:radius)-zd;
+               NORM(nx,ny,nz);
+            }
          }
       }
    }
@@ -487,7 +649,13 @@ TRACE
          {
             // eps is actually abs(y)
             // vperp is negative!
-            eps = fabs( 4.0*vperp*V2K/tau + 2.0 ) / dtauovertau;
+            double this_tau = tau;
+            if ( dtauovertau_ext )
+            {
+               this_tau *= 1.0 + 0.5*dtauovertau_ext*randpm1();
+            }
+            
+            eps = fabs( 4.0*vperp*V2K/this_tau + 2.0 ) / dtauovertau;
             
             // Darwin/Ewald curve
             if ( eps > 1 )
@@ -533,12 +701,15 @@ TRACE
       }
       else
       {
-         // reflection: kf = ki - tau0 + 2*kD  where tau0 is perpendicular projection 
-         // of the tau vector and kD is due to doppler movement (tau0 is NOT always parallel to kD!!)
-         q0mod = 2.0 * vperp; // q0mod is now directly in velocity units
+         // reflection: vector kf = ki - qmod0  where qmod0 = 2*n*(n dot ki'),
+         // n is the surface normal vector and ki' the incident wavevector
+         // in the moving frame
+         q0mod = 2.0 * vperp;
+         // q0mod is now directly in velocity units (and contains energy shift due to Doppler effect!)
+
          vx -= q0mod*nx;
          vy -= q0mod*ny;
-         vz -= q0mod*nz - 2.0*vd;
+         vz -= q0mod*nz;
          if (R!=1)
             p *= R / (1.0-transmit);
          
@@ -562,15 +733,26 @@ TRACE
 
 MCDISPLAY
 %{
-   const int ttsegments = 10;
-   const int phisegments = 10;
-   const int steps = 30;
+   int ttsegments;
+   int phisegments;
+   int steps;
 //   const double centerspheresize = 0.1*radius;
 
    int i, itt, iphi, istep;
    double phi,tt,dphi,dtt;
    double x1,y1,z1,x2,y2,z2;
    double z0;
+
+   if (debyescherrer) {
+      ttsegments = 4;
+      phisegments = 20;
+      steps = 50;
+   } else {
+      ttsegments = 10;
+      phisegments = 10;
+      steps = 30;
+   }
+
    
    // mark the center with a sphere
 //   circle("xy",0,0,0,centerspheresize);
@@ -590,8 +772,8 @@ MCDISPLAY
          tt = ttmin + (ttmax - ttmin) * (double)itt / (double)ttsegments;
          for (istep=0; istep<steps; istep++) {
             phi = phimin + dphi*istep;
-            sph2cart(&x1,&y1,&z1,radius,tt,phi);
-            sph2cart(&x2,&y2,&z2,radius,tt,phi+dphi);
+            sph2cart(&x1,&y1,&z1,radius,tt,phi,debyescherrer);
+            sph2cart(&x2,&y2,&z2,radius,tt,phi+dphi,debyescherrer);
             line(x1,y1,z1-z0,x2,y2,z2-z0);
          }
       }
@@ -600,8 +782,8 @@ MCDISPLAY
          phi = phimin + (phimax - phimin) * (double)iphi / (double)phisegments;
          for (istep=0; istep<steps; istep++) {
             tt = ttmin + dtt*istep;
-            sph2cart(&x1,&y1,&z1,radius,tt,phi);
-            sph2cart(&x2,&y2,&z2,radius,tt+dtt,phi);
+            sph2cart(&x1,&y1,&z1,radius,tt,phi,debyescherrer);
+            sph2cart(&x2,&y2,&z2,radius,tt+dtt,phi,debyescherrer);
             line(x1,y1,z1-z0,x2,y2,z2-z0);
          }
       }
@@ -610,13 +792,13 @@ MCDISPLAY
       if ( amplitude )
       {
          
-         sph2cart(&x1,&y1,&z1,radius,ttmin,phimin);
+         sph2cart(&x1,&y1,&z1,radius,ttmin,phimin,debyescherrer);
          dashed_line(x1,y1,z1-z0-amplitude,x1,y1,z1-z0+amplitude,6);
-         sph2cart(&x1,&y1,&z1,radius,ttmax,phimin);
+         sph2cart(&x1,&y1,&z1,radius,ttmax,phimin,debyescherrer);
          dashed_line(x1,y1,z1-z0-amplitude,x1,y1,z1-z0+amplitude,6);
-         sph2cart(&x1,&y1,&z1,radius,ttmin,phimax);
+         sph2cart(&x1,&y1,&z1,radius,ttmin,phimax,debyescherrer);
          dashed_line(x1,y1,z1-z0-amplitude,x1,y1,z1-z0+amplitude,6);
-         sph2cart(&x1,&y1,&z1,radius,ttmax,phimax);
+         sph2cart(&x1,&y1,&z1,radius,ttmax,phimax,debyescherrer);
          dashed_line(x1,y1,z1-z0-amplitude,x1,y1,z1-z0+amplitude,6);
          
          for (i=-1;i<=1;i+=2)
@@ -627,8 +809,8 @@ MCDISPLAY
                tt = ttmin + (ttmax - ttmin) * (double)itt / (double)ttsegments;
                for (istep=0; istep<steps; istep++) {
                   phi = phimin + dphi*istep;
-                  sph2cart(&x1,&y1,&z1,radius,tt,phi);
-                  sph2cart(&x2,&y2,&z2,radius,tt,phi+dphi);
+                  sph2cart(&x1,&y1,&z1,radius,tt,phi,debyescherrer);
+                  sph2cart(&x2,&y2,&z2,radius,tt,phi+dphi,debyescherrer);
                   dashed_line(x1,y1,z1-z0,x2,y2,z2-z0,1);
                }
             }
@@ -637,8 +819,8 @@ MCDISPLAY
                phi = phimin + (phimax - phimin) * (double)iphi / (double)phisegments;
                for (istep=0; istep<steps; istep++) {
                   tt = ttmin + dtt*istep;
-                  sph2cart(&x1,&y1,&z1,radius,tt,phi);
-                  sph2cart(&x2,&y2,&z2,radius,tt+dtt,phi);
+                  sph2cart(&x1,&y1,&z1,radius,tt,phi,debyescherrer);
+                  sph2cart(&x2,&y2,&z2,radius,tt+dtt,phi,debyescherrer);
                   dashed_line(x1,y1,z1-z0,x2,y2,z2-z0,1);
                }
             }


### PR DESCRIPTION
 Changes in PerfectCrystal.comp version 1.1:
 - BUGFIX: correct neutron energy shift in Doppler mode
 - added option 'debyescherrer' to select analyzer geometry
 - added option 'facette' to approximate analyzer sphere by small, flat crystals