### PR TITLE
McStas Union bug fixes and logging of scattering magnitude

### DIFF
--- a/mcstas-comps/contrib/union/Union_conditional_PSD.comp
+++ b/mcstas-comps/contrib/union/Union_conditional_PSD.comp
@@ -85,9 +85,8 @@ int conditional_function_PSD(union conditional_data_union *data_union, Coords *p
 
   
   // Transform to this coordinate system
-  Coords local_position = transform_position(*position,data_union->p_PSD->PSD_position,data_union->p_PSD->PSD_t_rotation);
-  Coords local_velocity = rot_apply(data_union->p_PSD->PSD_t_rotation,*velocity);
-  
+  Coords local_position = transform_position(*position,data_union->p_PSD->PSD_position,data_union->p_PSD->PSD_rotation);
+  Coords local_velocity = rot_apply(data_union->p_PSD->PSD_rotation,*velocity);
   
   // Prop_Z0
   if (local_velocity.z == 0) return 0;
@@ -95,6 +94,7 @@ int conditional_function_PSD(union conditional_data_union *data_union, Coords *p
   if (dt<0) return 0;
   local_position.x = local_position.x + dt*local_velocity.x;
   local_position.y = local_position.y + dt*local_velocity.y;
+  
   double detect_time = *time + dt;
   
   if (data_union->p_PSD->T_limit == 1) {

--- a/mcstas-comps/contrib/union/Union_conditional_standard.comp
+++ b/mcstas-comps/contrib/union/Union_conditional_standard.comp
@@ -18,13 +18,13 @@
 *
 * 1) One specifies a number of processes using process components
 * 2) These are gathered into material definitions using Union_make_material
-* 3) Geometries are placed using Union_box/cylinder/sphere, assigned a material
+* 3) Geometries are placed using Union_box / Union_cylinder, assigned a material
 * 4) A Union_master component placed after all of the above
 *
 * Only in step 4 will any simulation happen, and per default all geometries
 *  defined before this master, but after the previous will be simulated here.
 *
-* There is a dedicated manual available for the Union components
+* There is a dedicated manual available for the Union_components
 *
 * This is a conditional component that affects the loggers in the target_loggers
 *  string. When a logger is affected, it will only record events if the
@@ -39,34 +39,32 @@
 *  long as the tagging system is active, so you may want to increase the number
 *  of histories allowed by that master component before stopping.
 *
-* This conditional is a little special, because it needs to be placed in space.
-*  It's center location is like a psd.'
-*
 * %P
 * INPUT PARAMETERS:
 * target_loggers:     [string] Comma seperated list of loggers this conditional should affect
 * master_tagging=0    [1] Apply this conditional to the tagging system in next master
 * tagging_extend_index[1] Not currently used
-* time_min            [s] Min time (on psd), if not set ignored
-* time_max            [s] Max time (on psd), if not set ignored
-* end_volume          [1] Not used yet
+* time_min            [s] Min time, if not set ignored
+* time_max            [s] Max time, if not set ignored
+* E_min               [meV] Max energy, if not set ignored
+* E_max               [meV] Min energy, if not set ignored
+* total_order_min     [1] Max time, if not set ignored
+* total_order_max     [1] Min time, if not set ignored
 * last_volume_index   [1] Not used yet
 *
+*
 * OUTPUT PARAMETERS:
-* this_material:            Structure that contains information on this material
-* global_material_element:  Element of global_material_list which is a global variable
 *
 * GLOBAL PARAMETERS:
-* global_material_list:     List of all defined materials, available in the global scope
 *
 * %L
 *
 * %E
 ******************************************************************************/
 
-DEFINE COMPONENT Union_conditional_PSD
+DEFINE COMPONENT Union_conditional_standard
 DEFINITION PARAMETERS ()
-SETTING PARAMETERS(string target_loggers="NULL", int master_tagging=0, int tagging_extend_index = -1, xwidth, yheight,time_min=0, time_max=0) // E limit, |k| limit, volumes to have visited, processes that was used, end volume, last process
+SETTING PARAMETERS(string target_loggers="NULL", int master_tagging=0, int tagging_extend_index = -1, time_min=0, time_max=0, E_min=0, E_max=0, total_order_min=0, total_order_max=0, last_volume_index=-1) // E limit, |k| limit, volumes to have visited, processes that was used, end volume, last process
 OUTPUT PARAMETERS (accepted_loggers_all,accepted_loggers_specific,accepted_tagging,found_logger,loop_index,return_value,this_conditional_data,this_data_union)
 
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */
@@ -81,32 +79,30 @@ SHARE
 
 #endif
 
-int conditional_function_PSD(union conditional_data_union *data_union, Coords *position, Coords *velocity, double *weight, double *time, int *current_volume, int *total_number_of_scattering, int *number_of_scattering_per_volume, int **number_of_scattering_per_volume_process) {
+int conditional_function_standard(union conditional_data_union *data_union, Coords *position, Coords *velocity, double *weight, double *time, int *current_volume, int *total_number_of_scattering, int *number_of_scattering_per_volume, int **number_of_scattering_per_volume_process) {
 
-  
-  // Transform to this coordinate system
-  Coords local_position = transform_position(*position,data_union->p_PSD->PSD_position,data_union->p_PSD->PSD_t_rotation);
-  Coords local_velocity = rot_apply(data_union->p_PSD->PSD_t_rotation,*velocity);
-  
-  
-  // Prop_Z0
-  if (local_velocity.z == 0) return 0;
-  double dt = -local_position.z/local_velocity.z;
-  if (dt<0) return 0;
-  local_position.x = local_position.x + dt*local_velocity.x;
-  local_position.y = local_position.y + dt*local_velocity.y;
-  double detect_time = *time + dt;
-  
-  if (data_union->p_PSD->T_limit == 1) {
-    if (detect_time < data_union->p_PSD->Tmin || detect_time > data_union->p_PSD->Tmax)
+  //printf(" Inside conditional function \n");
+  if (data_union->p_standard->T_limit == 1) {
+    if (*time < data_union->p_standard->Tmin || *time > data_union->p_standard->Tmax)
+      return 0;
+  }
+    
+  if (data_union->p_standard->E_limit == 1) {
+    // VS2E = 5.2269518201E-9 m_n / 2e
+    double E = 5.2269518201E-9*(velocity->x*velocity->x + velocity->y*velocity->y + velocity->z*velocity->z);
+    if (E < data_union->p_standard->Emin || E > data_union->p_standard->Emax)
       return 0;
   }
   
-  if (local_position.x > data_union->p_PSD->PSD_half_xwidth) return 0;
-  if (local_position.x < -data_union->p_PSD->PSD_half_xwidth) return 0;
-  if (local_position.y > data_union->p_PSD->PSD_half_yheight) return 0;
-  if (local_position.y < -data_union->p_PSD->PSD_half_yheight) return 0;
+  if (data_union->p_standard->Total_scat_limit == 1) {
+    if (*total_number_of_scattering < data_union->p_standard->Total_scat_min || *total_number_of_scattering > data_union->p_standard->Total_scat_max)
+      return 0;
+  }
   
+  if (data_union->p_standard->volume_index != -1) {
+    if (*current_volume != data_union->p_standard->volume_index)
+      return 0;
+  }
   
   // All conditions fulfilled
   return 1;
@@ -146,6 +142,45 @@ int manual_linking_logger_function_conditional(char *input_string, struct pointe
    return accepted_loggers->num_elements;
 }
 
+/*
+// Linking function for masters, finds the indicies of the specified masters on the global_master_list
+int manual_linking_tagging_function_conditional(char *input_string, struct global_tagging_conditional_list_struct *global_tagging_list, struct pointer_to_1d_int_list *accepted_tagging) {
+    // Need to check a input_string of text for an occurance of name. If it is in the inputstring, yes return 1, otherwise 0.
+   char *token;
+   int loop_index,found;
+   char local_string[512];
+   
+   strcpy(local_string,input_string);
+   // get the first token
+   token = strtok(local_string,",");
+   
+   // walk through other tokens
+   while( token != NULL ) 
+   {
+      found = 0;
+      for (loop_index=0;loop_index<global_tagging_list->num_elements;loop_index++) {
+        if (strcmp(token,global_tagging_list->elements[loop_index].name) == 0) {
+          add_element_to_int_list(accepted_tagging,loop_index);
+          found = 1;
+          break;
+        }
+      }
+      
+      if (found == 0) {
+        add_element_to_int_list(accepted_tagging,loop_index);
+        add_element_to_tagging_conditional_list(
+        
+        add_function_to_conditional_list(global_tagging_list.elements[accepted_tagging.elements[loop_index]].conditional_list,&conditional_function_standard,&this_data_union);
+      }
+      
+      // Updates the token
+      token = strtok(NULL,",");
+   }
+   
+   return accepted_tagging->num_elements;
+}
+*/
+
 int count_commas(char *string) {
   int return_value = 0;
   
@@ -157,9 +192,11 @@ int count_commas(char *string) {
     
   //printf("number_of_commas = %d \n",return_value);
   return return_value;
+  
 }
 #endif
-  
+
+
 
 
 %}
@@ -178,7 +215,7 @@ struct pointer_to_1d_int_list accepted_loggers_specific = {0,NULL};
 
 struct logger_struct *found_logger;
 
-struct conditional_PSD_struct this_conditional_data;
+struct conditional_standard_struct this_conditional_data;
 union conditional_data_union this_data_union;
 
 struct global_tagging_conditional_element_struct *new_tagging_element;
@@ -189,8 +226,15 @@ INITIALIZE
 %{
 
   //printf("starded conditional initialize \n");
+  // Check if an E range has been set
+  if (E_min == E_max)
+    // If not, do not check the final energy
+    this_conditional_data.E_limit = 0;
+  else
+    // If it has, check the final energy
+    this_conditional_data.E_limit = 1;
   
-  // If time range is set, use it
+  // Likewise for time
   if (time_min == time_max)
     this_conditional_data.T_limit = 0;
   else
@@ -199,30 +243,49 @@ INITIALIZE
   this_conditional_data.Tmin = time_min;
   this_conditional_data.Tmax = time_max;
   
-  if (xwidth < 0) {
-    printf("ERROR: In Union conditional %s xwidth is less than 0!\n",NAME_CURRENT_COMP);
-  }
-  this_conditional_data.PSD_half_xwidth = 0.5*xwidth;
+  if (last_volume_index != -1)
+    this_conditional_data.volume_index = last_volume_index;
   
-  if (yheight < 0) {
-    printf("ERROR: In Union conditional %s yheight is less than 0!\n",NAME_CURRENT_COMP);
+  // Initialize storage from input
+  if (E_min < 0) {
+    printf("ERROR, Union logger \"%s\" had E_min < 0.\n",NAME_CURRENT_COMP);
+    exit(1);
   }
-  this_conditional_data.PSD_half_yheight = 0.5*yheight;
+  this_conditional_data.Emin = E_min; // The names need to be different to avoid defines ruining the day
   
+  // Initialize storage from input
+  if (E_max < 0) {
+    printf("ERROR, Union logger \"%s\" had E_max < 0.\n",NAME_CURRENT_COMP);
+    exit(1);
+  }
+  this_conditional_data.Emax = E_max; // The names need to be different to avoid defines ruining the day
+  
+  
+  if (total_order_max != 0)
+    this_conditional_data.Total_scat_limit = 1;
+  else
+    this_conditional_data.Total_scat_limit = 0;
+    
+  if (total_order_max < total_order_min) {
+    printf("ERROR, Union logger \"%s\" had total_order_max < total_oder_min.\n",NAME_CURRENT_COMP);
+    exit(1);
+  }
+  this_conditional_data.Total_scat_max = total_order_max;
+  this_conditional_data.Total_scat_min = total_order_min;
   
   // Test position and rotation stored in a data storage, and pointers assigned to transform lists
-  this_conditional_data.PSD_position = POS_A_CURRENT_COMP;
-  add_position_pointer_to_list(&global_positions_to_transform_list,&this_conditional_data.PSD_position);
+  this_conditional_data.test_position = POS_A_CURRENT_COMP;
+  add_position_pointer_to_list(&global_positions_to_transform_list,&this_conditional_data.test_position);
   
-  rot_copy(this_conditional_data.PSD_rotation,ROT_A_CURRENT_COMP);
-  add_rotation_pointer_to_list(&global_rotations_to_transform_list,&this_conditional_data.PSD_rotation);
+  rot_copy(this_conditional_data.test_rotation,ROT_A_CURRENT_COMP);
+  add_rotation_pointer_to_list(&global_rotations_to_transform_list,&this_conditional_data.test_rotation);
   
-  rot_transpose(ROT_A_CURRENT_COMP,this_conditional_data.PSD_t_rotation);
-  add_rotation_pointer_to_list(&global_rotations_to_transform_list,&this_conditional_data.PSD_t_rotation);
+  rot_transpose(ROT_A_CURRENT_COMP,this_conditional_data.test_t_rotation);
+  add_rotation_pointer_to_list(&global_rotations_to_transform_list,&this_conditional_data.test_t_rotation);
   
   
   // Set the data union to be for this specific type of conditional, and supply it with a pointer to its static data
-  this_data_union.p_PSD = &this_conditional_data;
+  this_data_union.p_standard = &this_conditional_data;
   
   if (master_tagging == 1) {
     // Apply this conditional to the next master components tagging system
@@ -245,7 +308,7 @@ INITIALIZE
       strcat(global_tagging_conditional_list.elements[global_tagging_conditional_list.current_index].name,NAME_CURRENT_COMP);
     }
       // Add the conditional element to the current list
-      add_function_to_conditional_list(&global_tagging_conditional_list.elements[global_tagging_conditional_list.current_index].conditional_list,&conditional_function_PSD,&this_data_union);
+      add_function_to_conditional_list(&global_tagging_conditional_list.elements[global_tagging_conditional_list.current_index].conditional_list,&conditional_function_standard,&this_data_union);
   }
   
   // Need to find the loggers which need to have this conditional applied
@@ -287,7 +350,7 @@ INITIALIZE
       }
       
       // Add a pointer to this conditional function to the list of conditionals for this logger
-      add_function_to_conditional_list(&found_logger->conditional_list,&conditional_function_PSD,&this_data_union);
+      add_function_to_conditional_list(&found_logger->conditional_list,&conditional_function_standard,&this_data_union);
     }
     for (loop_index=0;loop_index<accepted_loggers_specific.num_elements;loop_index++) {
       //printf("specific loop \n");
@@ -306,8 +369,15 @@ INITIALIZE
       }
       
       // Add a pointer to this conditional function to the list of conditionals for this logger
-      add_function_to_conditional_list(&found_logger->conditional_list,&conditional_function_PSD,&this_data_union);
+      add_function_to_conditional_list(&found_logger->conditional_list,&conditional_function_standard,&this_data_union);
     }
+    /*
+    for (loop_index=0;loop_index<accepted_tagging.num_elements;loop_index++) {
+      //printf("master loop \n");
+      // Adding a conditional to the tagging part of a master does not need any change in the record functions, as it doesn't work as a logger
+      add_function_to_conditional_list(&global_tagging_conditional_list.elements[accepted_tagging.elements[loop_index]].conditional_list,&conditional_function_standard,&this_data_union);
+    }
+    */
       
   } else {
     // What to do if no target_logger string given? Apply to all loggers? Apply to overall tagging system? Apply to former logger?

--- a/mcstas-comps/contrib/union/Union_logger_1D.comp
+++ b/mcstas-comps/contrib/union/Union_logger_1D.comp
@@ -46,9 +46,9 @@
 *
 * %P
 * INPUT PARAMETERS:
-* variable:        [string] Only supports time right now, not used
-* min_value:       [1] histogram boundery for logged value (now time)
-* max_value:       [1] histogram boundery for logged value (now time)
+* variable:        [string] time for time in seconds, q for magnitude of scattering vector in 1/AA.
+* min_value:       [1] histogram boundery for logged value
+* max_value:       [1] histogram boundery for logged value
 * n1:              [1] Number of bins in histogram
 * target_geometry: [string] Comma seperated list of geometry names that will be logged, leave empty for all volumes (even not defined yet)
 * target_process:  [string] Comma seperated names of physical processes, if volumes are selected, one can select Union_process names
@@ -101,6 +101,7 @@ struct a_1D_storage_struct {
   int order;
   int order_in_this_volume;
   int order_process_in_this_volume;
+  int variable_identifier;
 };
 
 // record_to_temp
@@ -136,56 +137,63 @@ void record_to_temp_1D(Coords *position, double *k_new, double *k_old, double p,
   if (add_point == 1) {
 
     int i;
+    double value;
+    
+    if (storage->variable_identifier == 1) {
+      value = time;
+    } else if (storage->variable_identifier == 2) {
+      value = sqrt( (k_new[0]-k_old[0])*(k_new[0]-k_old[0]) + (k_new[1]-k_old[1])*(k_new[1]-k_old[1]) + (k_new[2]-k_old[2])*(k_new[2]-k_old[2]));
+    }
   
     // Find bin in histogram
-    if (time>storage->Detector_1D.min && time<storage->Detector_1D.max) {
-      i = floor((time - storage->Detector_1D.min)*storage->Detector_1D.bins/(storage->Detector_1D.max - storage->Detector_1D.min));
-    }
-
-    // Save bin in histogram to temp (may need to allocate more memory)
-    int index;
-    //printf("number of data points used: %d space allocated for %d data points. \n",storage->temp_1D_data.num_elements,storage->temp_1D_data.allocated_elements);
+    if (value>storage->Detector_1D.min && value<storage->Detector_1D.max) {
+      i = floor((value - storage->Detector_1D.min)*storage->Detector_1D.bins/(storage->Detector_1D.max - storage->Detector_1D.min));
+    
+      // Save bin in histogram to temp (may need to allocate more memory)
+      int index;
+      //printf("number of data points used: %d space allocated for %d data points. \n",storage->temp_1D_data.num_elements,storage->temp_1D_data.allocated_elements);
   
-    if (storage->temp_1D_data.num_elements < storage->temp_1D_data.allocated_elements) {
-      storage->temp_1D_data.elements[storage->temp_1D_data.num_elements].index = i;
-      storage->temp_1D_data.elements[storage->temp_1D_data.num_elements++].weight = p;
-    } else {
-      // No more space, need to allocate a larger buffer for this logger. Wish I had generics.
+      if (storage->temp_1D_data.num_elements < storage->temp_1D_data.allocated_elements) {
+        storage->temp_1D_data.elements[storage->temp_1D_data.num_elements].index = i;
+        storage->temp_1D_data.elements[storage->temp_1D_data.num_elements++].weight = p;
+      } else {
+        // No more space, need to allocate a larger buffer for this logger. Wish I had generics.
     
-      // copy current data to temp
-      struct temp_1D_data_struct temporary_storage;
-      temporary_storage.num_elements = storage->temp_1D_data.num_elements;
-      temporary_storage.elements = malloc(temporary_storage.num_elements*sizeof(struct temp_1D_data_element_struct));
+        // copy current data to temp
+        struct temp_1D_data_struct temporary_storage;
+        temporary_storage.num_elements = storage->temp_1D_data.num_elements;
+        temporary_storage.elements = malloc(temporary_storage.num_elements*sizeof(struct temp_1D_data_element_struct));
     
-      for (index=0;index<storage->temp_1D_data.num_elements;index++) {
-        temporary_storage.elements[index].index = storage->temp_1D_data.elements[index].index;
-        temporary_storage.elements[index].weight = storage->temp_1D_data.elements[index].weight;
-      }
+        for (index=0;index<storage->temp_1D_data.num_elements;index++) {
+          temporary_storage.elements[index].index = storage->temp_1D_data.elements[index].index;
+          temporary_storage.elements[index].weight = storage->temp_1D_data.elements[index].weight;
+        }
       
-      // free current data
-      free(storage->temp_1D_data.elements);
+        // free current data
+        free(storage->temp_1D_data.elements);
     
-      // allocate larger array (10 larger)
-      storage->temp_1D_data.allocated_elements = 10 + storage->temp_1D_data.num_elements;
-      storage->temp_1D_data.elements = malloc(storage->temp_1D_data.allocated_elements*sizeof(struct temp_1D_data_element_struct));
+        // allocate larger array (10 larger)
+        storage->temp_1D_data.allocated_elements = 10 + storage->temp_1D_data.num_elements;
+        storage->temp_1D_data.elements = malloc(storage->temp_1D_data.allocated_elements*sizeof(struct temp_1D_data_element_struct));
     
-      // copy back from temp
-      for (index=0;index<storage->temp_1D_data.num_elements;index++) {
-        storage->temp_1D_data.elements[index].index = temporary_storage.elements[index].index;
-        storage->temp_1D_data.elements[index].weight = temporary_storage.elements[index].weight;
+        // copy back from temp
+        for (index=0;index<storage->temp_1D_data.num_elements;index++) {
+          storage->temp_1D_data.elements[index].index = temporary_storage.elements[index].index;
+          storage->temp_1D_data.elements[index].weight = temporary_storage.elements[index].weight;
+        }
+    
+        // free temporary data
+        free(temporary_storage.elements);
+    
+        // add new data point
+        storage->temp_1D_data.elements[storage->temp_1D_data.num_elements].index = i;
+        storage->temp_1D_data.elements[storage->temp_1D_data.num_elements++].weight = p;
       }
-    
-      // free temporary data
-      free(temporary_storage.elements);
-    
-      // add new data point
-      storage->temp_1D_data.elements[storage->temp_1D_data.num_elements].index = i;
-      storage->temp_1D_data.elements[storage->temp_1D_data.num_elements++].weight = p;
-    }
   
-    // If this is the first time this ray is being recorded in this logger, add it to the list of loggers that write to temp and may get it moved to perm
-    if (storage->temp_1D_data.num_elements == 1)
-      add_to_logger_with_data(logger_with_data_array,logger);
+      // If this is the first time this ray is being recorded in this logger, add it to the list of loggers that write to temp and may get it moved to perm
+      if (storage->temp_1D_data.num_elements == 1)
+        add_to_logger_with_data(logger_with_data_array,logger);
+    }
   }
   
 }
@@ -229,11 +237,19 @@ void record_to_perm_1D(Coords *position, double *k_new, double *k_old, double p,
     //printf("storage was set \n");
       
     int i;
+    double value;
+    
+    if (storage->variable_identifier == 1) {
+      value = time;
+    } else if (storage->variable_identifier == 2) {
+      value = sqrt( (k_new[0]-k_old[0])*(k_new[0]-k_old[0]) + (k_new[1]-k_old[1])*(k_new[1]-k_old[1]) + (k_new[2]-k_old[2])*(k_new[2]-k_old[2]));
+    }
+  
   
     // Find bin in histogram
-    if (time>storage->Detector_1D.min && time<storage->Detector_1D.max) {
+    if (value>storage->Detector_1D.min && value<storage->Detector_1D.max) {
   
-      i = floor((time - storage->Detector_1D.min)*(double)storage->Detector_1D.bins/(storage->Detector_1D.max - storage->Detector_1D.min));
+      i = floor((value - storage->Detector_1D.min)*(double)storage->Detector_1D.bins/(storage->Detector_1D.max - storage->Detector_1D.min));
     
       //printf("Added to statistics for monitor [%d] [%d] \n",i,j);
       //printf("indicies found\n");
@@ -386,6 +402,8 @@ int found_process;
 int specified_processes;
 char local_string[256];
 
+int variable_identifier; // 1 time, 2 |q|, ...
+
 // Reused for logger
 struct pointer_to_1d_int_list accepted_processes = {0,NULL};
 
@@ -435,20 +453,26 @@ INITIALIZE
   //printf("past 1D pointer assignment \n");
   
   // Input sanitation for filename apparently done in 2D_detector_out
-  
-
-  
   sprintf(this_storage.Detector_1D.title_string,"1D Union logger");
-  
-  sprintf(this_storage.Detector_1D.string_axis,"time [s]");
-  sprintf(this_storage.Detector_1D.string_axis_short,"t");
-  
   sprintf(this_storage.Detector_1D.string_axis_value,"Intensity");
-  
-  
   sprintf(this_storage.Detector_1D.Filename,filename);
   
+  // detect variable type and set axis accordingly
+  if (strcmp(variable,"time") == 0) {
+    variable_identifier = 1;
+    sprintf(this_storage.Detector_1D.string_axis,"time [s]");
+    sprintf(this_storage.Detector_1D.string_axis_short,"t");
+  } else if (strcmp(variable,"q") == 0) {
+    variable_identifier = 2;
+    sprintf(this_storage.Detector_1D.string_axis,"q [1/AA]");
+    sprintf(this_storage.Detector_1D.string_axis_short,"q");
+  } else {
+    printf("ERROR, Union logger \"%s\" had unrecoignized variable name \"%s\", must be either time or q.\n",NAME_CURRENT_COMP,variable);
+    exit(1);
+  }
   
+  
+  this_storage.variable_identifier = variable_identifier;
   this_storage.order = order_total;
   this_storage.order_in_this_volume = order_volume;
   this_storage.order_process_in_this_volume = order_volume_process;

--- a/mcstas-comps/contrib/union/Union_logger_2DQ.comp
+++ b/mcstas-comps/contrib/union/Union_logger_2DQ.comp
@@ -56,7 +56,7 @@
 * target_process:  [string] Comma seperated names of physical processes, if volumes are selected, one can select Union_process names
 * order_total:     [1] Only log rays that scatter for the n'th time, 0 for all orders
 * order_volume:    [1] Only log rays that scatter for the n'th time in the same geometry
-* order_volume_process [1] Only log rays that scatter for the n'th time in the same geometry, using the same process
+* order_volume_process [1] Only log rays that scatter for the n'th time in the same geometry, uwsing the same process
 * logger_conditional_extend_index [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then acces logger_conditional_extend[n] if logger_conditional_extend_index is set to n
 *
 * OUTPUT PARAMETERS:
@@ -151,56 +151,56 @@ void record_to_temp_2DQ(Coords *position, double *k_new, double *k_old, double p
     if (q1>storage->Detector_2D.D1min && q1<storage->Detector_2D.D1max && q2>storage->Detector_2D.D2min && q2<storage->Detector_2D.D2max) {
       i = floor((q1 - storage->Detector_2D.D1min)*storage->Detector_2D.bins_1/(storage->Detector_2D.D1max - storage->Detector_2D.D1min));
       j = floor((q2 - storage->Detector_2D.D2min)*storage->Detector_2D.bins_2/(storage->Detector_2D.D2max - storage->Detector_2D.D2min));
-    }
-
-    // Save bin in histogram to temp (may need to allocate more memory)
-    int index;
-    //printf("number of data points used: %d space allocated for %d data points. \n",storage->temp_2DQ_data.num_elements,storage->temp_2DQ_data.allocated_elements);
+    
+      // Save bin in histogram to temp (may need to allocate more memory)
+      int index;
+      //printf("number of data points used: %d space allocated for %d data points. \n",storage->temp_2DQ_data.num_elements,storage->temp_2DQ_data.allocated_elements);
   
-    if (storage->temp_2DQ_data.num_elements < storage->temp_2DQ_data.allocated_elements) {
-      storage->temp_2DQ_data.elements[storage->temp_2DQ_data.num_elements].index_1 = i;
-      storage->temp_2DQ_data.elements[storage->temp_2DQ_data.num_elements].index_2 = j;
-      storage->temp_2DQ_data.elements[storage->temp_2DQ_data.num_elements++].weight = p;
-    } else {
-      // No more space, need to allocate a larger buffer for this logger. Wish I had generics.
+      if (storage->temp_2DQ_data.num_elements < storage->temp_2DQ_data.allocated_elements) {
+        storage->temp_2DQ_data.elements[storage->temp_2DQ_data.num_elements].index_1 = i;
+        storage->temp_2DQ_data.elements[storage->temp_2DQ_data.num_elements].index_2 = j;
+        storage->temp_2DQ_data.elements[storage->temp_2DQ_data.num_elements++].weight = p;
+      } else {
+        // No more space, need to allocate a larger buffer for this logger. Wish I had generics.
     
-      // copy current data to temp
-      struct temp_2DQ_data_struct temporary_storage;
-      temporary_storage.num_elements = storage->temp_2DQ_data.num_elements;
-      temporary_storage.elements = malloc(temporary_storage.num_elements*sizeof(struct temp_2DQ_data_element_struct));
+        // copy current data to temp
+        struct temp_2DQ_data_struct temporary_storage;
+        temporary_storage.num_elements = storage->temp_2DQ_data.num_elements;
+        temporary_storage.elements = malloc(temporary_storage.num_elements*sizeof(struct temp_2DQ_data_element_struct));
     
-      for (index=0;index<storage->temp_2DQ_data.num_elements;index++) {
-        temporary_storage.elements[index].index_1 = storage->temp_2DQ_data.elements[index].index_1;
-        temporary_storage.elements[index].index_2 = storage->temp_2DQ_data.elements[index].index_2;
-        temporary_storage.elements[index].weight = storage->temp_2DQ_data.elements[index].weight;
-      }
+        for (index=0;index<storage->temp_2DQ_data.num_elements;index++) {
+          temporary_storage.elements[index].index_1 = storage->temp_2DQ_data.elements[index].index_1;
+          temporary_storage.elements[index].index_2 = storage->temp_2DQ_data.elements[index].index_2;
+          temporary_storage.elements[index].weight = storage->temp_2DQ_data.elements[index].weight;
+        }
       
-      // free current data
-      free(storage->temp_2DQ_data.elements);
+        // free current data
+        free(storage->temp_2DQ_data.elements);
     
-      // allocate larger array (10 larger)
-      storage->temp_2DQ_data.allocated_elements = 10 + storage->temp_2DQ_data.num_elements;
-      storage->temp_2DQ_data.elements = malloc(storage->temp_2DQ_data.allocated_elements*sizeof(struct temp_2DQ_data_element_struct));
+        // allocate larger array (10 larger)
+        storage->temp_2DQ_data.allocated_elements = 10 + storage->temp_2DQ_data.num_elements;
+        storage->temp_2DQ_data.elements = malloc(storage->temp_2DQ_data.allocated_elements*sizeof(struct temp_2DQ_data_element_struct));
     
-      // copy back from temp
-      for (index=0;index<storage->temp_2DQ_data.num_elements;index++) {
-        storage->temp_2DQ_data.elements[index].index_1 = temporary_storage.elements[index].index_1;
-        storage->temp_2DQ_data.elements[index].index_2 = temporary_storage.elements[index].index_2;
-        storage->temp_2DQ_data.elements[index].weight = temporary_storage.elements[index].weight;
+        // copy back from temp
+        for (index=0;index<storage->temp_2DQ_data.num_elements;index++) {
+          storage->temp_2DQ_data.elements[index].index_1 = temporary_storage.elements[index].index_1;
+          storage->temp_2DQ_data.elements[index].index_2 = temporary_storage.elements[index].index_2;
+          storage->temp_2DQ_data.elements[index].weight = temporary_storage.elements[index].weight;
+        }
+    
+        // free temporary data
+        free(temporary_storage.elements);
+    
+        // add new data point
+        storage->temp_2DQ_data.elements[storage->temp_2DQ_data.num_elements].index_1 = i;
+        storage->temp_2DQ_data.elements[storage->temp_2DQ_data.num_elements].index_2 = j;
+        storage->temp_2DQ_data.elements[storage->temp_2DQ_data.num_elements++].weight = p;
       }
-    
-      // free temporary data
-      free(temporary_storage.elements);
-    
-      // add new data point
-      storage->temp_2DQ_data.elements[storage->temp_2DQ_data.num_elements].index_1 = i;
-      storage->temp_2DQ_data.elements[storage->temp_2DQ_data.num_elements].index_2 = j;
-      storage->temp_2DQ_data.elements[storage->temp_2DQ_data.num_elements++].weight = p;
-    }
   
-    // If this is the first time this ray is being recorded in this logger, add it to the list of loggers that write to temp and may get it moved to perm
-    if (storage->temp_2DQ_data.num_elements == 1)
-      add_to_logger_with_data(logger_with_data_array,logger);
+      // If this is the first time this ray is being recorded in this logger, add it to the list of loggers that write to temp and may get it moved to perm
+      if (storage->temp_2DQ_data.num_elements == 1)
+        add_to_logger_with_data(logger_with_data_array,logger);
+    }
   }
   
 }

--- a/mcstas-comps/contrib/union/Union_logger_2D_kf.comp
+++ b/mcstas-comps/contrib/union/Union_logger_2D_kf.comp
@@ -154,56 +154,57 @@ void record_to_temp_2D_kf(Coords *position, double *k_new, double *k_old, double
     if (q1>storage->Detector_2D.D1min && q1<storage->Detector_2D.D1max && q2>storage->Detector_2D.D2min && q2<storage->Detector_2D.D2max) {
       i = floor((q1 - storage->Detector_2D.D1min)*storage->Detector_2D.bins_1/(storage->Detector_2D.D1max - storage->Detector_2D.D1min));
       j = floor((q2 - storage->Detector_2D.D2min)*storage->Detector_2D.bins_2/(storage->Detector_2D.D2max - storage->Detector_2D.D2min));
-    }
+    
 
-    // Save bin in histogram to temp (may need to allocate more memory)
-    int index;
-    //printf("number of data points used: %d space allocated for %d data points. \n",storage->temp_2D_kf_data.num_elements,storage->temp_2D_kf_data.allocated_elements);
+      // Save bin in histogram to temp (may need to allocate more memory)
+      int index;
+      //printf("number of data points used: %d space allocated for %d data points. \n",storage->temp_2D_kf_data.num_elements,storage->temp_2D_kf_data.allocated_elements);
   
-    if (storage->temp_2D_kf_data.num_elements < storage->temp_2D_kf_data.allocated_elements) {
-      storage->temp_2D_kf_data.elements[storage->temp_2D_kf_data.num_elements].index_1 = i;
-      storage->temp_2D_kf_data.elements[storage->temp_2D_kf_data.num_elements].index_2 = j;
-      storage->temp_2D_kf_data.elements[storage->temp_2D_kf_data.num_elements++].weight = p;
-    } else {
-      // No more space, need to allocate a larger buffer for this logger. Wish I had generics.
+      if (storage->temp_2D_kf_data.num_elements < storage->temp_2D_kf_data.allocated_elements) {
+        storage->temp_2D_kf_data.elements[storage->temp_2D_kf_data.num_elements].index_1 = i;
+        storage->temp_2D_kf_data.elements[storage->temp_2D_kf_data.num_elements].index_2 = j;
+        storage->temp_2D_kf_data.elements[storage->temp_2D_kf_data.num_elements++].weight = p;
+      } else {
+        // No more space, need to allocate a larger buffer for this logger. Wish I had generics.
     
-      // copy current data to temp
-      struct temp_2D_kf_data_struct temporary_storage;
-      temporary_storage.num_elements = storage->temp_2D_kf_data.num_elements;
-      temporary_storage.elements = malloc(temporary_storage.num_elements*sizeof(struct temp_2D_kf_data_element_struct));
+        // copy current data to temp
+        struct temp_2D_kf_data_struct temporary_storage;
+        temporary_storage.num_elements = storage->temp_2D_kf_data.num_elements;
+        temporary_storage.elements = malloc(temporary_storage.num_elements*sizeof(struct temp_2D_kf_data_element_struct));
     
-      for (index=0;index<storage->temp_2D_kf_data.num_elements;index++) {
-        temporary_storage.elements[index].index_1 = storage->temp_2D_kf_data.elements[index].index_1;
-        temporary_storage.elements[index].index_2 = storage->temp_2D_kf_data.elements[index].index_2;
-        temporary_storage.elements[index].weight = storage->temp_2D_kf_data.elements[index].weight;
-      }
+        for (index=0;index<storage->temp_2D_kf_data.num_elements;index++) {
+          temporary_storage.elements[index].index_1 = storage->temp_2D_kf_data.elements[index].index_1;
+          temporary_storage.elements[index].index_2 = storage->temp_2D_kf_data.elements[index].index_2;
+          temporary_storage.elements[index].weight = storage->temp_2D_kf_data.elements[index].weight;
+        }
       
-      // free current data
-      free(storage->temp_2D_kf_data.elements);
+        // free current data
+        free(storage->temp_2D_kf_data.elements);
     
-      // allocate larger array (10 larger)
-      storage->temp_2D_kf_data.allocated_elements = 10 + storage->temp_2D_kf_data.num_elements;
-      storage->temp_2D_kf_data.elements = malloc(storage->temp_2D_kf_data.allocated_elements*sizeof(struct temp_2D_kf_data_element_struct));
+        // allocate larger array (10 larger)
+        storage->temp_2D_kf_data.allocated_elements = 10 + storage->temp_2D_kf_data.num_elements;
+        storage->temp_2D_kf_data.elements = malloc(storage->temp_2D_kf_data.allocated_elements*sizeof(struct temp_2D_kf_data_element_struct));
     
-      // copy back from temp
-      for (index=0;index<storage->temp_2D_kf_data.num_elements;index++) {
-        storage->temp_2D_kf_data.elements[index].index_1 = temporary_storage.elements[index].index_1;
-        storage->temp_2D_kf_data.elements[index].index_2 = temporary_storage.elements[index].index_2;
-        storage->temp_2D_kf_data.elements[index].weight = temporary_storage.elements[index].weight;
+        // copy back from temp
+        for (index=0;index<storage->temp_2D_kf_data.num_elements;index++) {
+          storage->temp_2D_kf_data.elements[index].index_1 = temporary_storage.elements[index].index_1;
+          storage->temp_2D_kf_data.elements[index].index_2 = temporary_storage.elements[index].index_2;
+          storage->temp_2D_kf_data.elements[index].weight = temporary_storage.elements[index].weight;
+        }
+    
+        // free temporary data
+        free(temporary_storage.elements);
+    
+        // add new data point
+        storage->temp_2D_kf_data.elements[storage->temp_2D_kf_data.num_elements].index_1 = i;
+        storage->temp_2D_kf_data.elements[storage->temp_2D_kf_data.num_elements].index_2 = j;
+        storage->temp_2D_kf_data.elements[storage->temp_2D_kf_data.num_elements++].weight = p;
       }
-    
-      // free temporary data
-      free(temporary_storage.elements);
-    
-      // add new data point
-      storage->temp_2D_kf_data.elements[storage->temp_2D_kf_data.num_elements].index_1 = i;
-      storage->temp_2D_kf_data.elements[storage->temp_2D_kf_data.num_elements].index_2 = j;
-      storage->temp_2D_kf_data.elements[storage->temp_2D_kf_data.num_elements++].weight = p;
-    }
   
-    // If this is the first time this ray is being recorded in this logger, add it to the list of loggers that write to temp and may get it moved to perm
-    if (storage->temp_2D_kf_data.num_elements == 1)
-      add_to_logger_with_data(logger_with_data_array,logger);
+      // If this is the first time this ray is being recorded in this logger, add it to the list of loggers that write to temp and may get it moved to perm
+      if (storage->temp_2D_kf_data.num_elements == 1)
+        add_to_logger_with_data(logger_with_data_array,logger);
+    }
   }
   
 }

--- a/mcstas-comps/contrib/union/Union_logger_2D_space.comp
+++ b/mcstas-comps/contrib/union/Union_logger_2D_space.comp
@@ -168,56 +168,57 @@ void record_to_temp_2DS(Coords *position, double *k_new, double *k_old, double p
     if (p1>storage->Detector_2D.D1min && p1<storage->Detector_2D.D1max && p2>storage->Detector_2D.D2min && p2<storage->Detector_2D.D2max) {
       i = floor((p1 - storage->Detector_2D.D1min)*storage->Detector_2D.bins_1/(storage->Detector_2D.D1max - storage->Detector_2D.D1min));
       j = floor((p2 - storage->Detector_2D.D2min)*storage->Detector_2D.bins_2/(storage->Detector_2D.D2max - storage->Detector_2D.D2min));
-    }
-
-    // Save bin in histogram to temp (may need to allocate more memory)
-    int index;
-    //printf("number of data points used: %d space allocated for %d data points. \n",storage->temp_2DS_data.num_elements,storage->temp_2DS_data.allocated_elements);
+    
+      // Save bin in histogram to temp (may need to allocate more memory)
+      int index;
+      //printf("number of data points used: %d space allocated for %d data points. \n",storage->temp_2DS_data.num_elements,storage->temp_2DS_data.allocated_elements);
   
-    if (storage->temp_2DS_data.num_elements < storage->temp_2DS_data.allocated_elements) {
-      storage->temp_2DS_data.elements[storage->temp_2DS_data.num_elements].index_1 = i;
-      storage->temp_2DS_data.elements[storage->temp_2DS_data.num_elements].index_2 = j;
-      storage->temp_2DS_data.elements[storage->temp_2DS_data.num_elements++].weight = p;
-    } else {
-      // No more space, need to allocate a larger buffer for this logger. Wish I had generics.
+      if (storage->temp_2DS_data.num_elements < storage->temp_2DS_data.allocated_elements) {
+        storage->temp_2DS_data.elements[storage->temp_2DS_data.num_elements].index_1 = i;
+        storage->temp_2DS_data.elements[storage->temp_2DS_data.num_elements].index_2 = j;
+        storage->temp_2DS_data.elements[storage->temp_2DS_data.num_elements++].weight = p;
+      } else {
+        // No more space, need to allocate a larger buffer for this logger. Wish I had generics.
     
-      // copy current data to temp
-      struct temp_2DS_data_struct temporary_storage;
-      temporary_storage.num_elements = storage->temp_2DS_data.num_elements;
-      temporary_storage.elements = malloc(temporary_storage.num_elements*sizeof(struct temp_2DS_data_element_struct));
+        // copy current data to temp
+        struct temp_2DS_data_struct temporary_storage;
+        temporary_storage.num_elements = storage->temp_2DS_data.num_elements;
+        temporary_storage.elements = malloc(temporary_storage.num_elements*sizeof(struct temp_2DS_data_element_struct));
     
-      for (index=0;index<storage->temp_2DS_data.num_elements;index++) {
-        temporary_storage.elements[index].index_1 = storage->temp_2DS_data.elements[index].index_1;
-        temporary_storage.elements[index].index_2 = storage->temp_2DS_data.elements[index].index_2;
-        temporary_storage.elements[index].weight = storage->temp_2DS_data.elements[index].weight;
-      }
+        for (index=0;index<storage->temp_2DS_data.num_elements;index++) {
+          temporary_storage.elements[index].index_1 = storage->temp_2DS_data.elements[index].index_1;
+          temporary_storage.elements[index].index_2 = storage->temp_2DS_data.elements[index].index_2;
+          temporary_storage.elements[index].weight = storage->temp_2DS_data.elements[index].weight;
+        }
       
-      // free current data
-      free(storage->temp_2DS_data.elements);
+        // free current data
+        free(storage->temp_2DS_data.elements);
     
-      // allocate larger array (10 larger)
-      storage->temp_2DS_data.allocated_elements = 10 + storage->temp_2DS_data.num_elements;
-      storage->temp_2DS_data.elements = malloc(storage->temp_2DS_data.allocated_elements*sizeof(struct temp_2DS_data_element_struct));
+        // allocate larger array (10 larger)
+        storage->temp_2DS_data.allocated_elements = 10 + storage->temp_2DS_data.num_elements;
+        storage->temp_2DS_data.elements = malloc(storage->temp_2DS_data.allocated_elements*sizeof(struct temp_2DS_data_element_struct));
     
-      // copy back from temp
-      for (index=0;index<storage->temp_2DS_data.num_elements;index++) {
-        storage->temp_2DS_data.elements[index].index_1 = temporary_storage.elements[index].index_1;
-        storage->temp_2DS_data.elements[index].index_2 = temporary_storage.elements[index].index_2;
-        storage->temp_2DS_data.elements[index].weight = temporary_storage.elements[index].weight;
+        // copy back from temp
+        for (index=0;index<storage->temp_2DS_data.num_elements;index++) {
+          storage->temp_2DS_data.elements[index].index_1 = temporary_storage.elements[index].index_1;
+          storage->temp_2DS_data.elements[index].index_2 = temporary_storage.elements[index].index_2;
+          storage->temp_2DS_data.elements[index].weight = temporary_storage.elements[index].weight;
+        }
+    
+        // free temporary data
+        free(temporary_storage.elements);
+    
+        // add new data point
+        storage->temp_2DS_data.elements[storage->temp_2DS_data.num_elements].index_1 = i;
+        storage->temp_2DS_data.elements[storage->temp_2DS_data.num_elements].index_2 = j;
+        storage->temp_2DS_data.elements[storage->temp_2DS_data.num_elements++].weight = p;
       }
-    
-      // free temporary data
-      free(temporary_storage.elements);
-    
-      // add new data point
-      storage->temp_2DS_data.elements[storage->temp_2DS_data.num_elements].index_1 = i;
-      storage->temp_2DS_data.elements[storage->temp_2DS_data.num_elements].index_2 = j;
-      storage->temp_2DS_data.elements[storage->temp_2DS_data.num_elements++].weight = p;
-    }
   
-    // If this is the first time this ray is being recorded in this logger, add it to the list of loggers that write to temp and may get it moved to perm
-    if (storage->temp_2DS_data.num_elements == 1)
-      add_to_logger_with_data(logger_with_data_array,logger);
+      // If this is the first time this ray is being recorded in this logger, add it to the list of loggers that write to temp and may get it moved to perm
+      if (storage->temp_2DS_data.num_elements == 1)
+        add_to_logger_with_data(logger_with_data_array,logger);
+      
+    }
   }
   
 }
@@ -304,19 +305,20 @@ void record_to_perm_2DS(Coords *position, double *k_new, double *k_old, double p
 
 // write_temp_to_perm
 void write_temp_to_perm_2DS(union logger_data_union *data_union) {
-
   struct a_2DS_storage_struct *storage;
   storage = data_union->p_2DS_storage;
 
   int index;
   // Add all data points to the historgram, they are saved as index / weight combinations
   for (index=0;index<storage->temp_2DS_data.num_elements;index++) {
+  
     storage->Detector_2D.Array_N[storage->temp_2DS_data.elements[index].index_1][storage->temp_2DS_data.elements[index].index_2]++;
     
     storage->Detector_2D.Array_p[storage->temp_2DS_data.elements[index].index_1][storage->temp_2DS_data.elements[index].index_2] += storage->temp_2DS_data.elements[index].weight;
     
     storage->Detector_2D.Array_p2[storage->temp_2DS_data.elements[index].index_1][storage->temp_2DS_data.elements[index].index_2] += storage->temp_2DS_data.elements[index].weight*storage->temp_2DS_data.elements[index].weight;
   }
+  
   clear_temp_2DS(data_union);
 }
 

--- a/mcstas-comps/contrib/union/Union_logger_2D_space_time.comp
+++ b/mcstas-comps/contrib/union/Union_logger_2D_space_time.comp
@@ -225,9 +225,9 @@ void record_to_temp_2DS_t(Coords *position, double *k_new, double *k_old, double
         storage->temp_2DS_t_data.elements[storage->temp_2DS_t_data.num_elements++].weight = p;
       }
   
-    // If this is the first time this ray is being recorded in this logger, add it to the list of loggers that write to temp and may get it moved to perm
-    if (storage->temp_2DS_t_data.num_elements == 1)
-      add_to_logger_with_data(logger_with_data_array,logger);
+      // If this is the first time this ray is being recorded in this logger, add it to the list of loggers that write to temp and may get it moved to perm
+      if (storage->temp_2DS_t_data.num_elements == 1)
+        add_to_logger_with_data(logger_with_data_array,logger);
       
     }
   }

--- a/mcstas-comps/contrib/union/Union_logger_3D_space.comp
+++ b/mcstas-comps/contrib/union/Union_logger_3D_space.comp
@@ -179,60 +179,61 @@ void record_to_temp_3DS(Coords *position, double *k_new, double *k_old, double p
       i = floor((p1 - storage->Detector_3D.D1min)*storage->Detector_3D.bins_1/(storage->Detector_3D.D1max - storage->Detector_3D.D1min));
       j = floor((p2 - storage->Detector_3D.D2min)*storage->Detector_3D.bins_2/(storage->Detector_3D.D2max - storage->Detector_3D.D2min));
       k = floor((p3 - storage->Detector_3D.D3min)*storage->Detector_3D.bins_3/(storage->Detector_3D.D3max - storage->Detector_3D.D3min));
-    }
+    
 
-    // Save bin in histogram to temp (may need to allocate more memory)
-    int index;
-    //printf("number of data points used: %d space allocated for %d data points. \n",storage->temp_3DS_data.num_elements,storage->temp_3DS_data.allocated_elements);
+      // Save bin in histogram to temp (may need to allocate more memory)
+      int index;
+      //printf("number of data points used: %d space allocated for %d data points. \n",storage->temp_3DS_data.num_elements,storage->temp_3DS_data.allocated_elements);
   
-    if (storage->temp_3DS_data.num_elements < storage->temp_3DS_data.allocated_elements) {
-      storage->temp_3DS_data.elements[storage->temp_3DS_data.num_elements].index_1 = k;
-      storage->temp_3DS_data.elements[storage->temp_3DS_data.num_elements].index_2 = i;
-      storage->temp_3DS_data.elements[storage->temp_3DS_data.num_elements].index_3 = j;
-      storage->temp_3DS_data.elements[storage->temp_3DS_data.num_elements++].weight = p;
-    } else {
-      // No more space, need to allocate a larger buffer for this logger. Wish I had generics.
+      if (storage->temp_3DS_data.num_elements < storage->temp_3DS_data.allocated_elements) {
+        storage->temp_3DS_data.elements[storage->temp_3DS_data.num_elements].index_1 = k;
+        storage->temp_3DS_data.elements[storage->temp_3DS_data.num_elements].index_2 = i;
+        storage->temp_3DS_data.elements[storage->temp_3DS_data.num_elements].index_3 = j;
+        storage->temp_3DS_data.elements[storage->temp_3DS_data.num_elements++].weight = p;
+      } else {
+        // No more space, need to allocate a larger buffer for this logger. Wish I had generics.
     
-      // copy current data to temp
-      struct temp_3DS_data_struct temporary_storage;
-      temporary_storage.num_elements = storage->temp_3DS_data.num_elements;
-      temporary_storage.elements = malloc(temporary_storage.num_elements*sizeof(struct temp_3DS_data_element_struct));
+        // copy current data to temp
+        struct temp_3DS_data_struct temporary_storage;
+        temporary_storage.num_elements = storage->temp_3DS_data.num_elements;
+        temporary_storage.elements = malloc(temporary_storage.num_elements*sizeof(struct temp_3DS_data_element_struct));
     
-      for (index=0;index<storage->temp_3DS_data.num_elements;index++) {
-        temporary_storage.elements[index].index_1 = storage->temp_3DS_data.elements[index].index_1;
-        temporary_storage.elements[index].index_2 = storage->temp_3DS_data.elements[index].index_2;
-        temporary_storage.elements[index].index_3 = storage->temp_3DS_data.elements[index].index_3;
-        temporary_storage.elements[index].weight = storage->temp_3DS_data.elements[index].weight;
-      }
+        for (index=0;index<storage->temp_3DS_data.num_elements;index++) {
+          temporary_storage.elements[index].index_1 = storage->temp_3DS_data.elements[index].index_1;
+          temporary_storage.elements[index].index_2 = storage->temp_3DS_data.elements[index].index_2;
+          temporary_storage.elements[index].index_3 = storage->temp_3DS_data.elements[index].index_3;
+          temporary_storage.elements[index].weight = storage->temp_3DS_data.elements[index].weight;
+        }
       
-      // free current data
-      free(storage->temp_3DS_data.elements);
+        // free current data
+        free(storage->temp_3DS_data.elements);
     
-      // allocate larger array (10 larger)
-      storage->temp_3DS_data.allocated_elements = 10 + storage->temp_3DS_data.num_elements;
-      storage->temp_3DS_data.elements = malloc(storage->temp_3DS_data.allocated_elements*sizeof(struct temp_3DS_data_element_struct));
+        // allocate larger array (10 larger)
+        storage->temp_3DS_data.allocated_elements = 10 + storage->temp_3DS_data.num_elements;
+        storage->temp_3DS_data.elements = malloc(storage->temp_3DS_data.allocated_elements*sizeof(struct temp_3DS_data_element_struct));
     
-      // copy back from temp
-      for (index=0;index<storage->temp_3DS_data.num_elements;index++) {
-        storage->temp_3DS_data.elements[index].index_1 = temporary_storage.elements[index].index_1;
-        storage->temp_3DS_data.elements[index].index_2 = temporary_storage.elements[index].index_2;
-        storage->temp_3DS_data.elements[index].index_3 = temporary_storage.elements[index].index_3;
-        storage->temp_3DS_data.elements[index].weight = temporary_storage.elements[index].weight;
+        // copy back from temp
+        for (index=0;index<storage->temp_3DS_data.num_elements;index++) {
+          storage->temp_3DS_data.elements[index].index_1 = temporary_storage.elements[index].index_1;
+          storage->temp_3DS_data.elements[index].index_2 = temporary_storage.elements[index].index_2;
+          storage->temp_3DS_data.elements[index].index_3 = temporary_storage.elements[index].index_3;
+          storage->temp_3DS_data.elements[index].weight = temporary_storage.elements[index].weight;
+        }
+    
+        // free temporary data
+        free(temporary_storage.elements);
+    
+        // add new data point
+        storage->temp_3DS_data.elements[storage->temp_3DS_data.num_elements].index_1 = k;
+        storage->temp_3DS_data.elements[storage->temp_3DS_data.num_elements].index_2 = i;
+        storage->temp_3DS_data.elements[storage->temp_3DS_data.num_elements].index_3 = j;
+        storage->temp_3DS_data.elements[storage->temp_3DS_data.num_elements++].weight = p;
       }
-    
-      // free temporary data
-      free(temporary_storage.elements);
-    
-      // add new data point
-      storage->temp_3DS_data.elements[storage->temp_3DS_data.num_elements].index_1 = k;
-      storage->temp_3DS_data.elements[storage->temp_3DS_data.num_elements].index_2 = i;
-      storage->temp_3DS_data.elements[storage->temp_3DS_data.num_elements].index_3 = j;
-      storage->temp_3DS_data.elements[storage->temp_3DS_data.num_elements++].weight = p;
-    }
   
-    // If this is the first time this ray is being recorded in this logger, add it to the list of loggers that write to temp and may get it moved to perm
-    if (storage->temp_3DS_data.num_elements == 1)
-      add_to_logger_with_data(logger_with_data_array,logger);
+      // If this is the first time this ray is being recorded in this logger, add it to the list of loggers that write to temp and may get it moved to perm
+      if (storage->temp_3DS_data.num_elements == 1)
+        add_to_logger_with_data(logger_with_data_array,logger);
+    }
   }
   
 }

--- a/mcstas-comps/contrib/union/Union_master.comp
+++ b/mcstas-comps/contrib/union/Union_master.comp
@@ -52,7 +52,7 @@ DEPENDENCY "-I@MCCODE_LIB@/share/"
 SHARE
 %{
 #ifndef Union
-#define Union $Revision: 0.8 $
+#define Union $Revision: 0.9 $
 
 #include "Union_functions.c"
 #include "Union_initialization.c"
@@ -362,6 +362,9 @@ INITIALIZE
     free_tagging_conditioanl_list = 1;
   }
   
+    // The absolute rotation of this component is saved for use in initialization
+  rot_transpose(ROT_A_CURRENT_COMP,master_transposed_rotation_matrix);
+  
   // Update positions and rotations in transform lists
   for (iterate=0;iterate<global_positions_to_transform_list.num_elements;iterate++) {
     //print_position(*global_positions_to_transform_list.positions[iterate],"Position to transform before");
@@ -376,16 +379,15 @@ INITIALIZE
   }
   for (iterate=0;iterate<global_rotations_to_transform_list.num_elements;iterate++) {
     //print_rotation(*(global_rotations_to_transform_list.rotations[iterate]),"rotation matrix to be updated");
-    rot_mul(ROT_A_CURRENT_COMP,*(global_rotations_to_transform_list.rotations[iterate]),temp_rotation_matrix);
+    
+    //rot_mul(ROT_A_CURRENT_COMP,*(global_rotations_to_transform_list.rotations[iterate]),temp_rotation_matrix);
+    rot_mul(master_transposed_rotation_matrix,*(global_rotations_to_transform_list.rotations[iterate]),temp_rotation_matrix);
     rot_copy(*(global_rotations_to_transform_list.rotations[iterate]),temp_rotation_matrix);
   }
   if (global_rotations_to_transform_list.num_elements > 0) {
     global_rotations_to_transform_list.num_elements = 0;
     free(global_rotations_to_transform_list.rotations);
   }
-  
-  // The absolute rotation of this component is saved for use in initialization
-  rot_transpose(ROT_A_CURRENT_COMP,master_transposed_rotation_matrix);
   
   // A pointer to the geometry structure
   Geometries[0] = &Volumes[0]->geometry;
@@ -566,16 +568,28 @@ INITIALIZE
       Volumes[volume_index]->geometry.center.y = rotated_position.y;
       Volumes[volume_index]->geometry.center.z = rotated_position.z;
       
+      // The focus_data information need to be updated as well
+      rot_mul(ROT_A_CURRENT_COMP,Volumes[volume_index]->geometry.focus_data.absolute_rotation,temp_rotation_matrix);
+      // Copy the result back to the volumes structure
+      rot_copy(Volumes[volume_index]->geometry.focus_data.absolute_rotation,temp_rotation_matrix);
+      // Now update the transpose as well
+      //rot_transpose(Volumes[volume_index]->geometry.focus_data.absolute_rotation,temp_rotation_matrix);
+      //rot_copy(Volumes[volume_index]->geometry.transpose_rotation_matrix,temp_rotation_matrix);
+      
       // Using the same algorithm, the Aim vector of the focus_data struct is transformed as well
+      // There may be an issue with focusing in a isotropic and non isotropic scattering process
       non_rotated_position.x = Volumes[volume_index]->geometry.focus_data.Aim.x;
       non_rotated_position.y = Volumes[volume_index]->geometry.focus_data.Aim.y;
       non_rotated_position.z = Volumes[volume_index]->geometry.focus_data.Aim.z;
 
       rotated_position = rot_apply(ROT_A_CURRENT_COMP,non_rotated_position);
+      //rotated_position = rot_apply(master_transposed_rotation_matrix,non_rotated_position);
 
+      /*
       Volumes[volume_index]->geometry.focus_data.Aim.x = rotated_position.x;
       Volumes[volume_index]->geometry.focus_data.Aim.y = rotated_position.y;
       Volumes[volume_index]->geometry.focus_data.Aim.z = rotated_position.z;
+      */
 
       //sprintf(string_output,"Rotated Aim vector for volume [%d]",volume_index);
       //print_position(Volumes[volume_index]->geometry.focus_data.Aim,string_output);
@@ -710,6 +724,7 @@ INITIALIZE
   if (max_conditional_extend_index > -1) {
     logger_conditional_extend_array = malloc((max_conditional_extend_index + 1)*sizeof(int));
   }
+  
   
   // In this function different lists of volume indecies are generated. They are the key to the speed of the component and central for the logic.
   // They use simple set algebra to generate these lists for each volume:
@@ -888,6 +903,7 @@ TRACE
   done = 0;
   error_msg = 0;
   clear_intersection_table(&intersection_time_table);
+  
   
   time_propagated_without_scattering = 0;
   v_length = sqrt(vx*vx+vy*vy+vz*vz);
@@ -1151,6 +1167,7 @@ TRACE
                 wavevector_rotated = rot_apply(Volumes[current_volume]->geometry.process_rot_matrix_array[Volumes[current_volume]->p_physics->p_scattering_array[process - process_start].non_isotropic_rot_index],wavevector);
                 
                 coords_get(wavevector_rotated,&k_rotated[0],&k_rotated[1],&k_rotated[2]);
+
               } else {
                 k_rotated[0] = k[0]; k_rotated[1] = k[1]; k_rotated[2] = k[2];
               }
@@ -1179,10 +1196,12 @@ TRACE
             
             my_sum_plus_abs = my_sum + Volumes[current_volume]->p_physics->my_a*(2200/v_length);
             
+            // May need a safeguard for a situation with my_sum = 0
             // NEW SYSTEM
-            if (my_sum_plus_abs < 1E-18) {
+            if (my_sum < 1E-18) {
                 // The scattering cross section is basicly zero, no scattering should occur.
                 scattering_event = 0;
+                p *= exp(-length_to_boundery*my_sum_plus_abs); // Correct for absorption
             } else if (length_to_boundery < safty_distance2) {
                 // Experiment 28/11/2016
                 // Too close to boundery to safly make another scattering, attenuate
@@ -1229,6 +1248,7 @@ TRACE
                 if (scattering_event == 1) {
                   // Adjust weight for absorption
                   p *= my_sum/my_sum_plus_abs;
+                  if (my_sum/my_sum_plus_abs > 1) printf("weight factor above 1! Should not happen! \n");
                   // Select process
                   if (Volumes[current_volume]->p_physics->number_of_processes == 1) {
                     // trivial case
@@ -1332,7 +1352,7 @@ TRACE
             // Safe check that should be unecessary. Used to fine tune how close to the edge of a volume a scattering event is allowed to take place (1E-14 m away currently).
             if (Volumes[current_volume]->geometry.within_function(ray_position,&Volumes[current_volume]->geometry) == 0) {
               printf("\nERROR, propagated out of current volume instead of to a point within!\n");
-              printf("length_to_scattering_specified = %2.20f\n             length propagated = %2.20f\n            length_to_boundery = %2.20f \n",length_to_scattering,sqrt(time_to_scattering*time_to_scattering*vx*vx+time_to_scattering*time_to_scattering*vy*vy+time_to_scattering*time_to_scattering*vz*vz),length_to_boundery);
+              printf("length_to_scattering_specified = %2.20f\n             length propagated = %2.20f\n            length_to_boundery = %2.20f \n   current_position = (%lf,%lf,%lf) \n",length_to_scattering,sqrt(time_to_scattering*time_to_scattering*vx*vx+time_to_scattering*time_to_scattering*vy*vy+time_to_scattering*time_to_scattering*vz*vz),length_to_boundery,x,y,z);
               
               volume_index = within_which_volume(ray_position,starting_lists.reduced_start_list,starting_lists.starting_destinations_list,Volumes,&mask_status_list,number_of_volumes,pre_allocated1,pre_allocated2,pre_allocated3);
               
@@ -1358,13 +1378,17 @@ TRACE
             
             // I may replace a intial and final k with one instance that serves as both input and output
             if (0 == Volumes[current_volume]->p_physics->p_scattering_array[selected_process].scattering_function(k_new,k,&p,Volumes[current_volume]->p_physics->p_scattering_array[selected_process].data_transfer,&Volumes[current_volume]->geometry.focus_data)) {
+              /*
+              // PowderN and Single_crystal requires the option of absorbing the neutron, which is weird. If there is a scattering probability, there should be a new direction.
+              // It can arise from need to simplify sampling process and end up in cases where weight factor is 0, and the ray should be absorbed in these cases
               printf("ERROR: Union_master: %s.Absorbed ray because scattering function returned 0 (error/absorb)\n",NAME_CURRENT_COMP);
               component_error_msg++;
               if (component_error_msg > 100) {
                 printf("To many errors encountered, exiting. \n");
                 exit(1);
               }
-              ABSORB; // PowderN and Single_crystal requires the option of absorbing the neutron, which is weird. If there is a scattering probability, there should be a new direction.
+              */
+              ABSORB;
             }
             
             // Update velocity using k
@@ -1701,12 +1725,15 @@ TRACE
               for (iterate=0;iterate<number_of_volumes;iterate++)
                  printf("%d:%d - ",iterate,scattered_flag[iterate]);
               printf("\n");
+              printf("r = (%f,%f,%f) v = (%f,%f,%f) \n",x,y,z,vx,vy,vz);
               
               printf("Trace error number (%d/100) \n",component_error_msg);
               //print_intersection_table(intersection_time_table);
               //printf("Cluster is loosing the thread, debug for this behavior\n");
               //printf("global_all_volume_logger_list.num_elements = %d\n",global_all_volume_logger_list.num_elements);
               //printf("global_specific_volumes_logger_list.num_elements = %d\n",global_specific_volumes_logger_list.num_elements);
+              
+              //exit(1); // Temporary
             }
             error_msg++;
             
@@ -1720,7 +1747,7 @@ TRACE
     }
     /*
     */
-    if (limit == 0) {done = 1; printf("Reached limit on number of interactions, and discarded the neutron, was in volume %d\n",current_volume);ABSORB;}
+    if (limit == 0) {done = 1; ray_sucseeded = 0; printf("Reached limit on number of interactions, and discarded the neutron, was in volume %d\n",current_volume);ABSORB;}
     if (trace_verbal) printf("----------- END OF WHILE LOOP --------------------------------------\n");
     //printf("This ray did %d iterations in the while loop\n",1000-limit);
     
@@ -1791,6 +1818,7 @@ TRACE
       conditional_status = 1;
       for (iterate=0;iterate<tagging_conditional_list->num_elements;iterate++) {
         // Call this particular conditional. If it fails, report the status and break
+        // Since a conditional can work for a logger and master_tagging at the same time, it may be evaluated twice
         //printf("checking conditional! \n");
         if (trace_verbal) printf("Checking tagging conditional number %d\n",iterate);
         if (0 == tagging_conditional_list->conditional_functions[iterate](
@@ -1821,6 +1849,7 @@ TRACE
     // Could error log here
   }
   
+  
 %}
 
 
@@ -1834,6 +1863,7 @@ FINALLY
 // write out histories from tagging system if enabled
 if (enable_tagging) {
     if (finally_verbal) printf("Writing tagging tree to disk \n");
+    if (finally_verbal) printf("Number of leafs = %d \n",tagging_leaf_counter);
     // While writing the tagging tree to disk, all the leafs are deallocated
     write_tagging_tree(&master_tagging_node_list, Volumes, tagging_leaf_counter, number_of_volumes);
 }

--- a/mcstas-comps/share/Geometry_functions.c
+++ b/mcstas-comps/share/Geometry_functions.c
@@ -1181,6 +1181,7 @@ int cylinder_within_cylinder(struct geometry_struct *geometry_child,struct geome
                         // If there is a solution before the cylinder ends, cylinder 2 can not be within cylinder 1
                         if (positive_solution < height2) {
                             if (verbal == 1) printf("Along axis: Not inside, as the positive solutions is less than the cylinder height: %f %f\n",temp_solution[0],temp_solution[1]);
+                            if (verbal == 1) printf("Radial position = (%f,%f,%f) \n",radial_position[0],radial_position[1],radial_position[2]);
                             return 0;
                         }
                     }
@@ -1199,6 +1200,11 @@ int cylinder_within_cylinder(struct geometry_struct *geometry_child,struct geome
                     //printf("Base point number %d was not inside cylinder 1 (%f %f %f)\n",iterate,base_point_vector[0],base_point_vector[1],base_point_vector[2]);
                     return 0;
                 }
+            
+                // Base point in vector notation needed for intersect function.
+                base_point_vector[0] = base_point.x;
+                base_point_vector[1] = base_point.y;
+                base_point_vector[2] = base_point.z;
             
                 // The vector circ_point is from the base to the circumference. This is used to check the bottom cap.
                 sample_cylinder_intersect(temp_solution,&number_of_solutions,base_point_vector,cyl_radial_direction,geometry_parent);
@@ -1226,7 +1232,7 @@ int cylinder_within_cylinder(struct geometry_struct *geometry_child,struct geome
                 } else {
                     if (verbal == 1) printf("Radially bottom: 0 or 1 solution!\n");
                     if (verbal == 1) print_position(circ_point,"current circ point");
-                    if (verbal == 1) print_position(coords_set(cyl_radial_direction[0],cyl_radial_direction[1],cyl_radial_direction[2]),"current cyl_radial_directio (should be same as above)");
+                    if (verbal == 1) print_position(coords_set(cyl_radial_direction[0],cyl_radial_direction[1],cyl_radial_direction[2]),"current cyl_radial_direction (should be same as above)");
                     return 0; // If there are 1 or 0 solutions, the radial position (on cylinder 2) would not be inside cylinder 1
                 }
             

--- a/mcstas-comps/share/Union_functions.c
+++ b/mcstas-comps/share/Union_functions.c
@@ -345,6 +345,7 @@ union data_transfer_union{
     struct Incoherent_physics_storage_struct  *pointer_to_a_Incoherent_physics_storage_struct;
     struct Powder_physics_storage_struct *pointer_to_a_Powder_physics_storage_struct;
     struct Single_crystal_physics_storage_struct *pointer_to_a_Single_crystal_physics_storage_struct;
+    struct AF_HB_1D_physics_storage_struct *pointer_to_a_AF_HB_1D_physics_storage_struct;
     struct Template_physics_storage_struct *pointer_to_a_Template_physics_storage_struct;
     // possible to add as many structs as wanted, without increasing memory footprint.
 };
@@ -3921,6 +3922,7 @@ void focus_initialize(struct geometry_struct *geometry, Coords POS_A_TARGET, Coo
   geometry->focus_data.spatial_focus_width = 0;
   geometry->focus_data.spatial_focus_height = 0;
   geometry->focus_data.spatial_focus_radius = 0;
+  rot_copy(geometry->focus_data.absolute_rotation,ROT_A_CURRENT);
 
   // Built on code from Incoherent.comp by Kim Lefmann and Kristian Nielsen
   if (target_index != 0 && !target_x && !target_y && !target_z)
@@ -3973,5 +3975,4 @@ void focus_initialize(struct geometry_struct *geometry, Coords POS_A_TARGET, Coo
     geometry->focus_data.focusing_function = &randvec_target_circle_union;
   }
 };
-
 


### PR DESCRIPTION
A few bug fixes for Union components and single feature addition allowing the scattering magnitude to be logged by Union_logger_1D.comp.

Union_conditional_standard overwritten on accident.

Union_logger_1d can now log magnitude of scattering vector.

Bug fixed in logic of cylinder_within_cylinder that prevented correct detection of child - parent relationship when the detectors were tilted with regards to each other.

Updated logic in Union_master to account for materials with high absorption cross section, and processes that can give no scattering cross section.

Fixed bug in most Union_loggers that would cause them to write to memory outside of the allocated space in case events were recorded outside their histogram bounderies.

Found bug in focusing code that means behavior is different depending on the process being isotropic or not. Have not been fixed yet.