### PR TITLE
Add/modify mcstas inst example files for translation to mantid IDFs

### DIFF
--- a/mcstas-comps/examples/templateSANS_Mantid.instr
+++ b/mcstas-comps/examples/templateSANS_Mantid.instr
@@ -102,7 +102,7 @@ COMPONENT PSDrad = PSD_monitor_rad(
   AT (0, 0, 3.02) RELATIVE sampleMantid
 
 COMPONENT nD_Mantid_1 = Monitor_nD(
-    options ="mantid square x limits=[-0.3 0.3] bins=128 y limits=[-0.3 0.3] bins=128, neutron pixel t, list all neutrons",
+    options ="mantid square x limits=[-0.3 0.3] bins=128 y limits=[-0.3 0.3] bins=128, neutron pixel min=0 t, list all neutrons",
     xmin = -0.3,
     xmax = 0.3,
     ymin = -0.3,

--- a/mcstas-comps/examples/templateVanadiumMultipleScat_Mantid.instr
+++ b/mcstas-comps/examples/templateVanadiumMultipleScat_Mantid.instr
@@ -1,0 +1,44 @@
+DEFINE INSTRUMENT templateVanadiumMultipleScat_Mantid()
+
+DECLARE
+%{
+int multi_flag ;
+int single_flag ;
+%}
+
+TRACE
+
+COMPONENT Origin = Progress_bar(percent=5)
+AT (0,0,0) ABSOLUTE
+EXTEND %{
+	single_flag = multi_flag = 0;
+%}
+
+COMPONENT sourceMantid = Source_simple(radius=0.001, dist=1,
+		focus_xw=0.001, focus_yh=0.001, E0=5, dE=0.01)
+  AT (0, 0, 0) RELATIVE Origin
+
+COMPONENT sampleMantid = Incoherent(radius=0.002,
+		yheight=0.015, focus_r=0, pack=1, target_x=0,
+		target_y=0, target_z=1, f_QE=0, gamma=0)
+  AT (0, 0, 1) RELATIVE sourceMantid
+EXTEND
+%{
+if (SCATTERED == 1) single_flag =1 ;
+if (SCATTERED > 1) multi_flag =1 ;
+%}
+
+COMPONENT nD_Mantid_0 = Monitor_nD(
+    options ="Mantid square, x limits=[-2.5 2.5] bins=50 y limits=[-2.5 2.5] bins=50, neutron pixel min=0 t limits [0.002,0.005] list all neutrons, file=multi",
+    xwidth = 5, yheight = 5, restore_neutron = 1)
+  WHEN (multi_flag ==1)
+  AT (0, 0, 1) RELATIVE sampleMantid
+
+
+COMPONENT Mantid_1 = Monitor_nD(
+    options ="square, x limits=[-2.5 2.5] bins=50 y limits=[-2.5 2.5] bins=50, neutron pixel min=0 t limits [0.002,0.005] list all neutrons, file=single",
+    xwidth = 5, yheight = 5, restore_neutron = 1)
+  WHEN (single_flag ==1)
+  AT (0, 0, 1) RELATIVE sampleMantid
+  
+END


### PR DESCRIPTION
Fixes #587 

Testing

* Test that new and modified .instr files run with mcstas using steps in https://github.com/McStasMcXtrace/McCode/wiki/McStas-and-Mantid. 
* Optionally download Mantid nightly build and you should e.g. see for templateVanadiumMultipleScat_Mantid.instr:

![capture](https://user-images.githubusercontent.com/1135476/35608682-ffc343a8-0651-11e8-995b-722e2fbb76df.JPG)
 
* Read through the parts of section https://github.com/McStasMcXtrace/McCode/wiki/McStas-and-Mantid#setup-the-mcstas-instrument-to-create-a-mantid-instrument which mention the added .instr file and the modified .instr file