### PR TITLE
Adding "revision" file to the component lib, that would allow easier …

### DIFF
--- a/mcstas-comps/CMakeLists.txt
+++ b/mcstas-comps/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 # Set McCode values (from mkdist or defaults)
 include(MCUtil)
 setupMCCODE("mcstas")
-
+set(WORK "${PROJECT_BINARY_DIR}/work")
 
 # CPack configuration
 set(CPACK_PACKAGE_NAME          "${FLAVOR}-comps-${MCCODE_VERSION}")
@@ -40,6 +40,21 @@ endif()
 foreach(name contrib data examples misc monitors obsolete optics samples share sources editors libs)
   installLib("${PROJECT_SOURCE_DIR}/${name}")
 endforeach()
+
+# Include mcstas-comp revision tag file
+configure_file("${CMAKE_SOURCE_DIR}/revision.in" "${WORK}/revision" @ONLY)
+
+if(WINDOWS)
+  install(
+    FILES "${WORK}/revision"
+    DESTINATION "${lib}"
+  )
+else()
+  install(
+    FILES "${WORK}/revision"
+    DESTINATION "${FLAVOR}/${MCCODE_VERSION}"
+  )
+endif()
 
 if (NOT WINDOWS)
   install(TARGETS nxs DESTINATION "${MCCODE_LIB}/libs/libnxs/")

--- a/mcstas-comps/revision.in
+++ b/mcstas-comps/revision.in
@@ -1,0 +1,1 @@
+- Component library: @MCCODE_NAME@-@MCCODE_VERSION@, built @MCCODE_DATE@


### PR DESCRIPTION
…"respins" of component libraries.

(Note that cmake-style "build in path" seems broken: cmake .. && make && make install fails since libs/mcpl is a link - but ./build* / mkdist works just fine...)