### PR TITLE
Update of Union example documentation section and absorber bug fix

### DIFF
--- a/mcstas-comps/contrib/union/Union_make_material.comp
+++ b/mcstas-comps/contrib/union/Union_make_material.comp
@@ -6,6 +6,7 @@
 * %I
 * Written by: Mads Bertelsen
 * Date: 20.08.15
+* Version: $Revision: 0.1 $
 * Origin: Svanevej 19
 *
 * %D
@@ -28,16 +29,16 @@
 *
 * %P
 * INPUT PARAMETERS:
-* process_string: [string]     Comma seperated names of physical processes
-* my_absorption: [1/m]         Inverse penetration depth from absorption at standard energy
-* absorber: [0/1]              Control parameter, if set to 1 the material will have no scattering processes
+* process_string:  [string] Comma seperated names of physical processes
+* my_absorption:   [1/m]    Inverse penetration depth from absorption at standard energy
+* absorber:        [0/1]    Control parameter, if set to 1 the material will have no scattering processes
 *
 * OUTPUT PARAMETERS:
-* this_material: []            Structure that contains information on this material
-* global_material_element: []  Element of global_material_list which is a global variable
+* this_material:            Structure that contains information on this material
+* global_material_element:  Element of global_material_list which is a global variable
 *
 * GLOBAL PARAMETERS:
-* global_material_list: []     List of all defined materials, available in the global scope
+* global_material_list:     List of all defined materials, available in the global scope
 *
 * %L
 *
@@ -57,6 +58,7 @@ SHARE
 #define Union $Revision: 0.8 $
 
 #include "Union_functions.c"
+#include "Union_initialization.c"
 
 #endif
 

--- a/mcstas-comps/examples/Union_demonstration.instr
+++ b/mcstas-comps/examples/Union_demonstration.instr
@@ -5,40 +5,47 @@
 *         Risoe National Laboratory, Roskilde, Denmark
 *         Institut Laue Langevin, Grenoble, France
 *
-* Instrument: test
+* Instrument: Union_demonstration
 *
 * %Identification
 * Written by: Mads Bertelsen
 * Date: September 2015
 * Origin: University of Copenhagen
-* %INSTRUMENT_SITE:
-*
-* Simple test instrument for sample component.
+* %INSTRUMENT_SITE: Union_demos
 *
 * %Description
-* simple test instrument for sample component.
+* Demonstration of Union components. Here four different powder samples are
+*  placed in a can each connected to a weird sample holder and contained in
+*  a cryostat. This unrealistic example is meant to show the syntax and the
+*  new possibilities when using the Union components.
+* With the standard source only two of the samples are illuminated, yet
+*  multiple scattering occur and events are thus taking place in the last
+*  two samples.
 *
-* Example: filename="source_sct091_tu_02_1.dat" Detector: det_I=9.89304e+09
+* Example: Detector: m4pi_two_or_more_samples_I=0.0945567
 *
 * %Parameters
-* stick_displacement
+* stick_displacement [m] height displacement of sample stick
 *
 * %End
 *******************************************************************************/
 
-DEFINE INSTRUMENT test(stick_displacement=0)
+DEFINE INSTRUMENT Union_demonstration(stick_displacement=0)
 
 DECLARE
 %{
-int sample_1_index=27,sample_2_index=30,sample_3_index=33,sample_4_index=36; // Indexes of three samples
+int sample_1_index=27,sample_2_index=30,sample_3_index=33,sample_4_index=36; // Indexes of four samples
 int scattered_1,scattered_2,scattered_3,scattered_4;
 %}
 
 TRACE
 
-COMPONENT Vanadium_incoherent = Incoherent_process(sigma=6.08,packing_factor=1,unit_cell_volume=13.827)
+
+
+COMPONENT Vanadium_incoherent = Incoherent_process(sigma=5.08,packing_factor=1,unit_cell_volume=13.827)
 AT (0,0,0) ABSOLUTE
 
+// Here manual linking is used, the process string is writte explicitly
 COMPONENT Vanadium = Union_make_material(my_absorption=2.1,process_string="Vanadium_incoherent")
 AT (0,0,0) ABSOLUTE
 
@@ -83,6 +90,9 @@ AT (0,0,0) ABSOLUTE
 COMPONENT Au_powder = Powder_process(reflections="Au.laz",packing_factor=0.5)
 AT (0,0,0) ABSOLUTE
 
+// Here automatic linking is used, all process defined after the last make_material component
+//  is automatically collected in this next make_material component as the process string
+//  is not specified.
 COMPONENT Au_Ag_mix = Union_make_material(my_absorption=0.5*100*4*3.78/68.22+0.5*100*4*98.65/67.87)
 AT (0,0,0) ABSOLUTE
 
@@ -108,18 +118,6 @@ COMPONENT Cs_powder = Powder_process(reflections="Cs.laz")
 AT (0,0,0) ABSOLUTE
 
 COMPONENT Cs = Union_make_material(my_absorption=100*2*3.78/47.22)
-AT (0,0,0) ABSOLUTE
-
-// Fe definition
-// P0
-COMPONENT Fe_incoherent = Incoherent_process(sigma=2*0.4,packing_factor=1,unit_cell_volume=24.04)
-AT (0,0,0) ABSOLUTE
-
-// P1
-COMPONENT Fe_powder = Powder_process(reflections="Fe.laz")
-AT (0,0,0) ABSOLUTE
-
-COMPONENT Fe = Union_make_material(my_absorption=100*2*2.56/24.04)
 AT (0,0,0) ABSOLUTE
 
 
@@ -376,7 +374,7 @@ COMPONENT detector = PSD_monitor(xwidth=0.1, yheight=0.08, nx=200, ny=200, filen
 AT (0,-0.02,0.4) RELATIVE beam_center
 ROTATED (0,0,0) RELATIVE beam_center
 
-// Removes events not scattering in the three selected samples
+// Removes events not scattering in at least two of the samples
 // mcdisplay --inspect=m4pi_two_samples shows only rays that scatters on all three
 //  since all others were removed before that component with this arm.
 COMPONENT arm_1 = Arm()
@@ -386,7 +384,9 @@ EXTEND
   if (scattered_1 + scattered_2 + scattered_3 + scattered_4 < 2) ABSORB;
 %}
 
-COMPONENT m4pi_two_samples = PSD_monitor_4PI(radius=1, nx=180, ny=180, filename="Events.dat", restore_neutron=1)
+// Using mcdisplay and -inspect m4pi_two_or_more_samples one can show only
+//  trajectories where the ray scatters from two or more of the samples
+COMPONENT m4pi_two_or_more_samples = PSD_monitor_4PI(radius=1, nx=180, ny=180, filename="Events.dat", restore_neutron=1)
 WHEN (scattered_1 + scattered_2 + scattered_3 + scattered_4 > 1)
 AT (0, 0, 0) RELATIVE beam_center
 ROTATED (0,0,0) RELATIVE beam_center

--- a/mcstas-comps/examples/Union_demonstration_absorption_image.instr
+++ b/mcstas-comps/examples/Union_demonstration_absorption_image.instr
@@ -13,12 +13,13 @@
 * Origin: University of Copenhagen
 * %INSTRUMENT_SITE: Union_demos
 *
-* Simple test instrument for sample component.
-*
 * %Description
-* simple test instrument for sample component.
+* Demonstration of Union components, here 4 different powder samoples in a
+*  weird sample holder contained in a cryostat is simulated.
+* This instrument file produces an absorption image of the setup.
 *
-* Example: filename="source_sct091_tu_02_1.dat" Detector: det_I=9.89304e+09
+*
+* Example: Detector: screen_I=0.0107579
 *
 * %Parameters
 * stick_displacement: [] 
@@ -26,23 +27,17 @@
 * %End
 *******************************************************************************/
 
-DEFINE INSTRUMENT test(stick_displacement=0)
+DEFINE INSTRUMENT Union_demonstration_absorption_image(stick_displacement=0)
 
 DECLARE
 %{
-int scattered_1;
-int scattered_2;
-int sample_1_index = 4;
-int sample_2_index = 6;
 %}
 
 TRACE
 
-COMPONENT Vanadium_incoherent = Incoherent_process(sigma=6.08,packing_factor=1,unit_cell_volume=13.827)
-AT (0,0,0) ABSOLUTE
 
-COMPONENT Vanadium = Union_make_material(my_absorption=2.1,process_string="Vanadium_incoherent")
-AT (0,0,0) ABSOLUTE
+// Material definitions here use automatic linking, meaning that all processes
+//  preceding each make_material component is included in that material.
 
 // P0
 COMPONENT Al_incoherent = Incoherent_process(sigma=4*0.0082,packing_factor=1,unit_cell_volume=66.4) //,interact_fraction=0.8)
@@ -54,7 +49,6 @@ AT (0,0,0) ABSOLUTE
 
 COMPONENT Al = Union_make_material(my_absorption=100*4*0.231/66.4)
 AT (0,0,0) ABSOLUTE
-
 
 // Cu definition
 // P0
@@ -112,17 +106,7 @@ AT (0,0,0) ABSOLUTE
 COMPONENT Cs = Union_make_material(my_absorption=100*2*3.78/47.22)
 AT (0,0,0) ABSOLUTE
 
-// Fe definition
-// P0
-COMPONENT Fe_incoherent = Incoherent_process(sigma=2*0.4,packing_factor=1,unit_cell_volume=24.04)
-AT (0,0,0) ABSOLUTE
 
-// P1
-COMPONENT Fe_Powder = Powder_process(reflections="Fe.laz")
-AT (0,0,0) ABSOLUTE
-
-COMPONENT Fe = Union_make_material(my_absorption=100*2*2.56/24.04)
-AT (0,0,0) ABSOLUTE
 
 COMPONENT a1 = Progress_bar()
   AT (0,0,0) ABSOLUTE
@@ -343,13 +327,6 @@ ROTATED (0,0,0) RELATIVE sample_4
 COMPONENT test_sample = Union_master()
 AT(0,0,0) RELATIVE beam_center
 ROTATED(0,30,20) RELATIVE beam_center
-EXTEND
-%{
-	if (scattered_flag[sample_1_index] > 0) scattered_1 = 1; else scattered_1 = 0;
-	if (scattered_flag[sample_2_index] > 0) scattered_2 = 1; else scattered_2 = 0;
-
-    // if (SCATTERED) printf("I scatter\n"); else printf("I do not scatter\n");
-%}
 
 COMPONENT screen = PSD_monitor(xwidth=0.45,ymin=-0.15,ymax=0.85,nx=500,ny=1200,filename="absoprtion_picture.dat",restore_neutron=1)
   AT (0,0,2) RELATIVE a1

--- a/mcstas-comps/examples/Union_external_component.instr
+++ b/mcstas-comps/examples/Union_external_component.instr
@@ -11,14 +11,14 @@
 * Written by: Mads Bertelsen
 * Date: September 2015
 * Origin: University of Copenhagen
-* %INSTRUMENT_SITE:
+* %INSTRUMENT_SITE: Union_demos
 *
-* Simple test instrument for sample component.
 *
 * %Description
-* simple test instrument for sample component.
+* Example showing the use of the "number_of_activations" parameter to include
+*  an external component into an ensamle of Union components
 *
-* Example: filename="source_sct091_tu_02_1.dat" Detector: det_I=9.89304e+09
+* Example: Detector: Banana_monitor_I=5.26267
 *
 * %Parameters
 * stick_displacement: [] 
@@ -26,101 +26,23 @@
 * %End
 *******************************************************************************/
 
-DEFINE INSTRUMENT test(stick_displacement=0)
+DEFINE INSTRUMENT Union_external_component(stick_displacement=0)
 
 DECLARE
 %{
-int sample_1_index=27,sample_2_index=30,sample_3_index=36; // Indexes of three samples
-int scattered_1,scattered_2,scattered_3;
 int first_master,second_master;
+int powderN_scat;
 %}
 
 TRACE
 
-COMPONENT Vanadium_incoherent = Incoherent_process(sigma=6.08,packing_factor=1,unit_cell_volume=13.827)
-AT (0,0,0) ABSOLUTE
-
-COMPONENT Vanadium = Union_make_material(my_absorption=2.1,process_string="Vanadium_incoherent")
-AT (0,0,0) ABSOLUTE
-
-// P0
 COMPONENT Al_incoherent = Incoherent_process(sigma=4*0.0082,packing_factor=1,unit_cell_volume=66.4) //,interact_fraction=0.8)
 AT (0,0,0) ABSOLUTE
 
-// P1
 COMPONENT Al_powder = Powder_process(reflections="Al.laz")
 AT (0,0,0) ABSOLUTE
 
 COMPONENT Al = Union_make_material(my_absorption=100*4*0.231/66.4)
-AT (0,0,0) ABSOLUTE
-
-
-// Cu definition
-// P0
-COMPONENT Cu_incoherent = Incoherent_process(sigma=4*0.55,packing_factor=1,unit_cell_volume=47.22)
-AT (0,0,0) ABSOLUTE
-
-// P1
-COMPONENT Cu_powder = Powder_process(reflections="Cu.laz")
-AT (0,0,0) ABSOLUTE
-
-COMPONENT Cu = Union_make_material(my_absorption=100*4*3.78/47.22)
-AT (0,0,0) ABSOLUTE
-
-// Ag Au mix definition
-// P0
-COMPONENT Ag_incoherent = Incoherent_process(sigma=4*0.58,packing_factor=1,unit_cell_volume=68.22,packing_factor=0.5)
-AT (0,0,0) ABSOLUTE
-
-// P1
-COMPONENT Ag_powder = Powder_process(reflections="Ag.laz",packing_factor=0.5)
-AT (0,0,0) ABSOLUTE
-
-// P2
-COMPONENT Au_incoherent = Incoherent_process(sigma=4*0.43,packing_factor=1,unit_cell_volume=67.87,packing_factor=0.5)
-AT (0,0,0) ABSOLUTE
-
-// P3
-COMPONENT Au_powder = Powder_process(reflections="Au.laz",packing_factor=0.5)
-AT (0,0,0) ABSOLUTE
-
-COMPONENT Au_Ag_mix = Union_make_material(my_absorption=0.5*100*4*3.78/68.22+0.5*100*4*98.65/67.87)
-AT (0,0,0) ABSOLUTE
-
-// Cd definition
-// P0
-COMPONENT Cd_incoherent = Incoherent_process(sigma=2*3.46,packing_factor=1,unit_cell_volume=43.11)
-AT (0,0,0) ABSOLUTE
-
-// P1
-COMPONENT Cd_powder = Powder_process(reflections="Cd.laz")
-AT (0,0,0) ABSOLUTE
-
-COMPONENT Cd = Union_make_material(my_absorption=100*2*2520/43.11)
-AT (0,0,0) ABSOLUTE
-
-// Cs definition
-// P0
-COMPONENT Cs_incoherent = Incoherent_process(sigma=2*0.55,packing_factor=1,unit_cell_volume=47.22)
-AT (0,0,0) ABSOLUTE
-
-// P1
-COMPONENT Cs_powder = Powder_process(reflections="Cs.laz")
-AT (0,0,0) ABSOLUTE
-
-COMPONENT Cs = Union_make_material(my_absorption=100*2*3.78/47.22)
-AT (0,0,0) ABSOLUTE
-
-// Fe definition
-// P0
-COMPONENT Fe_incoherent = Incoherent_process(sigma=2*0.4,packing_factor=1,unit_cell_volume=24.04)
-AT (0,0,0) ABSOLUTE
-
-// P1
-COMPONENT Fe_powder = Powder_process(reflections="Fe.laz")
-AT (0,0,0) ABSOLUTE
-
-COMPONENT Fe = Union_make_material(my_absorption=100*2*2.56/24.04)
 AT (0,0,0) ABSOLUTE
 
 
@@ -261,6 +183,10 @@ first_master = number_of_scattering_events;
 COMPONENT cylinder_sample_powder = PowderN(reflections="Cu.laz", radius=0.01, yheight=0.03, pack=1, p_interact=0.8, thickness=0)
 AT (0,0,0) RELATIVE beam_center
 ROTATED (0,0,0) RELATIVE beam_center
+EXTEND
+%{
+  if (SCATTERED) powderN_scat = 1; else powderN_scat = 0;
+%}
 
 
 COMPONENT test_sample_after = Union_master(allow_inside_start=1)
@@ -282,6 +208,11 @@ AT (0, 0, 0) RELATIVE beam_center
 ROTATED (0,0,0) RELATIVE beam_center
 
 COMPONENT Banana_monitor = Monitor_nD(radius=1, yheight=0.1, options="banana, theta limits=[20,170], bins=500",filename="banana.dat",restore_neutron=1)
+AT (0,0,0) RELATIVE beam_center
+ROTATED (0,0,0) RELATIVE beam_center
+
+COMPONENT Banana_monitor_powderN = Monitor_nD(radius=1, yheight=0.1, options="banana, theta limits=[20,170], bins=500",filename="banana_powderN.dat",restore_neutron=1)
+WHEN (powderN_scat==1)
 AT (0,0,0) RELATIVE beam_center
 ROTATED (0,0,0) RELATIVE beam_center
 

--- a/mcstas-comps/examples/Union_external_component_test.instr
+++ b/mcstas-comps/examples/Union_external_component_test.instr
@@ -5,7 +5,7 @@
 *         Risoe National Laboratory, Roskilde, Denmark
 *         Institut Laue Langevin, Grenoble, France
 *
-* Instrument: test
+* Instrument: Union_external_component_test
 *
 * %Identification
 * Written by: Mads Bertelsen
@@ -13,41 +13,28 @@
 * Origin: University of Copenhagen
 * %INSTRUMENT_SITE: Union_demos
 *
-* Simple test instrument for sample component.
 *
 * %Description
-* simple test instrument for sample component.
+* Demonstration of the use of "number_of_activations" and exit volumes to
+*  include a regular McStas component in an ensemble of Union components.
 *
-* Example: filename="source_sct091_tu_02_1.dat" Detector: det_I=9.89304e+09
+* Example: Detector: Banana_monitor_I=4.49056
 *
 * %Parameters
-* stick_displacement: [] 
 *
 * %End
 *******************************************************************************/
 
-DEFINE INSTRUMENT test(stick_displacement=0)
+DEFINE INSTRUMENT Union_external_component_test()
 
 DECLARE
 %{
-int sample_1_index=27,sample_2_index=30,sample_3_index=36; // Indexes of three samples
-int scattered_1,scattered_2,scattered_3;
 int first_master,second_master;
+int powderN_scat;
 %}
 
 TRACE
 
-COMPONENT Vanadium_incoherent = Incoherent_process(sigma=6.08,packing_factor=1,unit_cell_volume=13.827)
-AT (0,0,0) ABSOLUTE
-
-COMPONENT Vanadium = Union_make_material(my_absorption=2.1,process_string="Vanadium_incoherent")
-AT (0,0,0) ABSOLUTE
-
-// P0
-COMPONENT Al_incoherent = Incoherent_process(sigma=4*0.0082,packing_factor=1,unit_cell_volume=66.4) //,interact_fraction=0.8)
-AT (0,0,0) ABSOLUTE
-
-// P1
 COMPONENT Al_powder = Powder_process(reflections="Al.laz")
 AT (0,0,0) ABSOLUTE
 
@@ -55,85 +42,8 @@ COMPONENT Al = Union_make_material(my_absorption=100*4*0.231/66.4)
 AT (0,0,0) ABSOLUTE
 
 
-// Cu definition
-// P0
-COMPONENT Cu_incoherent = Incoherent_process(sigma=4*0.55,packing_factor=1,unit_cell_volume=47.22)
-AT (0,0,0) ABSOLUTE
-
-// P1
-COMPONENT Cu_powder = Powder_process(reflections="Cu.laz")
-AT (0,0,0) ABSOLUTE
-
-COMPONENT Cu = Union_make_material(my_absorption=100*4*3.78/47.22)
-AT (0,0,0) ABSOLUTE
-
-// Ag Au mix definition
-// P0
-COMPONENT Ag_incoherent = Incoherent_process(sigma=4*0.58,packing_factor=1,unit_cell_volume=68.22,packing_factor=0.5)
-AT (0,0,0) ABSOLUTE
-
-// P1
-COMPONENT Ag_powder = Powder_process(reflections="Ag.laz",packing_factor=0.5)
-AT (0,0,0) ABSOLUTE
-
-// P2
-COMPONENT Au_incoherent = Incoherent_process(sigma=4*0.43,packing_factor=1,unit_cell_volume=67.87,packing_factor=0.5)
-AT (0,0,0) ABSOLUTE
-
-// P3
-COMPONENT Au_powder = Powder_process(reflections="Au.laz",packing_factor=0.5)
-AT (0,0,0) ABSOLUTE
-
-COMPONENT Au_Ag_mix = Union_make_material(my_absorption=0.5*100*4*3.78/68.22+0.5*100*4*98.65/67.87)
-AT (0,0,0) ABSOLUTE
-
-// Cd definition
-// P0
-COMPONENT Cd_incoherent = Incoherent_process(sigma=2*3.46,packing_factor=1,unit_cell_volume=43.11)
-AT (0,0,0) ABSOLUTE
-
-// P1
-COMPONENT Cd_powder = Powder_process(reflections="Cd.laz")
-AT (0,0,0) ABSOLUTE
-
-COMPONENT Cd = Union_make_material(my_absorption=100*2*2520/43.11)
-AT (0,0,0) ABSOLUTE
-
-// Cs definition
-// P0
-COMPONENT Cs_incoherent = Incoherent_process(sigma=2*0.55,packing_factor=1,unit_cell_volume=47.22)
-AT (0,0,0) ABSOLUTE
-
-// P1
-COMPONENT Cs_powder = Powder_process(reflections="Cs.laz")
-AT (0,0,0) ABSOLUTE
-
-COMPONENT Cs = Union_make_material(my_absorption=100*2*3.78/47.22)
-AT (0,0,0) ABSOLUTE
-
-// Fe definition
-// P0
-COMPONENT Fe_incoherent = Incoherent_process(sigma=2*0.4,packing_factor=1,unit_cell_volume=24.04)
-AT (0,0,0) ABSOLUTE
-
-// P1
-COMPONENT Fe_powder = Powder_process(reflections="Fe.laz")
-AT (0,0,0) ABSOLUTE
-
-COMPONENT Fe = Union_make_material(my_absorption=100*2*2.56/24.04)
-AT (0,0,0) ABSOLUTE
-
-
-
 COMPONENT a1 = Progress_bar()
   AT (0,0,0) ABSOLUTE
-
-// Source for transmission picture
-//COMPONENT source = Source_div(
-//        xwidth=0.12, yheight=0.12,focus_aw=0.5, focus_ah=0.5,
-//        E0 = 50,
-//        dE = 0, flux = 1E9)
-//  AT (0,-0.02,0) RELATIVE a1 ROTATED (0,0,0) RELATIVE a1
 
 COMPONENT source = Source_div(
         xwidth=0.01, yheight=0.01,focus_aw=0.05, focus_ah=0.05,
@@ -147,20 +57,13 @@ COMPONENT beam_center = Arm()
 AT (0,0,3) RELATIVE a1
 ROTATED (0,0,0) RELATIVE a1
 
-COMPONENT drum_center = Arm()
-AT (0,0.38,0) RELATIVE beam_center
-ROTATED (0,0,0) RELATIVE beam_center
-
-
-
-
 // V1
-COMPONENT inner_cryostat_wall = Union_cylinder(radius=0.06,yheight=0.16,priority=12,material_string="Al",p_interact=0.2,number_of_activations=2)
+COMPONENT cryostat_wall = Union_cylinder(radius=0.06,yheight=0.16,priority=12,material_string="Al",p_interact=0.2,number_of_activations=2)
 AT (0,0.01,0) RELATIVE beam_center
 ROTATED (0,0,0) RELATIVE beam_center
 
 // V2
-COMPONENT inner_cryostat_vacuum = Union_cylinder(radius=0.05,yheight=0.15,priority=13,material_string="Vacuum",number_of_activations=2)
+COMPONENT cryostat_vacuum = Union_cylinder(radius=0.05,yheight=0.15,priority=13,material_string="Vacuum",number_of_activations=2)
 AT (0,0.01,0) RELATIVE beam_center
 ROTATED (0,0,0) RELATIVE beam_center
 
@@ -180,18 +83,19 @@ first_master = number_of_scattering_events;
 COMPONENT cylinder_sample_powder = PowderN(reflections="Cu.laz", radius=0.01, yheight=0.03, pack=1, p_interact=0.8, thickness=0)
 AT (0,0,0) RELATIVE beam_center
 ROTATED (0,0,0) RELATIVE beam_center
+EXTEND
+%{
+  if (SCATTERED) powderN_scat = 1; else powderN_scat = 0;
+%}
 
 
 COMPONENT test_sample_after = Union_master(allow_inside_start=1)
-AT(0,0.1,0) RELATIVE beam_center
+AT(0,0,0) RELATIVE beam_center
 ROTATED(20,0,0) RELATIVE beam_center
 EXTEND
 %{
 second_master = number_of_scattering_events;
 %}
-
-
-
 
 
 COMPONENT m4pi = PSD_monitor_4PI(radius=1, nx=180, ny=180, filename="Events.dat", restore_neutron=1)
@@ -207,8 +111,13 @@ COMPONENT Banana_monitor = Monitor_nD(radius=1, yheight=0.1, options="banana, th
 AT (0,0,0) RELATIVE beam_center
 ROTATED (0,0,0) RELATIVE beam_center
 
+COMPONENT Banana_monitor_powderN = Monitor_nD(radius=1, yheight=0.1, options="banana, theta limits=[20,170], bins=500",filename="banana_powderN.dat",restore_neutron=1)
+WHEN (powderN_scat==1)
+AT (0,0,0) RELATIVE beam_center
+ROTATED (0,0,0) RELATIVE beam_center
+
 COMPONENT detector = PSD_monitor(xwidth=0.1, yheight=0.08, nx=200, ny=200, filename="PSD.dat", restore_neutron=1)
-AT (0,-0.02,0.4) RELATIVE beam_center
+AT (0,0,0.4) RELATIVE beam_center
 ROTATED (0,0,0) RELATIVE beam_center
 
 

--- a/mcstas-comps/examples/Union_incoherent_validation.instr
+++ b/mcstas-comps/examples/Union_incoherent_validation.instr
@@ -11,17 +11,15 @@
 * Written by: Mads Bertelsen
 * Date: May 2016
 * Origin: Johns Hopkins University, Baltimore
-* %INSTRUMENT_SITE: Tests_samples
-*
-* Validation of union network against incoherent scattering component
+* %INSTRUMENT_SITE: Union_demos
 *
 * %Description
-* simple test instrument for sample component.
+* Validation of Union components against incoherent scattering component
 *
-* Example: filename="source_sct091_tu_02_1.dat" Detector: det_I=9.89304e+09
+* Example: Detector: Banana_monitor_I=18.4632
 *
 * %Parameters
-* comp_select: []        
+* comp_select: [] 1: Union components, 2: Incoherent
 * sample_radius: []      
 * sample_height: []      
 * pack: []               
@@ -45,9 +43,6 @@ TRACE
 COMPONENT Vanadium_incoherent = Incoherent_process(sigma=sigma_inc_vanadium,packing_factor=pack,unit_cell_volume=Vc_vanadium)
 AT (0,0,0) ABSOLUTE
 
-//COMPONENT Vanadium_incoherent = Template_process(sigma=sigma_inc_vanadium,packing_factor=pack,unit_cell_volume=Vc_vanadium)
-//AT (0,0,0) ABSOLUTE
-
 COMPONENT Vanadium = Union_make_material(my_absorption=100*sigma_abs_vanadium/Vc_vanadium*pack,process_string="Vanadium_incoherent")
 AT (0,0,0) ABSOLUTE
 
@@ -55,7 +50,6 @@ COMPONENT a1 = Progress_bar()
   AT (0,0,0) ABSOLUTE
 
 COMPONENT source = Source_div(
-//        xwidth=0.0005, yheight=0.0005,focus_aw=15, focus_ah=15,
         xwidth=0.0005, yheight=0.0005,focus_aw=2, focus_ah=1.5,
         E0 = 10, dE = 0, flux=1E10)
   AT (0,0,0) RELATIVE a1 ROTATED (0,0,0) RELATIVE a1
@@ -80,6 +74,9 @@ WHEN(comp_select == 2)
 AT (0,0,0) RELATIVE sample_position
 ROTATED (0,0,0) RELATIVE sample_position
 
+COMPONENT m4pi = PSD_monitor_4PI(radius=1, nx=180, ny=180, filename="4Pi_events.dat",restore_neutron=1)
+  AT (0, 0, 0) RELATIVE sample_position
+
 COMPONENT Banana_monitor = Monitor_nD(radius=1, yheight=0.1, options="banana, theta limits=[20,170], bins=200",filename="banana.dat",restore_neutron=1)
 AT (0,0,0) RELATIVE sample_position
 ROTATED (0,0,0) RELATIVE sample_position
@@ -103,8 +100,5 @@ ROTATED (45,-35,0) RELATIVE sample_position
 
 COMPONENT PSDlin_scattering_2 = PSDlin_monitor(xwidth=0.1, yheight=0.05, nx=100, filename="Output_scattering_2.psd",restore_neutron = 1)
 AT (0,0,0.5) RELATIVE scattering_arm_2
-
-COMPONENT m4pi = PSD_monitor_4PI(radius=1, nx=180, ny=180, filename="4Pi_events.dat",restore_neutron=1)
-  AT (0, 0, 0) RELATIVE sample_position
 
 END

--- a/mcstas-comps/examples/Union_laue_camera.instr
+++ b/mcstas-comps/examples/Union_laue_camera.instr
@@ -1,22 +1,22 @@
 /*******************************************************************************
-*         McStas instrument definition URL=http://www.mcstas.org
 *
-* Instrument: templateLaue
+* McStas, neutron ray-tracing package
+*         Copyright (C) 1997-2008, All rights reserved
+*         Risoe National Laboratory, Roskilde, Denmark
+*         Institut Laue Langevin, Grenoble, France
+*
+* Instrument: Union_manual_example
 *
 * %Identification
-* Written by: K. Nielsen
-* Date: June 2nd, 2010
-* Origin: ILL
-* Modified by: EF,
-* %INSTRUMENT_SITE: Templates
-*
-* A simple Laue diffractometer
+* Written by: Mads Bertelsen
+* Date: September 2015
+* Origin: University of Copenhagen
+* %INSTRUMENT_SITE: Union_demos
 *
 * %Description
-* A single crystal sample is illuminated with a white cold beam.
-* Based on a Laue tutorial written by K. Nielsen, Feb 7, 2000.
+* Laue camera using Union components for the sample
 *
-* %Example: templateLaue Detector: det_I=8.39706e+06
+* %Example: Detector: Banana_monitor_I=1.74328e+06
 *
 * %Parameters
 * delta_d_d: []               
@@ -25,18 +25,18 @@
 * dlam: []                    
 * radius: []                  
 * height: []                  
-* x_rotation_geometry: []     
+* x_rotation_geometry: []  rotates union geometry component
 * y_rotation_geometry: []     
-* x_rotation_geometry_ref: [] 
+* x_rotation_geometry_ref: [] rotates reference component
 * y_rotation_geometry_ref: [] 
-* x_rotation_process: []      
+* x_rotation_process: [] rotates powder process (crystal orientation)
 * y_rotation_process: []      
 * z_rotation_process: []      
 * geometry_interact: []       
 *
 * %End
 *******************************************************************************/
-DEFINE INSTRUMENT templateLaue(delta_d_d=1e-4, mosaic=5, lam0=7, dlam=5, radius = 0.01, height=0.01,
+DEFINE INSTRUMENT Union_laue_camera(delta_d_d=1e-4, mosaic=5, lam0=7, dlam=5, radius = 0.01, height=0.01,
    x_rotation_geometry=0, y_rotation_geometry=0,
    x_rotation_geometry_ref=0, y_rotation_geometry_ref=0,
    x_rotation_process=0, y_rotation_process=0, z_rotation_process=0,
@@ -45,7 +45,6 @@ DEFINE INSTRUMENT templateLaue(delta_d_d=1e-4, mosaic=5, lam0=7, dlam=5, radius 
 DECLARE
 %{
 int scattered_flag_instr;
-
 %}
 
 TRACE

--- a/mcstas-comps/examples/Union_manual_example.instr
+++ b/mcstas-comps/examples/Union_manual_example.instr
@@ -5,7 +5,7 @@
 *         Risoe National Laboratory, Roskilde, Denmark
 *         Institut Laue Langevin, Grenoble, France
 *
-* Instrument: test
+* Instrument: Union_manual_example
 *
 * %Identification
 * Written by: Mads Bertelsen
@@ -13,19 +13,17 @@
 * Origin: University of Copenhagen
 * %INSTRUMENT_SITE: Union_demos
 *
-* Simple test instrument for sample component.
-*
 * %Description
-* simple test instrument for sample component.
+* Example on using Union components from the Union project manual
 *
-* Example: filename="source_sct091_tu_02_1.dat" Detector: det_I=9.89304e+09
+* Example: Detector: Banana_monitor_I=3.823e-05
 *
 * %Parameters
 *
 * %End
 *******************************************************************************/
 
-DEFINE INSTRUMENT test()
+DEFINE INSTRUMENT Union_manual_example()
 
 DECLARE
 %{

--- a/mcstas-comps/examples/Union_powder_validation.instr
+++ b/mcstas-comps/examples/Union_powder_validation.instr
@@ -11,17 +11,16 @@
 * Written by: Mads Bertelsen
 * Date: May 2016
 * Origin: Johns Hopkins University, Baltimore
-* %INSTRUMENT_SITE: Tests_samples
+* %INSTRUMENT_SITE: Union_demos
 *
-* Validation of union network against incoherent scattering component
 *
 * %Description
-* simple test instrument for sample component.
+*  Validation of Union powder against standard PowderN component. 
 *
-* Example: filename="source_sct091_tu_02_1.dat" Detector: det_I=9.89304e+09
+* Example: Banana_monitor_I=20.1897
 *
 * %Parameters
-* comp_select: []         
+* comp_select: [1] 1: Union components, 2: PowderN
 * material_data_file: []  
 * E0: []                  
 * dE: []                  
@@ -43,8 +42,6 @@ DECLARE
 %{
 int single_scattering_flag;
 %}
-
-
 
 TRACE
 
@@ -93,13 +90,7 @@ if (SCATTERED) single_scattering_flag = 1;
 else single_scattering_flag = 0;
 %}
 
-COMPONENT cylinder_sample_sqw = Isotropic_Sqw(radius=sample_radius, yheight=sample_height, Sqw_coh=material_data_file, rho=2/Vc, powder_barns=1, powder_Vc = Vc)
- //sigma_inc = sigma_inc, sigma_abs = sigma_abs, d_phi=15)
-WHEN(comp_select == 3)
-AT (0,0,0) RELATIVE sample_position
-ROTATED (0,0,0) RELATIVE sample_position
-
-COMPONENT pre_detectors_m4pi = PSD_monitor_4PI(radius=1, nx=180, ny=180, filename="4Pi_events_pre.dat",restore_neutron=1)
+COMPONENT detectors_m4pi = PSD_monitor_4PI(radius=1, nx=180, ny=180, filename="4Pi_events.dat",restore_neutron=1)
   AT (0, 0, 0) RELATIVE sample_position
 
 COMPONENT Banana_monitor = Monitor_nD(radius=1, yheight=0.1, options="banana, theta limits=[20,170], bins=500",filename="banana.dat",restore_neutron=1)

--- a/mcstas-comps/examples/Union_sample_picture_replica.instr
+++ b/mcstas-comps/examples/Union_sample_picture_replica.instr
@@ -5,7 +5,7 @@
 *         Risoe National Laboratory, Roskilde, Denmark
 *         Institut Laue Langevin, Grenoble, France
 *
-* Instrument: test
+* Instrument: Union_sample_picture_replica
 *
 * %Identification
 * Written by: Mads Bertelsen
@@ -13,20 +13,20 @@
 * Origin: University of Copenhagen
 * %INSTRUMENT_SITE:
 *
-* Simple test instrument for sample component.
 *
 * %Description
-* simple test instrument for sample component.
+* Reconstruction of a sample holder from picture.
+* All arms are 30 cm below the actual center point in order to avoid arms
+*  in the mcdisplay picture.
 *
-* Example: filename="source_sct091_tu_02_1.dat" Detector: det_I=9.89304e+09
+* Example: Detector: detector_I=1982.98
 *
 * %Parameters
-* stick_displacement: [] 
 *
 * %End
 *******************************************************************************/
 
-DEFINE INSTRUMENT test(stick_displacement=0)
+DEFINE INSTRUMENT Union_sample_picture_replica()
 
 DECLARE
 %{
@@ -34,21 +34,22 @@ DECLARE
 
 TRACE
 
-COMPONENT Vanadium_incoherent = Incoherent_process(sigma=6.08,packing_factor=1,unit_cell_volume=13.827)
+COMPONENT Vanadium_incoherent = Incoherent_process(sigma=2*5.08,packing_factor=1,unit_cell_volume=27.66)
 AT (0,0,0) ABSOLUTE
 
-COMPONENT Vanadium = Union_make_material(my_absorption=2.1,process_string="Vanadium_incoherent")
+COMPONENT Vanadium = Union_make_material(my_absorption=2*5.08*100/27.66,process_string="Vanadium_incoherent")
 AT (0,0,0) ABSOLUTE
 
 // P0
-COMPONENT Al_incoherent = Incoherent_process(sigma=4*0.0082,packing_factor=1,unit_cell_volume=66.4) //,interact_fraction=0.8)
+COMPONENT Al_incoherent = Incoherent_process(sigma=4*0.0082,packing_factor=1,unit_cell_volume=66.4)
 AT (0,0,0) ABSOLUTE
 
 // P1
 COMPONENT Al_Powder = Powder_process(reflections="Al.laz")
 AT (0,0,0) ABSOLUTE
 
-COMPONENT Al = Union_make_material(my_absorption=450*100*4*0.231/66.4)
+// Exagerated Al absorption in order to make absorption picture more clear
+COMPONENT Al = Union_make_material(my_absorption=150*100*4*0.231/66.4)
 AT (0,0,0) ABSOLUTE
 
 // P0
@@ -71,14 +72,10 @@ COMPONENT source = Source_div(
         dE = 0, flux = 1E9)
   AT (0,-0.05,0) RELATIVE a1 ROTATED (0,0,0) RELATIVE a1
 
-COMPONENT focus_stop = Arm()
-AT (0,0,0.1) RELATIVE source
-
-
 // Sample position
 COMPONENT beam_center = Arm()
 AT (0,-0.3,0.3) RELATIVE a1
-ROTATED (0,20,0) RELATIVE a1
+ROTATED (0,40,0) RELATIVE a1
 
 
 COMPONENT sample = Union_cylinder(radius=0.005,yheight=0.0265, priority=20,material_string="Cu")
@@ -179,9 +176,6 @@ COMPONENT test_sample = Union_master()
 AT(0,0,0) RELATIVE beam_center
 ROTATED(0,0,0) RELATIVE beam_center
 
-//COMPONENT m4pi = PSD_monitor_4PI(radius=1, nx=180, ny=180, filename="Events.dat", restore_neutron=1)
-//AT (0, 0, 0) RELATIVE beam_center
-//ROTATED (0,0,0) RELATIVE beam_center
 
 COMPONENT detector = PSD_monitor(xwidth=0.05, yheight=0.15, nx=200, ny=200, filename="PSD.dat", restore_neutron=1)
 AT (0,0,0.6) RELATIVE source

--- a/mcstas-comps/examples/Union_single_crystal_validation.instr
+++ b/mcstas-comps/examples/Union_single_crystal_validation.instr
@@ -1,25 +1,25 @@
 /*******************************************************************************
-*         McStas instrument definition URL=http://www.mcstas.org
 *
-* Instrument: templateLaue
+* McStas, neutron ray-tracing package
+*         Copyright (C) 1997-2008, All rights reserved
+*         Risoe National Laboratory, Roskilde, Denmark
+*         Institut Laue Langevin, Grenoble, France
+*
+* Instrument: incoherent_validation
 *
 * %Identification
-* Written by: K. Nielsen
-* Date: June 2nd, 2010
-* Origin: ILL
-* Modified by: EF,
-* %INSTRUMENT_SITE: Templates
-*
-* A simple Laue diffractometer
+* Written by: Mads Bertelsen
+* Date: May 2016
+* Origin: Johns Hopkins University, Baltimore
+* %INSTRUMENT_SITE: Union_demos
 *
 * %Description
-* A single crystal sample is illuminated with a white cold beam.
-* Based on a Laue tutorial written by K. Nielsen, Feb 7, 2000.
+*  Validation of Union single crystal against standard single_crystal.
 *
-* %Example: templateLaue Detector: det_I=8.39706e+06
+* %Example: Detector: Banana_monitor_I=964146
 *
 * %Parameters
-* comp_select: []             
+* comp_select: [1] 1: Union components, 2: Single crystal
 * string material_data_file:
 * sigma_inc: []               
 * my_absorption_union: []     
@@ -47,7 +47,7 @@
 *******************************************************************************/
 
 /* Change name of instrument and input parameters with default values */
-DEFINE INSTRUMENT templateLaue(comp_select=1,string material_data_file="YBaCuO.lau",sigma_inc=2.105, my_absorption_union=8.55, delta_d_d=1e-4, mosaic=5, lam0=7, dlam=5 , xwidth=0.01, yheight=0.01, zdepth=0.01,unit_cell_volume=173.28,sigma_abs_sc=0,sigma_inc=2.105,x_rotation_geometry=0,y_rotation_geometry=0,x_rotation_geometry_ref=0,y_rotation_geometry_ref=0,x_rotation_process=0,y_rotation_process=0,geometry_interact=0,PG=0,powder=0)
+DEFINE INSTRUMENT Union_single_crystal_validation(comp_select=1,string material_data_file="YBaCuO.lau",sigma_inc=2.105, my_absorption_union=8.55, delta_d_d=1e-4, mosaic=5, lam0=7, dlam=5 , xwidth=0.01, yheight=0.01, zdepth=0.01,unit_cell_volume=173.28,sigma_abs_sc=0,sigma_inc=2.105,x_rotation_geometry=0,y_rotation_geometry=0,x_rotation_geometry_ref=0,y_rotation_geometry_ref=0,x_rotation_process=0,y_rotation_process=0,geometry_interact=0,PG=0,powder=0)
 
 DECLARE
 %{
@@ -100,9 +100,7 @@ if (number_of_scattering_events == 0) scattered_flag_instr=0;
 else scattered_flag_instr=1;
 %}
 
-
 COMPONENT sample = Single_crystal(
-          //xwidth=xwidth, yheight=yheight, zdepth=zdepth,
           radius=xwidth,yheight=yheight,
           delta_d_d=delta_d_d, mosaic = mosaic,
           ax = 3.8186, ay = 0,      az = 0,

--- a/mcstas-comps/examples/Union_tagging_demo.instr
+++ b/mcstas-comps/examples/Union_tagging_demo.instr
@@ -13,30 +13,28 @@
 * Origin: Johns Hopkins University, Baltimore
 * %INSTRUMENT_SITE: Union_demos
 *
-* Validation of union network against incoherent scattering component
-*
 * %Description
-* simple test instrument for sample component.
+*  Powder in Al can
 *
-* Example: filename="source_sct091_tu_02_1.dat" Detector: det_I=9.89304e+09
+* Example: Detector: Banana_monitor_I=9.84391e-09
 *
 * %Parameters
-* material_data_file: []  
-* E0: []                  
-* dE: []                  
-* sample_radius: []       
-* sample_height: []       
-* pack: []                
-* sigma_inc: []           
-* sigma_abs: []           
-* Vc: []                  
-* geometry_interact: []   
-* incoherent_fraction: [] 
+* material_data_file: [string] Name of data file for powder sample
+* E0: [meV]
+* dE: [meV]
+* sample_radius: [m]
+* sample_height: [m]
+* pack: [1] Packing factor, 1 is full density
+* sigma_inc: [barns] Incoherent cross section for powder sample
+* sigma_abs: [barns] Absorption cross section for powder sample
+* Vc: [AA] Unit cell volume for powder sample
+* geometry_interact: [1] Fraction of beam to interact with geometry
+* incoherent_fraction: [1] Fraction of scattered events that select the powder process
 *
 * %End
 *******************************************************************************/
 
-DEFINE INSTRUMENT incoherent_validation(string material_data_file = "Cu.laz",E0 = 100,dE = 2,sample_radius=0.01,sample_height=0.01,pack=1,sigma_inc=2.2,sigma_abs=15.12,Vc=47.22,geometry_interact=0.5,incoherent_fraction=0.2)
+DEFINE INSTRUMENT Union_tagging_demo(string material_data_file = "Cu.laz",E0 = 100,dE = 2,sample_radius=0.01,sample_height=0.01,pack=1,sigma_inc=2.2,sigma_abs=15.12,Vc=47.22,geometry_interact=0.5,incoherent_fraction=0.2)
 
 DECLARE
 %{
@@ -56,7 +54,8 @@ AT (0,0,0) ABSOLUTE
 COMPONENT Cu_incoherent_process = Incoherent_process(sigma=sigma_inc,packing_factor=pack,unit_cell_volume=Vc,interact_fraction=incoherent_fraction)
 AT (0,0,0) ABSOLUTE
 
-COMPONENT Cu_powder_process = Powder_process(reflections=material_data_file,d_phi=15) //,format=Lazy)
+// d_phi is a focusing option in the Powder process
+COMPONENT Cu_powder_process = Powder_process(reflections=material_data_file,d_phi=15)
 AT (0,0,0) ABSOLUTE
 
 COMPONENT Cu_powder = Union_make_material(my_absorption=100*sigma_abs/Vc*pack,process_string="Cu_incoherent_process,Cu_powder_process")
@@ -85,7 +84,7 @@ ROTATED (0,0,0) RELATIVE sample_position
 COMPONENT test_sample = Union_master()
 AT(0,0,1) RELATIVE a1
 
-COMPONENT pre_detectors_m4pi = PSD_monitor_4PI(radius=1, nx=180, ny=180, filename="4Pi_events_pre.dat",restore_neutron=1)
+COMPONENT detector_m4pi = PSD_monitor_4PI(radius=1, nx=180, ny=180, filename="4Pi_events.dat",restore_neutron=1)
   AT (0, 0, 0) RELATIVE sample_position
 
 COMPONENT Banana_monitor = Monitor_nD(radius=1, yheight=0.1, options="banana, theta limits=[20,170], bins=500",filename="banana.dat",restore_neutron=1)
@@ -112,7 +111,6 @@ ROTATED (45,-35,0) RELATIVE sample_position
 COMPONENT PSDlin_scattering_2 = PSDlin_monitor(xwidth=0.1, yheight=0.05, nx=100, filename="Output_scattering_2.psd",restore_neutron = 1)
 AT (0,0,0.5) RELATIVE scattering_arm_2
 
-COMPONENT m4pi = PSD_monitor_4PI(radius=1, nx=180, ny=180, filename="4Pi_events.dat",restore_neutron=1)
-  AT (0, 0, 0) RELATIVE sample_position
+
 
 END

--- a/mcstas-comps/examples/Union_test_absorption.instr
+++ b/mcstas-comps/examples/Union_test_absorption.instr
@@ -11,39 +11,26 @@
 * Written by: Mads Bertelsen
 * Date: September 2015
 * Origin: University of Copenhagen
-* %INSTRUMENT_SITE:
+* %INSTRUMENT_SITE: Union_demos
 *
-* Simple test instrument for sample component.
 *
 * %Description
-* simple test instrument for sample component.
+* Testing an absorber made using the Union components. An absorber is made
+*  without processes and just the make_material component, and requires
+*  a few special cases.
+*
+* Example: Detector: screen_I=5.91451e-06
 *
 * %End
 *******************************************************************************/
 
-DEFINE INSTRUMENT test()
+DEFINE INSTRUMENT Union_test_absorption()
 
 DECLARE
 %{
-
 %}
 
 TRACE
-
-COMPONENT Vanadium_incoherent = Incoherent_process(sigma=6.08,packing_factor=1,unit_cell_volume=13.827)
-AT (0,0,0) ABSOLUTE
-
-//COMPONENT Vanadium_incoherent_2 = Incoherent_process(sigma=5.09,packing_factor=0.9,unit_cell_volume=13.9)
-//AT (0,0,0) ABSOLUTE
-
-COMPONENT Vanadium = Union_make_material(my_absorption=2.1,process_string="Vanadium_incoherent")
-AT (0,0,0) ABSOLUTE
-
-COMPONENT Al_incoherent = Incoherent_process(sigma=20,packing_factor=1,unit_cell_volume=66.4)
-AT (0,0,0) ABSOLUTE
-
-COMPONENT Al = Union_make_material(my_absorption=4)
-AT (0,0,0) ABSOLUTE
 
 COMPONENT absorber_material = Union_make_material(my_absorption=3,absorber=1)
 AT (0,0,0) ABSOLUTE
@@ -55,16 +42,16 @@ COMPONENT source = Source_div(
         xwidth=0.15, yheight=0.15,focus_aw=0.01, focus_ah=0.01,
         E0 = 10,
         dE = 0)
-  AT (0,0,0) RELATIVE a1 ROTATED (0,0,0) RELATIVE a1
-
+  AT (0,0,0) RELATIVE a1
+  ROTATED (0,0,0) RELATIVE a1
 
 COMPONENT beam_center = Arm()
 AT (0,0,1.4) RELATIVE a1
 ROTATED (0,0,0) RELATIVE a1
 
-COMPONENT masked_cylinder_1 = Union_cylinder(
+COMPONENT cylinder = Union_cylinder(
   radius = 0.05, yheight = 0.1,
-  priority=6, material_string="absorber_material",visualize=1)
+  priority=6, material_string="absorber_material")
 AT (0,0,0) RELATIVE beam_center
 ROTATED (0,0,0) RELATIVE beam_center
 

--- a/mcstas-comps/examples/Union_test_absorption_image.instr
+++ b/mcstas-comps/examples/Union_test_absorption_image.instr
@@ -13,41 +13,40 @@
 * Origin: University of Copenhagen
 * %INSTRUMENT_SITE: Union_demos
 *
-* Simple test instrument for sample component.
-*
 * %Description
-* simple test instrument for sample component.
+* Simple test instrument showing absorption image of a cryostat with vanadium
+*  sample using the Union components.
 *
-* Example: filename="source_sct091_tu_02_1.dat" Detector: det_I=9.89304e+09
+* Example: Detector: screen_I=0.00925
 *
 * %Parameters
-* stick_displacement: [] 
+* stick_displacement: [m] Displacement of sample stick
 *
 * %End
 *******************************************************************************/
 
-DEFINE INSTRUMENT test(stick_displacement=0)
+DEFINE INSTRUMENT Union_test_absorption_image(stick_displacement=0)
 
 DECLARE
 %{
-int scattered_1;
-int scattered_2;
-int sample_1_index = 4;
-int sample_2_index = 6;
 %}
 
 TRACE
 
-COMPONENT Vanadium_incoherent = Incoherent_process(sigma=2.2,packing_factor=1,unit_cell_volume=13.827)
+
+COMPONENT Vanadium_incoherent = Incoherent_process(sigma=2*5.08,packing_factor=1,unit_cell_volume=27.66)
 AT (0,0,0) ABSOLUTE
 
-COMPONENT Vanadium = Union_make_material(my_absorption=1.5,process_string="Vanadium_incoherent")
+COMPONENT Vanadium = Union_make_material(my_absorption=2*5.08*100/27.66,process_string="Vanadium_incoherent")
 AT (0,0,0) ABSOLUTE
 
-COMPONENT Al_incoherent = Incoherent_process(sigma=0.1,packing_factor=1,unit_cell_volume=66.4)
+COMPONENT Al_incoherent = Incoherent_process(sigma=4*0.0082,packing_factor=1,unit_cell_volume=66.4) //,interact_fraction=0.8)
 AT (0,0,0) ABSOLUTE
 
-COMPONENT Al = Union_make_material(my_absorption=3)
+COMPONENT Al_powder = Powder_process(reflections="Al.laz")
+AT (0,0,0) ABSOLUTE
+
+COMPONENT Al = Union_make_material(my_absorption=100*4*0.231/66.4)
 AT (0,0,0) ABSOLUTE
 
 COMPONENT Absorber_incoherent = Incoherent_process(sigma=2.2,packing_factor=1,unit_cell_volume=13.827)
@@ -55,6 +54,7 @@ AT (0,0,0) ABSOLUTE
 
 COMPONENT Absorber = Union_make_material(my_absorption=1000,absorber=1)
 AT (0,0,0) ABSOLUTE
+
 
 COMPONENT a1 = Progress_bar()
   AT (0,0,0) ABSOLUTE
@@ -193,79 +193,11 @@ ROTATED (-7,0,32) RELATIVE sample_holder3
 
 COMPONENT test_sample = Union_master()
 AT(0,0,0) RELATIVE beam_center
-ROTATED(0,30,20) RELATIVE beam_center
-EXTEND
-%{
-	if (scattered_flag[sample_1_index] > 0) scattered_1 = 1; else scattered_1 = 0;
-	if (scattered_flag[sample_2_index] > 0) scattered_2 = 1; else scattered_2 = 0;
-
-    // if (SCATTERED) printf("I scatter\n"); else printf("I do not scatter\n");
-%}
-
-COMPONENT tube_point = Arm()
-AT (0.10,0.5,0.4) RELATIVE beam_center
-ROTATED (0,0,0) RELATIVE beam_center
-
-
-// 1
-COMPONENT box_tube1 = Union_box(xwidth=0.03,xwidth2=0.04, yheight=0.03, yheight2=0.04, zdepth=0.1, priority=5,material_string="Al")
-AT (0,0,0) RELATIVE tube_point
-ROTATED (90,0,0) RELATIVE tube_point
-
-//COMPONENT box_tube1 = Union_box(xwidth=0.03, yheight=0.1, zdepth=0.03, priority=5,material_string="Al")
-//AT (0,0,0) RELATIVE tube_point
-//ROTATED (0,0,0) RELATIVE tube_point
-
-
-// 2
-COMPONENT cylinder_tube1 = Union_cylinder(radius = 0.013,yheight = 0.11,priority=6,material_string="Vacuum")
-AT (0,0,0) RELATIVE tube_point
-ROTATED (0,0,0) RELATIVE tube_point
-
-// 3
-COMPONENT cylinder_cross1 = Union_cylinder(radius = 0.003,yheight = 0.05,priority=7,material_string="Al")
-AT (0,0,0) RELATIVE tube_point
-ROTATED (90,0,90) RELATIVE tube_point
-
-// 4
-COMPONENT cylinder_cross2 = Union_cylinder(radius = 0.003,yheight = 0.05,priority=8,material_string="Al")
-AT (0,0,0) RELATIVE tube_point
-ROTATED (90,0,0) RELATIVE tube_point
-
-// 5
-COMPONENT box_totem1 = Union_box(xwidth=0.03,yheight=0.03,zdepth=0.03,priority=9,material_string="Al")
-AT (0,-0.01,-0.07+0.4) RELATIVE beam_center
-ROTATED (45,0,45) RELATIVE beam_center
-
-// 6
-COMPONENT box_totem2 = Union_box(xwidth=0.03,yheight=0.03,zdepth=0.03,priority=10,material_string="Al")
-AT (0,0.01,-0.065+0.4) RELATIVE beam_center
-ROTATED (0,0,0) RELATIVE beam_center
-
-// 7
-COMPONENT box_totem3 = Union_box(xwidth=0.03,yheight=0.03,zdepth=0.03,priority=11,material_string="Al")
-AT (0,0.03,-0.06+0.4) RELATIVE beam_center
-ROTATED (45,0,45) RELATIVE beam_center
-
-COMPONENT test_sample2 = Union_master()
-AT(0,0,0) RELATIVE beam_center
 ROTATED(0,0,0) RELATIVE beam_center
-EXTEND
-%{
-	//if (scattered_flag[sample_1_index] > 0) scattered_1 = 1; else scattered_1 = 0;
-	//if (scattered_flag[sample_2_index] > 0) scattered_2 = 1; else scattered_2 = 0;
 
-    // if (SCATTERED) printf("I scatter\n"); else printf("I do not scatter\n");
-%}
-
-
-
-
-
-COMPONENT screen = PSD_monitor(xwidth=0.4,ymin=-0.15,ymax=0.85,nx=500,ny=1200,filename="absoprtion_picture.dat",restore_neutron=1)
+COMPONENT screen = PSD_monitor(
+   xwidth=0.4,ymin=-0.15,ymax=0.85,
+   nx=500,ny=1200,filename="absoprtion_picture.dat",restore_neutron=1)
   AT (0,0,2) RELATIVE a1
-
-
-
 
 END

--- a/mcstas-comps/examples/Union_test_box.instr
+++ b/mcstas-comps/examples/Union_test_box.instr
@@ -5,23 +5,25 @@
 *         Risoe National Laboratory, Roskilde, Denmark
 *         Institut Laue Langevin, Grenoble, France
 *
-* Instrument: test
+* Instrument: Union_test_box
 *
 * %Identification
 * Written by: Mads Bertelsen
 * Date: September 2015
 * Origin: University of Copenhagen
-* %INSTRUMENT_SITE:
+* %INSTRUMENT_SITE: Union_demos
 *
-* Simple test instrument for sample component.
+* Simple test instrument for Union box component.
+*
+* Example: Detector: m4pi_both_I=4.8716e-10
 *
 * %Description
-* simple test instrument for sample component.
+* Simple test instrument for Union box component.
 *
 * %End
 *******************************************************************************/
 
-DEFINE INSTRUMENT test()
+DEFINE INSTRUMENT Union_test_box()
 
 DECLARE
 %{
@@ -33,26 +35,16 @@ int sample_2_index = 4;
 
 TRACE
 
-COMPONENT Vanadium_incoherent = Incoherent_process(sigma=6.08,packing_factor=1,unit_cell_volume=13.827)
+COMPONENT test_incoherent = Incoherent_process(sigma=20,packing_factor=1,unit_cell_volume=66.4)
 AT (0,0,0) ABSOLUTE
 
-//COMPONENT Vanadium_incoherent_2 = Incoherent_process(sigma=5.09,packing_factor=0.9,unit_cell_volume=13.9)
-//AT (0,0,0) ABSOLUTE
-
-COMPONENT Vanadium = Union_make_material(my_absorption=2.1,process_string="Vanadium_incoherent")
-AT (0,0,0) ABSOLUTE
-
-COMPONENT Al_incoherent = Incoherent_process(sigma=20,packing_factor=1,unit_cell_volume=66.4)
-AT (0,0,0) ABSOLUTE
-
-COMPONENT Al = Union_make_material(my_absorption=4)
+COMPONENT test_material = Union_make_material(my_absorption=4)
 AT (0,0,0) ABSOLUTE
 
 COMPONENT a1 = Progress_bar()
   AT (0,0,0) ABSOLUTE
 
 COMPONENT source = Source_div(
-//        xwidth=0.0005, yheight=0.0005,focus_aw=15, focus_ah=15,
         xwidth=0.0005, yheight=0.0005,focus_aw=3, focus_ah=2,
         E0 = 10,
         dE = 0)
@@ -75,38 +67,38 @@ AT (0,0,0) RELATIVE beam_center
 ROTATED (0,0,0) RELATIVE beam_center
 
 
-// 1
-COMPONENT box_tube1 = Union_box(xwidth=0.1, yheight=0.15, xwidth2=0.03, yheight2=0.03, zdepth=0.15, priority=5, material_string="Al")
+// V1
+COMPONENT box_tube1 = Union_box(xwidth=0.1, yheight=0.15, xwidth2=0.03, yheight2=0.03, zdepth=0.045, priority=5, material_string="test_material")
 AT (0,0,0) RELATIVE tube_point
 ROTATED (0,0,0) RELATIVE tube_point
 
-// 2
+// V2
 COMPONENT cylinder_tube1 = Union_cylinder(radius = 0.013,yheight = 0.11,priority=6,material_string="Vacuum")
 AT (0,0,0) RELATIVE tube_point
 ROTATED (0,0,0) RELATIVE tube_point
 
-// 3
-COMPONENT cylinder_cross1 = Union_cylinder(radius = 0.003,yheight = 0.05,priority=7,material_string="Al")
+// V3
+COMPONENT cylinder_cross1 = Union_cylinder(radius = 0.003,yheight = 0.11,priority=7,material_string="test_material")
 AT (0,0,0) RELATIVE tube_point
 ROTATED (90,0,90) RELATIVE tube_point
 
-// 4
-COMPONENT cylinder_cross2 = Union_cylinder(radius = 0.003,yheight = 0.05,priority=8,material_string="Al")
+// V4
+COMPONENT cylinder_cross2 = Union_cylinder(radius = 0.003,yheight = 0.05,priority=8,material_string="test_material")
 AT (0,0,0) RELATIVE tube_point
 ROTATED (90,0,0) RELATIVE tube_point
 
-// 5
-COMPONENT box_totem1 = Union_box(xwidth=0.03,yheight=0.03,zdepth=0.03,priority=9,material_string="Vacuum")
+// V5
+COMPONENT box_totem1 = Union_box(xwidth=0.03,yheight=0.03,zdepth=0.03,priority=9,material_string="test_material")
 AT (0,-0.01,-0.07) RELATIVE beam_center
 ROTATED (45,0,45) RELATIVE beam_center
 
-// 6
-COMPONENT box_totem2 = Union_box(xwidth=0.03,yheight=0.03,zdepth=0.03,priority=10,material_string="Vacuum")
+// V6
+COMPONENT box_totem2 = Union_box(xwidth=0.03,yheight=0.03,zdepth=0.03,priority=10,material_string="test_material")
 AT (0,0.01,-0.065) RELATIVE beam_center
 ROTATED (0,0,0) RELATIVE beam_center
 
-// 7
-COMPONENT box_totem3 = Union_box(xwidth=0.03,yheight=0.03,zdepth=0.03,priority=11,material_string="Vacuum")
+// V7
+COMPONENT box_totem3 = Union_box(xwidth=0.03,yheight=0.03,zdepth=0.03,priority=11,material_string="test_material")
 AT (0,0.03,-0.06) RELATIVE beam_center
 ROTATED (45,0,45) RELATIVE beam_center
 
@@ -117,8 +109,6 @@ EXTEND
 %{
 	if (scattered_flag[sample_1_index] > 0) scattered_1 = 1; else scattered_1 = 0;
 	if (scattered_flag[sample_2_index] > 0) scattered_2 = 1; else scattered_2 = 0;
-
-    // if (SCATTERED) printf("I scatter\n"); else printf("I do not scatter\n");
 %}
 
 

--- a/mcstas-comps/examples/Union_test_mask.instr
+++ b/mcstas-comps/examples/Union_test_mask.instr
@@ -5,15 +5,17 @@
 *         Risoe National Laboratory, Roskilde, Denmark
 *         Institut Laue Langevin, Grenoble, France
 *
-* Instrument: test
+* Instrument: Union_test_mask
 *
 * %Identification
 * Written by: Mads Bertelsen
 * Date: September 2015
 * Origin: University of Copenhagen
-* %INSTRUMENT_SITE:
+* %INSTRUMENT_SITE: Union_demos
 *
-* Simple test instrument for sample component.
+* Simple test instrument for mask functionality in Union framework.
+*
+* Example: Detector: m4pi_I=2.27579e-07
 *
 * %Description
 * simple test instrument for sample component.
@@ -21,7 +23,7 @@
 * %End
 *******************************************************************************/
 
-DEFINE INSTRUMENT test()
+DEFINE INSTRUMENT Union_test_mask()
 
 DECLARE
 %{
@@ -33,19 +35,10 @@ int sample_2_index = 2;
 
 TRACE
 
-COMPONENT Vanadium_incoherent = Incoherent_process(sigma=6.08,packing_factor=1,unit_cell_volume=13.827)
+COMPONENT test_incoherent = Incoherent_process(sigma=20,packing_factor=1,unit_cell_volume=66.4)
 AT (0,0,0) ABSOLUTE
 
-//COMPONENT Vanadium_incoherent_2 = Incoherent_process(sigma=5.09,packing_factor=0.9,unit_cell_volume=13.9)
-//AT (0,0,0) ABSOLUTE
-
-COMPONENT Vanadium = Union_make_material(my_absorption=2.1,process_string="Vanadium_incoherent")
-AT (0,0,0) ABSOLUTE
-
-COMPONENT Al_incoherent = Incoherent_process(sigma=20,packing_factor=1,unit_cell_volume=66.4)
-AT (0,0,0) ABSOLUTE
-
-COMPONENT Al = Union_make_material(my_absorption=4)
+COMPONENT test_material = Union_make_material(my_absorption=4)
 AT (0,0,0) ABSOLUTE
 
 COMPONENT a1 = Progress_bar()
@@ -69,18 +62,13 @@ COMPONENT beam_center = Arm()
 AT (0,0,10.4) RELATIVE a1
 ROTATED (0,0,0) RELATIVE a1
 
-COMPONENT tube_point = Arm()
-AT (0,0,0) RELATIVE beam_center
-ROTATED (0,0,0) RELATIVE beam_center
-
-
 
 // Children tests
-COMPONENT volume_1 = Union_box(xwidth=0.1,yheight=0.1,zdepth=0.1,priority=10,material_string="Al")
+COMPONENT volume_1 = Union_box(xwidth=0.1,yheight=0.1,zdepth=0.1,priority=10,material_string="test_material")
 AT (0,0,0) RELATIVE beam_center
 ROTATED (0,0,0) RELATIVE beam_center
 
-COMPONENT volume_2 = Union_box(xwidth=0.09,yheight=0.1,zdepth=0.1,priority=11,material_string="Al")
+COMPONENT volume_2 = Union_box(xwidth=0.09,yheight=0.1,zdepth=0.1,priority=11,material_string="test_material")
 AT (0,0.01,0.01) RELATIVE beam_center
 ROTATED (0,0,0) RELATIVE beam_center
 
@@ -101,138 +89,6 @@ AT (0,0.0,0.0) RELATIVE beam_center
 ROTATED (0,0,0) RELATIVE beam_center
 
 
-/*
-// Overlap tests
-COMPONENT volume_1 = Union_box(xwidth=0.1,yheight=0.1,zdepth=0.1,priority=10,material_string="Al")
-AT (0,0,0) RELATIVE beam_center
-ROTATED (0,0,0) RELATIVE beam_center
-
-COMPONENT volume_2 = Union_box(xwidth=0.09,yheight=0.1,zdepth=0.1,priority=11,material_string="Al")
-AT (0,0.08,0.01) RELATIVE beam_center
-ROTATED (0,0,0) RELATIVE beam_center
-
-COMPONENT volume_2_mask = Union_box(xwidth=0.091,yheight=0.11,zdepth=0.11,priority=12,mask_string="volume_2")
-AT (0,0.08,0.01) RELATIVE beam_center
-ROTATED (0,0,0) RELATIVE beam_center
-
-COMPONENT volume_1_sister = Union_box(xwidth=0.08,yheight=0.11,zdepth=0.11,priority=12.5,material_string="Al")
-AT (0,0,0) RELATIVE beam_center
-ROTATED (0,0,0) RELATIVE beam_center
-
-COMPONENT volume_1_mask = Union_box(xwidth=0.09,yheight=0.1,zdepth=0.1,priority=13,mask_string="volume_1,volume_1_sister")
-AT (0,-0.08,-0.01) RELATIVE beam_center
-ROTATED (0,0,0) RELATIVE beam_center
-*/
-
-
-/*
-// Run test
-COMPONENT volume_1 = Union_box(xwidth=0.1,yheight=0.1,zdepth=0.1,priority=10,material_string="Al")
-AT (0,0,0) RELATIVE beam_center
-ROTATED (0,0,0) RELATIVE beam_center
-
-COMPONENT volume_1_mask_1 = Union_box(xwidth=0.1,yheight=0.11,zdepth=0.1,priority=13,mask_string="volume_1")
-AT (0,0,0) RELATIVE beam_center
-ROTATED (0,45,0) RELATIVE beam_center
-
-COMPONENT volume_1_mask_2 = Union_box(xwidth=0.09,yheight=0.08,zdepth=0.05,priority=14,mask_string="volume_1",mask_setting="ANY")
-AT (0,0,-0.05) RELATIVE beam_center
-ROTATED (0,0,0) RELATIVE beam_center
-
-COMPONENT volume_2 = Union_box(xwidth=0.1,yheight=0.105,zdepth=0.1,priority=8,material_string="Al")
-AT (0.06,0.01,0.01) RELATIVE beam_center
-ROTATED (0,0,0) RELATIVE beam_center
-*/
-
-/*
-// Intersect list check
-COMPONENT volume_1 = Union_box(xwidth=0.1,yheight=0.1,zdepth=0.1,priority=10,material_string="Al")
-AT (0,0,0) RELATIVE beam_center
-ROTATED (0,0,0) RELATIVE beam_center
-
-COMPONENT volume_1_mask_1 = Union_box(xwidth=0.05,yheight=0.05,zdepth=0.05,priority=13,mask_string="volume_1")
-AT (0,0.05,0) RELATIVE beam_center
-ROTATED (0,45,0) RELATIVE beam_center
-
-// This box is inside volume 1, but not it's mask. It should thus go on volume 0's normal intersect list
-COMPONENT volume_2 = Union_box(xwidth=0.05,yheight=0.05,zdepth=0.05,priority=8,material_string="Al")
-AT (0.0,-0.02,0.01) RELATIVE beam_center
-ROTATED (0,0,0) RELATIVE beam_center
-*/
-
-/*
-// Destinations list check
-COMPONENT volume_1 = Union_box(xwidth=0.1,yheight=0.1,zdepth=0.1,priority=10,material_string="Al")
-AT (0,0,0) RELATIVE beam_center
-ROTATED (0,0,0) RELATIVE beam_center
-
-COMPONENT volume_1_mask_1 = Union_box(xwidth=0.05,yheight=0.05,zdepth=0.05,priority=13,mask_string="volume_1")
-AT (0,0.05,0) RELATIVE beam_center
-ROTATED (0,45,0) RELATIVE beam_center
-
-// This box is inside volume 1, but not it's mask. It should thus go on volume 0's normal intersect list
-COMPONENT volume_2 = Union_box(xwidth=0.05,yheight=0.05,zdepth=0.05,priority=8,material_string="Al")
-AT (0.0,-0.02,0.01) RELATIVE beam_center
-ROTATED (0,0,0) RELATIVE beam_center
-
-COMPONENT volume_3 = Union_box(xwidth=0.02,yheight=0.20,zdepth=0.02,priority=16,material_string="Al")
-AT (0.0,0.0,0.0) RELATIVE beam_center
-ROTATED (0,0,0) RELATIVE beam_center
-*/
-
-
-
-/*
-// Current volume / scattering process test
-COMPONENT angled_point = Arm()
-AT (0,0,0) RELATIVE beam_center
-ROTATED (0,30,0) RELATIVE beam_center
-
-COMPONENT masked_cylinder_1 = Union_cylinder(
-  radius = 0.53, yheight = 0.05,
-  priority=6, material_string="Al",visualize=1)
-AT (0,0,-0.5) RELATIVE angled_point
-ROTATED (0,0,90) RELATIVE angled_point
-
-COMPONENT masked_cylinder_2 = Union_cylinder(
-  radius = 0.50, yheight = 0.06,
-  priority=7, material_string="Vacuum",visualize=1)
-AT (0,0,-0.5) RELATIVE angled_point
-ROTATED (0,0,90) RELATIVE angled_point
-
-COMPONENT mask = Union_box(xwidth=0.07,yheight=0.24,zdepth=0.07,priority=13,mask_string="masked_cylinder_1,masked_cylinder_2")
-AT (0,0,0) RELATIVE angled_point
-ROTATED (0,0,0) RELATIVE angled_point
-
-COMPONENT extra_volume = Union_box(xwidth=0.04,yheight=0.04,zdepth=0.01,priority=14,material_string="Al")
-AT (0,0,-0.02) RELATIVE angled_point
-ROTATED (0,0,0) RELATIVE angled_point
-*/
-
-/*
-// Testing on totem
-// 1
-COMPONENT box_totem1 = Union_box(xwidth=0.03,yheight=0.03,zdepth=0.03,priority=9,material_string="Al")
-AT (0,-0.01,-0.07) RELATIVE beam_center
-ROTATED (45,0,45) RELATIVE beam_center
-
-// 2
-COMPONENT box_totem2 = Union_box(xwidth=0.03,yheight=0.03,zdepth=0.03,priority=10,material_string="Al")
-AT (0,0.01,-0.065) RELATIVE beam_center
-ROTATED (0,0,0) RELATIVE beam_center
-
-// 3
-COMPONENT box_totem3 = Union_box(xwidth=0.03,yheight=0.03,zdepth=0.03,priority=11,material_string="Al")
-AT (0,0.03,-0.06) RELATIVE beam_center
-ROTATED (45,0,45) RELATIVE beam_center
-
-// Mask 1
-COMPONENT box_tube1 = Union_box(xwidth=0.05, yheight=0.07, xwidth2=0.03, yheight2=0.03, zdepth=0.2, priority=5, mask_string="box_totem1,box_totem2", mask_setting="ALL")
-AT (0,0,0) RELATIVE tube_point
-ROTATED (0,0,0) RELATIVE tube_point
-*/
-
-
 
 COMPONENT test_sample = Union_master()
 AT(0,0,0) RELATIVE beam_center
@@ -241,8 +97,6 @@ EXTEND
 %{
 	if (scattered_flag[sample_1_index] > 0) scattered_1 = 1; else scattered_1 = 0;
 	if (scattered_flag[sample_2_index] > 0) scattered_2 = 1; else scattered_2 = 0;
-
-    // if (SCATTERED) printf("I scatter\n"); else printf("I do not scatter\n");
 %}
 
 
@@ -261,7 +115,6 @@ EXTEND
 %{
 	if (scattered_1 + scattered_2 != 2) ABSORB;
 %}
-
 
 COMPONENT m4pi_both = PSD_monitor_4PI(radius=1, nx=180, ny=180, filename="Events_12") WHEN (scattered_1 && scattered_2)
   AT (0, 0, 0) RELATIVE beam_center

--- a/mcstas-comps/examples/Union_test_powder.instr
+++ b/mcstas-comps/examples/Union_test_powder.instr
@@ -5,45 +5,38 @@
 *         Risoe National Laboratory, Roskilde, Denmark
 *         Institut Laue Langevin, Grenoble, France
 *
-* Instrument: test
+* Instrument: Union_test_powder
 *
 * %Identification
 * Written by: Mads Bertelsen
 * Date: September 2015
 * Origin: University of Copenhagen
-* %INSTRUMENT_SITE:
+* %INSTRUMENT_SITE: Union_demos
 *
-* Simple test instrument for sample component.
+* Simple test instrument for powder process in Union framework.
 *
 * %Description
 * simple test instrument for sample component.
 *
-* Example: filename="source_sct091_tu_02_1.dat" Detector: det_I=9.89304e+09
+* Example: Detector: m4pi_I=4.23557e-06
 *
 * %End
 *******************************************************************************/
 
-DEFINE INSTRUMENT test()
+DEFINE INSTRUMENT Union_test_powder()
 
 DECLARE
 %{
 %}
 
 TRACE
-
-//COMPONENT Vanadium_incoherent = Incoherent_process(sigma=6.08,packing_factor=1,unit_cell_volume=13.827)
-//AT (0,0,0) ABSOLUTE
-
-//COMPONENT Vanadium = Union_make_material(my_absorption=2.1,process_string="Vanadium_incoherent")
-//AT (0,0,0) ABSOLUTE
-
-COMPONENT Al_incoherent = Incoherent_process(sigma=1.5,packing_factor=1,unit_cell_volume=66.4)
+COMPONENT test_incoherent = Incoherent_process(sigma=1.5,packing_factor=1,unit_cell_volume=66.4)
 AT (0,0,0) ABSOLUTE
 
-COMPONENT Al_powder = Powder_process(reflections="Al.laz") //,format=Lazy)
+COMPONENT test_powder = Powder_process(reflections="Al.laz")
 AT (0,0,0) ABSOLUTE
 
-COMPONENT Al = Union_make_material(my_absorption=4)
+COMPONENT test_material = Union_make_material(my_absorption=4)
 AT (0,0,0) ABSOLUTE
 
 
@@ -51,7 +44,6 @@ COMPONENT a1 = Progress_bar()
   AT (0,0,0) ABSOLUTE
 
 COMPONENT source = Source_div(
-//        xwidth=0.0005, yheight=0.0005,focus_aw=15, focus_ah=15,
         xwidth=0.0005, yheight=0.0005,focus_aw=3, focus_ah=2,
         E0 = 100,
         dE = 0)
@@ -62,8 +54,8 @@ COMPONENT beam_center = Arm()
 AT (0,0,1.4) RELATIVE a1
 ROTATED (0,0,0) RELATIVE a1
 
-// 1
-COMPONENT test_powder_sample = Union_cylinder(radius=0.04,yheight=0.03,priority=5,material_string="Al")
+// V1
+COMPONENT test_powder_sample = Union_cylinder(radius=0.04,yheight=0.03,priority=5,material_string="test_material")
 AT (0,0,0) RELATIVE beam_center
 ROTATED (0,0,0) RELATIVE beam_center
 
@@ -73,10 +65,6 @@ ROTATED(0,0,0) RELATIVE beam_center
 
 COMPONENT m4pi = PSD_monitor_4PI(radius=1, nx=180, ny=180, filename="Events",restore_neutron=1)
   AT (0, 0, 0) RELATIVE beam_center
-
-
-
-
 
 
 END

--- a/mcstas-comps/examples/Union_time_of_flight.instr
+++ b/mcstas-comps/examples/Union_time_of_flight.instr
@@ -5,7 +5,7 @@
 *         Risoe National Laboratory, Roskilde, Denmark
 *         Institut Laue Langevin, Grenoble, France
 *
-* Instrument: test
+* Instrument: Union_time_of_flight
 *
 * %Identification
 * Written by: Mads Bertelsen
@@ -18,26 +18,24 @@
 * %Description
 * simple test instrument for sample component.
 *
-* Example: filename="source_sct091_tu_02_1.dat" Detector: det_I=9.89304e+09
+* Example: stick_displacement=0 Detector: banana_detector_tof_I=566.295
 *
 * %Parameters
-* stick_displacement: [] 
+* stick_displacement: [m] Displacement of sample stick
 *
 * %End
 *******************************************************************************/
 
-DEFINE INSTRUMENT test(stick_displacement=0)
+DEFINE INSTRUMENT Union_time_of_flight(stick_displacement=0)
 
 DECLARE
 %{
-int sample_1_index=27,sample_2_index=30,sample_3_index=36; // Indexes of three samples
-int scattered_1,scattered_2,scattered_3;
 %}
 
 TRACE
 
 // P0
-COMPONENT Al_incoherent = Incoherent_process(sigma=4*0.0082,packing_factor=1,unit_cell_volume=66.4) //,interact_fraction=0.8)
+COMPONENT Al_incoherent = Incoherent_process(sigma=4*0.0082,packing_factor=1,unit_cell_volume=66.4)
 AT (0,0,0) ABSOLUTE
 
 // P1
@@ -95,53 +93,63 @@ COMPONENT beam_center_arm = Arm()
 AT (0,0.3,0.0) RELATIVE target
 ROTATED (180,50,0) RELATIVE target
 
+
+// V1
 COMPONENT sample = Union_cylinder(radius=0.005,yheight=0.0265, priority=120,material_string="Na2Ca3Al2F14")
 AT (0,0.3,0) RELATIVE beam_center_arm
 ROTATED (-85,0,0) RELATIVE beam_center_arm
 
-
+// V2
 COMPONENT Al_ring1 = Union_cylinder(radius=0.008,yheight=0.001, priority=111,material_string="Al")
 AT (0,0.009,-0.002) RELATIVE sample
 ROTATED (-6,0,0) RELATIVE sample
 
+// V3
 COMPONENT Al_ring1_vacuum = Union_cylinder(radius=0.007,yheight=0.0011, priority=112,material_string="Vacuum",visualize=1)
 AT (0,0.009,-0.002) RELATIVE sample
 ROTATED (-6,0,0) RELATIVE sample
 
+// V4
 COMPONENT Al_ring2 = Union_cylinder(radius=0.008,yheight=0.001, priority=113,material_string="Al")
 AT (0,0.005,-0.002) RELATIVE sample
 ROTATED (10,0,0) RELATIVE sample
 
+// V5
 COMPONENT Al_ring2_vacuum = Union_cylinder(radius=0.007,yheight=0.0011, priority=114,material_string="Vacuum",visualize=1)
 AT (0,0.005,-0.002) RELATIVE sample
 ROTATED (10,0,0) RELATIVE sample
 
+// V6
 COMPONENT Al_ring3 = Union_cylinder(radius=0.008,yheight=0.001, priority=115,material_string="Al")
 AT (0,0.001,-0.002) RELATIVE sample
 ROTATED (-7,0,0) RELATIVE sample
 
+// V7
 COMPONENT Al_ring3_vacuum = Union_cylinder(radius=0.007,yheight=0.0011, priority=116,material_string="Vacuum",visualize=1)
 AT (0,0.001,-0.002) RELATIVE sample
 ROTATED (-7,0,0) RELATIVE sample
 
+// V8
 COMPONENT Al_ring4 = Union_cylinder(radius=0.0075,yheight=0.001, priority=117,material_string="Al")
 AT (0,-0.0061,-0.0035) RELATIVE sample
 ROTATED (30,0,0) RELATIVE sample
 
+// V9
 COMPONENT Al_ring4_vacuum = Union_cylinder(radius=0.0065, yheight=0.0011, priority=118,material_string="Vacuum",visualize=1)
 AT (0,-0.0061,-0.0035) RELATIVE sample
 ROTATED (30,0,0) RELATIVE sample
 
-
+// V10
 COMPONENT sample_box_cut = Union_box(xwidth=0.0101,yheight=0.006,zdepth=0.006, priority=120.5, material_string="Vacuum", visualize=1)
 AT (0,-0.027*0.5+0.0029,0.0025) RELATIVE sample
 ROTATED (0,0,0) RELATIVE sample
 
+// V11
 COMPONENT al_in_box_cut = Union_box(xwidth=0.01,yheight=0.001,zdepth=0.001, priority=120.7, material_string="Al", visualize=1)
 AT (0,0.0019,-0.0019) RELATIVE sample_box_cut
 ROTATED (30,0,0) RELATIVE sample_box_cut
 
-
+// V12
 COMPONENT sample_holder_under_sample = Union_box(xwidth=0.01, yheight=0.025, zdepth=0.002, priority=121, material_string="Al", p_interact=0.3)
 AT (0,0,-0.005-0.0011) RELATIVE sample
 ROTATED (0,0,0) RELATIVE sample
@@ -150,6 +158,7 @@ COMPONENT long_piece_center_arm = Arm()
 AT (0,-0.0225,0) RELATIVE beam_center_arm
 ROTATED (0,0,0) RELATIVE beam_center_arm
 
+// V13
 COMPONENT sample_holder_long_piece = Union_box(xwidth=0.0099, yheight=0.03, zdepth=0.002, priority=122, material_string="Al", p_interact=0.3)
 AT (0,0.3,0.025*0.5) RELATIVE long_piece_center_arm
 ROTATED (0,0,0) RELATIVE long_piece_center_arm
@@ -158,28 +167,31 @@ COMPONENT bottom_horizontal_piece_center_arm = Arm()
 AT (0,-0.0255-0.022+0.01,0) RELATIVE beam_center_arm
 ROTATED (0,0,0) RELATIVE beam_center_arm
 
+// V14
 COMPONENT bottom_horizontal_piece = Union_box(xwidth=0.01, yheight=0.002, zdepth=0.025*0.5, priority=123, material_string="Al", p_interact=0.3)
 AT (0,0.3,0.025*0.25) RELATIVE bottom_horizontal_piece_center_arm
 ROTATED (-10,0,0) RELATIVE bottom_horizontal_piece_center_arm
-
-
 
 COMPONENT cylinder_top_center_arm = Arm()
 AT (0,-0.01,0) RELATIVE bottom_horizontal_piece_center_arm
 ROTATED (0,0,0) RELATIVE bottom_horizontal_piece_center_arm
 
+// V15
 COMPONENT bottom_vertical_piece = Union_box(xwidth=0.0099, yheight=0.025, zdepth=0.002, priority=124, material_string="Al", p_interact=0.3)
 AT (0,0.3-0.0025,0) RELATIVE cylinder_top_center_arm
 ROTATED (0,0,0) RELATIVE cylinder_top_center_arm
 
+// V16
 COMPONENT cylinder_holder = Union_cylinder(radius=0.01, yheight=0.05, priority=115.5, material_string="Al")
 AT (0,0.3-0.025,0) RELATIVE cylinder_top_center_arm
 ROTATED (0,0,0) RELATIVE cylinder_top_center_arm
 
+// V17
 COMPONENT cylinder_holder_cutout = Union_box(xwidth=0.0201, yheight=0.02, zdepth=0.0025, priority=116.5, material_string="Al", p_interact=0.3)
 AT (0,0.3-0.0098,0) RELATIVE cylinder_top_center_arm
 ROTATED (0,0,0) RELATIVE cylinder_top_center_arm
 
+// V18
 COMPONENT screw_head = Union_cylinder(radius=0.003, yheight=0.004, priority=117.5, material_string="Al", p_interact=0.3)
 AT (0,0.3-0.006,-0.0121) RELATIVE cylinder_top_center_arm
 ROTATED (90,0,0) RELATIVE cylinder_top_center_arm
@@ -188,6 +200,7 @@ COMPONENT cylinder_bottom_center_arm = Arm()
 AT (0,-0.05,0) RELATIVE cylinder_top_center_arm
 ROTATED (0,0,0) RELATIVE cylinder_top_center_arm
 
+// V19
 COMPONENT cylinder_holder_base = Union_cylinder(radius=0.018, yheight=0.002, priority=118.5, material_string="Al")
 AT (0,0.3-0.0011,0) RELATIVE cylinder_bottom_center_arm
 ROTATED (0,0,0) RELATIVE cylinder_bottom_center_arm
@@ -196,110 +209,103 @@ COMPONENT sample_rod_bottom_arm = Arm()
 AT (0,0.1+stick_displacement,0) RELATIVE target
 ROTATED (0,85,0) RELATIVE target
 
-// V3
+// V20
 COMPONENT cryostat_mountin_plate = Union_cylinder(radius=0.215,yheight=0.01,priority=7,material_string="Al")
 AT (0,-0.147,0) RELATIVE target
 ROTATED (0,0,0) RELATIVE target
 
-// V4
+// V21
 COMPONENT cryostat_drum_walls = Union_cylinder(radius=0.1975,yheight=0.800,priority=8,material_string="Al")
 AT (0,0,0) RELATIVE drum_center
 ROTATED (0,0,0) RELATIVE drum_center
 
-// V5
+// V22
 COMPONENT cryostat_drum_vacuum = Union_cylinder(radius=0.19,yheight=0.790,priority=9,material_string="Vacuum")
 AT (0,0,0) RELATIVE drum_center
 ROTATED (0,0,0) RELATIVE drum_center
 
-// V6
+// V23
 COMPONENT outer_cryostat_wall = Union_cylinder(radius=0.180,yheight=0.355,priority=10,material_string="Al",p_interact=0.20)
 AT (0,0.032,0) RELATIVE target
 ROTATED (0,0,0) RELATIVE target
 
-// V7
+// V24
 COMPONENT outer_cryostat_vacuum = Union_cylinder(radius=0.178,yheight=0.355,priority=11,material_string="Vacuum")
 AT (0,0.037,0) RELATIVE target
 ROTATED (0,0,0) RELATIVE target
 
-// V12
+// V25
 COMPONENT sample_rod = Union_cylinder(radius=0.0075,yheight=1,priority=25,material_string="Al")
 AT (0,0.5,0) RELATIVE sample_rod_bottom_arm
 ROTATED (0,0,0) RELATIVE sample_rod_bottom_arm
 
-// V13
+// V26
 COMPONENT sample_rod_collar_1 = Union_cylinder(radius=0.034,yheight=0.02,priority=17,material_string="Al")
 AT (0,0.048,0) RELATIVE sample_rod_bottom_arm
 ROTATED (0,0,0) RELATIVE sample_rod_bottom_arm
 
-// V14
+// V27
 COMPONENT sample_rod_collar_2 = Union_cylinder(radius=0.034,yheight=0.02,priority=18,material_string="Al")
 AT (0,0.14,0) RELATIVE sample_rod_bottom_arm
 ROTATED (0,0,0) RELATIVE sample_rod_bottom_arm
 
-// V15
+// V28
 COMPONENT sample_rod_collar_3 = Union_cylinder(radius=0.034,yheight=0.02,priority=19,material_string="Al")
 AT (0,0.34,0) RELATIVE sample_rod_bottom_arm
 ROTATED (0,0,0) RELATIVE sample_rod_bottom_arm
 
-// V16
+// V29
 COMPONENT sample_rod_collar_4 = Union_cylinder(radius=0.034,yheight=0.02,priority=20,material_string="Al")
 AT (0,0.635,0) RELATIVE sample_rod_bottom_arm
 ROTATED (0,0,0) RELATIVE sample_rod_bottom_arm
 
-// V17
+// V30
 COMPONENT sample_rod_collar_1_vacuum = Union_cylinder(radius=0.03,yheight=0.016,priority=21,material_string="Vacuum")
 AT (0,0.048-0.005,0) RELATIVE sample_rod_bottom_arm
 ROTATED (0,0,0) RELATIVE sample_rod_bottom_arm
 
-// V18
+// V31
 COMPONENT sample_rod_collar_2_vacuum = Union_cylinder(radius=0.03,yheight=0.016,priority=22,material_string="Vacuum")
 AT (0,0.14-0.005,0) RELATIVE sample_rod_bottom_arm
 ROTATED (0,0,0) RELATIVE sample_rod_bottom_arm
 
-// V19
+// V32
 COMPONENT sample_rod_collar_3_vacuum = Union_cylinder(radius=0.03,yheight=0.016,priority=23,material_string="Vacuum")
 AT (0,0.34-0.005,0) RELATIVE sample_rod_bottom_arm
 ROTATED (0,0,0) RELATIVE sample_rod_bottom_arm
 
-// V20
+// V33
 COMPONENT sample_rod_collar_4_vacuum = Union_cylinder(radius=0.03,yheight=0.016,priority=24,material_string="Vacuum")
 AT (0,0.635-0.005,0) RELATIVE sample_rod_bottom_arm
 ROTATED (0,0,0) RELATIVE sample_rod_bottom_arm
 
-// V8
+// V34
 COMPONENT inner_cryostat_wall = Union_cylinder(radius=0.052,yheight=0.16,priority=12,material_string="Al",p_interact=0.20)
 AT (0,0.01,0) RELATIVE target
 ROTATED (0,0,0) RELATIVE target
 
-// V9
+// V35
 COMPONENT inner_cryostat_vacuum = Union_cylinder(radius=0.05,yheight=0.15,priority=13,material_string="Vacuum")
 AT (0,0.01,0) RELATIVE target
 ROTATED (0,0,0) RELATIVE target
 
-// V10
+// V36
 COMPONENT sample_stick_walls = Union_cylinder(radius=0.04,yheight=0.935,priority=14,material_string="Al")
 AT (0,0.555,0) RELATIVE target
 ROTATED (0,0,0) RELATIVE target
 
-// V11
+// V37
 COMPONENT sample_stick_vacuum = Union_cylinder(radius=0.035,yheight=0.94,priority=15,material_string="Vacuum")
 AT (0,0.55,0) RELATIVE target
 ROTATED (0,0,0) RELATIVE target
 
 
-
 COMPONENT test_sample = Union_master()
 AT(0,0,0) RELATIVE beam_center
 ROTATED(0,0,0) RELATIVE beam_center
-EXTEND
-%{
-if (scattered_flag[sample_1_index] > 0) scattered_1 = 1; else scattered_1 = 0;
-if (scattered_flag[sample_2_index] > 0) scattered_2 = 1; else scattered_2 = 0;
-if (scattered_flag[sample_3_index] > 0) scattered_3 = 1; else scattered_3 = 0;
-%}
 
 
-COMPONENT banana_detector = Monitor_nD(
+COMPONENT banana_detector_tof = Monitor_nD(
 xwidth=1,yheight=0.2,
 options = "banana, theta limits=[-120,120] bins=481, t limits=[3E-3 6E-3] bins=2000",restore_neutron=1)
 AT (0,0,0) RELATIVE beam_center
@@ -309,17 +315,7 @@ COMPONENT m4pi = PSD_monitor_4PI(radius=1, nx=180, ny=180, filename="Events.dat"
 AT (0, 0, 0) RELATIVE beam_center
 ROTATED (0,0,0) RELATIVE beam_center
 
-/*
-COMPONENT arm_1 = Arm()
-  AT (0, 0, 0) RELATIVE beam_center
-EXTEND
-%{
-	if (scattered_1 + scattered_2 + scattered_3 != 3) ABSORB;
-%}
-*/
-
 COMPONENT m4pi_three_samples = PSD_monitor_4PI(radius=1, nx=180, ny=180, filename="Events.dat", restore_neutron=1)
-WHEN (scattered_1 + scattered_2 + scattered_3 == 3)
 AT (0, 0, 0) RELATIVE beam_center
 ROTATED (0,0,0) RELATIVE beam_center
 

--- a/mcstas-comps/share/Union_initialization.c
+++ b/mcstas-comps/share/Union_initialization.c
@@ -9,34 +9,13 @@
 * Version: $Revision: 0.1 $
 * Origin: Svanevej 19
 *
-* A sample component to separate geometry and phsysics
 *
-* %D
-* Alpha version, no input system yet
-* Hardcode input to geometry engine
-* Allows complicated geometry by combination of simple shapes
+* This file sets up global lists needed for Union components to communicate with each other
+* These all have dynamically allocated memory somewhere in the structure, which is deallocated
+*  by the last Union_master.
 *
-* Algorithm:
-* Described elsewhere
 *
-* %P
-* INPUT PARAMETERS:
-* radius:  [m] Outer radius of sample in (x,z) plane
-*
-* OUTPUT PARAMETERS:
-* V_rho:  [AA^-3] Atomic density
-*
-* %L
-* The test/example instrument <a href="../examples/Test_Phonon.instr">Test_Phonon.instr</a>.
-*
-* %E
 ******************************************************************************/
-
-
-// This file sets up global lists needed for Union components to communicate with each other
-// These all have dynamically allocated memory somewhere in the structure, which is deallocated
-//  by the last Union_master.
-
 
 // Initialize global positions / rotations to transform lists
   // These are lists of pointers to positons / rotations, that will be updated from global frame


### PR DESCRIPTION
Updated documentation section on all Union example instruments, but there is still work to be done on the descriptions and examples. This will however close the issue of duplicate instrument names in the example folder.

Found a bug in the special case of having no Union process before a Union_make_material component, which is allowed if one is making an absorber, it did however fail to compile. The Union_make_material component lacked a call to the Union_initialization.c script.