### PR TITLE
Bug in Union component Template_process fixed

### DIFF
--- a/mcstas-comps/contrib/union/Template_process.comp
+++ b/mcstas-comps/contrib/union/Template_process.comp
@@ -154,6 +154,7 @@ INITIALIZE
   // This will be the same for all process's, and can thus be moved to an include.
   sprintf(This_process.name,NAME_CURRENT_COMP);
   This_process.process_p_interact = interact_fraction;
+  rot_copy(This_process.rotation_matrix,ROT_A_CURRENT_COMP);
   sprintf(global_process_element.name,NAME_CURRENT_COMP);
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;


### PR DESCRIPTION
The Union component Template_process lacked a line necessary for making a non isotropic process, which was added.