### PR TITLE
PowderN bug fix and small Union update

### DIFF
--- a/mcstas-comps/contrib/union/Powder_process.comp
+++ b/mcstas-comps/contrib/union/Powder_process.comp
@@ -368,7 +368,7 @@ int calc_xsect_union(double v, double *qv, double *my_sv2, int count, double *su
       line_info->xs_compute++;
       //printf("line_info->xs_Nq[line] = %f, line_info->xs_sum[line] = %f, line_info->xs_compute = %d\n",line_info->xs_Nq[line],line_info->xs_sum[line],line_info->xs_compute);
     } else line_info->xs_reuse++;
-    line0 = Nq - 1;
+    line0 = Nq;
   }
   
   line_info->xs_calls++;
@@ -469,7 +469,7 @@ int Powder_physics_my(double *my,double *k_initial, union data_transfer_union da
           line_info->xs_compute++;
           //printf("line_info->xs_Nq[line] = %f, line_info->xs_sum[line] = %f, line_info->xs_compute = %d\n",line_info->xs_Nq[line],line_info->xs_sum[line],line_info->xs_compute);
         } else line_info->xs_reuse++;
-        line0 = line_info->Nq - 1;
+        line0 = line_info->Nq;
         }
           
         line_info->xs_calls++;

--- a/mcstas-comps/contrib/union/Union_logger_3D_space.comp
+++ b/mcstas-comps/contrib/union/Union_logger_3D_space.comp
@@ -6,6 +6,7 @@
 * %I
 * Written by: Mads Bertelsen
 * Date: 20.08.15
+* Version: $Revision: 0.1 $
 * Origin: Svanevej 19
 *
 * A sample component to separate geometry and phsysics
@@ -46,22 +47,22 @@
 *
 * %P
 * INPUT PARAMETERS:
-* D_direction_1: [string]    Direction for first axis ("x", "y" or "z")
-* D1_max: [1]                histogram boundery, max position value for first axis
-* D1_min: [1]                histogram boundery, min position value for first axis
-* n1: [1]                    number of bins for first axis
-* D_direction_2: [string]    Direction for second axis ("x", "y" or "z")
-* D2_max: [1]                histogram boundery, max position value for second axis
-* D2_min: [1]                histogram boundery, min position value for second axis
-* n2: [1]                    number of bins for second axis
-* D_direction_3: [string]    Direction for second axis ("x", "y" or "z")
-* D3_max: [1]                histogram boundery, max position value for third axis
-* D3_min: [1]                histogram boundery, min position value for third axis
-* n3: [1]                    number of bins for third axis
-* target_geometry: [string]  Comma seperated list of geometry names that will be logged, leave empty for all volumes (even not defined yet)
-* target_process: [string]   Comma seperated names of physical processes, if volumes are selected, one can select Union_process names
-* order_total: [1]           Only log rays that scatter for the n'th time, 0 for all orders
-* order_volume: [1]          Only log rays that scatter for the n'th time in the same geometry
+* D_direction_1:   [string] Direction for first axis ("x", "y" or "z")
+* D1_max:          [1] histogram boundery, max position value for first axis
+* D1_min:          [1] histogram boundery, min position value for first axis
+* n1:              [1] number of bins for first axis
+* D_direction_2:   [string] Direction for second axis ("x", "y" or "z")
+* D2_max:          [1] histogram boundery, max position value for second axis
+* D2_min:          [1] histogram boundery, min position value for second axis
+* n2:              [1] number of bins for second axis
+* D_direction_3:   [string] Direction for second axis ("x", "y" or "z")
+* D3_max:          [1] histogram boundery, max position value for third axis
+* D3_min:          [1] histogram boundery, min position value for third axis
+* n3:              [1] number of bins for third axis
+* target_geometry: [string] Comma seperated list of geometry names that will be logged, leave empty for all volumes (even not defined yet)
+* target_process:  [string] Comma seperated names of physical processes, if volumes are selected, one can select Union_process names
+* order_total:     [1] Only log rays that scatter for the n'th time, 0 for all orders
+* order_volume:    [1] Only log rays that scatter for the n'th time in the same geometry
 * order_volume_process [1] Only log rays that scatter for the n'th time in the same geometry, using the same process
 * logger_conditional_extend_index [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then acces logger_conditional_extend[n] if logger_conditional_extend_index is set to n
 *
@@ -92,27 +93,31 @@ SHARE
 #endif
 
 struct temp_3DS_data_element_struct {
-int index_1;
-int index_2;
-int index_3;
-double weight;
+ int index_1;
+ int index_2;
+ int index_3;
+ double weight;
 };
 
 struct temp_3DS_data_struct {
-int num_elements;
-int allocated_elements;
-struct temp_3DS_data_element_struct *elements;
+  int num_elements;
+  int allocated_elements;
+  struct temp_3DS_data_element_struct *elements;
 };
 
 struct a_3DS_storage_struct {
-struct Detector_3D_struct Detector_3D;
-struct temp_3DS_data_struct temp_3DS_data;
-int dim_1_choice;
-int dim_2_choice;
-int dim_3_choice;
-int order;
-int order_in_this_volume;
-int order_process_in_this_volume;
+  struct Detector_3D_struct Detector_3D;
+  struct temp_3DS_data_struct temp_3DS_data;
+  int dim_1_choice;
+  int dim_2_choice;
+  int dim_3_choice;
+  int order;
+  int order_in_this_volume;
+  int order_process_in_this_volume;
+  
+  Coords position;
+  Rotation rotation;
+  Rotation t_rotation;
 };
 
 // record_to_temp
@@ -151,25 +156,25 @@ void record_to_temp_3DS(Coords *position, double *k_new, double *k_old, double p
 
     // dim_1_choice = 0 for x, 1 for y, 2 for z. Done in initialize from input. "x" "y" "z".
     if (storage->dim_1_choice == 0)
-      p1 = position->x;
+      p1 = position->x - storage->position.x;
     else if (storage->dim_1_choice == 1)
-      p1 = position->y;
+      p1 = position->y - storage->position.y;
     else if (storage->dim_1_choice == 2)
-      p1 = position->z;
+      p1 = position->z - storage->position.z;
     
     if (storage->dim_2_choice == 0)
-      p2 = position->x;
+      p2 = position->x - storage->position.x;
     else if (storage->dim_2_choice == 1)
-      p2 = position->y;
+      p2 = position->y - storage->position.y;
     else if (storage->dim_2_choice == 2)
-      p2 = position->z;
+      p2 = position->z - storage->position.z;
   
     if (storage->dim_3_choice == 0)
-      p2 = position->x;
+      p2 = position->x - storage->position.x;
     else if (storage->dim_3_choice == 1)
-      p2 = position->y;
+      p2 = position->y - storage->position.y;
     else if (storage->dim_3_choice == 2)
-      p2 = position->z;
+      p2 = position->z - storage->position.z;
   
     int i,j,k;
   
@@ -278,25 +283,25 @@ void record_to_perm_3DS(Coords *position, double *k_new, double *k_old, double p
 
     // dim_1_choice = 0 for x, 1 for y, 2 for z. Done in initialize from input. "x" "y" "z".
     if (storage->dim_1_choice == 0)
-      p1 = position->x;
+      p1 = position->x - storage->position.x;
     else if (storage->dim_1_choice == 1)
-      p1 = position->y;
+      p1 = position->y - storage->position.y;
     else if (storage->dim_1_choice == 2)
-      p1 = position->z;
+      p1 = position->z - storage->position.z;
     
     if (storage->dim_2_choice == 0)
-      p2 = position->x;
+      p2 = position->x - storage->position.x;
     else if (storage->dim_2_choice == 1)
-      p2 = position->y;
+      p2 = position->y - storage->position.y;
     else if (storage->dim_2_choice == 2)
-      p2 = position->z;
+      p2 = position->z - storage->position.z;
   
     if (storage->dim_3_choice == 0)
-      p3 = position->x;
+      p3 = position->x - storage->position.x;
     else if (storage->dim_3_choice == 1)
-      p3 = position->y;
+      p3 = position->y - storage->position.y;
     else if (storage->dim_3_choice == 2)
-      p3 = position->z;
+      p3 = position->z - storage->position.z;
   
     int i,j,k;
   
@@ -305,10 +310,16 @@ void record_to_perm_3DS(Coords *position, double *k_new, double *k_old, double p
       i = floor((p1 - storage->Detector_3D.D1min)*storage->Detector_3D.bins_1/(storage->Detector_3D.D1max - storage->Detector_3D.D1min));
       j = floor((p2 - storage->Detector_3D.D2min)*storage->Detector_3D.bins_2/(storage->Detector_3D.D2max - storage->Detector_3D.D2min));
       k = floor((p3 - storage->Detector_3D.D3min)*storage->Detector_3D.bins_3/(storage->Detector_3D.D3max - storage->Detector_3D.D3min));
-    }
     
-      //printf("Added to statistics for monitor [%d] [%d] \n",i,j);
-      //printf("indicies found\n");
+      /*
+      printf("(p1,p2,p3) = (%f,%f,%f)\n",p1,p2,p3);
+      printf("limits1 = [%f,%f] \n",storage->Detector_3D.D1min,storage->Detector_3D.D1max);
+      printf("limits2 = [%f,%f] \n",storage->Detector_3D.D2min,storage->Detector_3D.D2max);
+      printf("limits3 = [%f,%f] \n",storage->Detector_3D.D3min,storage->Detector_3D.D3max);
+      printf("n bins = [%d,%d,%d] \n",round(storage->Detector_3D.bins_1),round(storage->Detector_3D.bins_2),round(storage->Detector_3D.bins_3));
+      printf("Added to statistics for monitor [%d] [%d] [%d] \n",i,j,k);
+      printf("indicies found\n");
+      */
       
       /*
       storage->Detector_3D.Array_N[i][j][k]++;
@@ -317,14 +328,14 @@ void record_to_perm_3DS(Coords *position, double *k_new, double *k_old, double p
       */
       
       
-      
       // because of the order in which the elements are laid out in memory, the k index must be first.
       storage->Detector_3D.Array_N[k][i][j]++;
       storage->Detector_3D.Array_p[k][i][j] += p;
       storage->Detector_3D.Array_p2[k][i][j] += p*p;
-    
+      
+      
+    }
   }
-
 }
 
 // write_temp_to_perm
@@ -341,6 +352,23 @@ void write_temp_to_perm_3DS(union logger_data_union *data_union) {
     storage->Detector_3D.Array_p[storage->temp_3DS_data.elements[index].index_1][storage->temp_3DS_data.elements[index].index_2][storage->temp_3DS_data.elements[index].index_3] += storage->temp_3DS_data.elements[index].weight;
     
     storage->Detector_3D.Array_p2[storage->temp_3DS_data.elements[index].index_1][storage->temp_3DS_data.elements[index].index_2][storage->temp_3DS_data.elements[index].index_3] += storage->temp_3DS_data.elements[index].weight*storage->temp_3DS_data.elements[index].weight;
+  }
+  clear_temp_3DS(data_union);
+}
+
+void write_temp_to_perm_final_p_3DS(union logger_data_union *data_union, double final_weight) {
+
+  struct a_3DS_storage_struct *storage;
+  storage = data_union->p_3DS_storage;
+
+  int index;
+  // Add all data points to the historgram, they are saved as index / weight combinations
+  for (index=0;index<storage->temp_3DS_data.num_elements;index++) {
+    storage->Detector_3D.Array_N[storage->temp_3DS_data.elements[index].index_1][storage->temp_3DS_data.elements[index].index_2][storage->temp_3DS_data.elements[index].index_3]++;
+    
+    storage->Detector_3D.Array_p[storage->temp_3DS_data.elements[index].index_1][storage->temp_3DS_data.elements[index].index_2][storage->temp_3DS_data.elements[index].index_3] += final_weight;
+    
+    storage->Detector_3D.Array_p2[storage->temp_3DS_data.elements[index].index_1][storage->temp_3DS_data.elements[index].index_2][storage->temp_3DS_data.elements[index].index_3] += final_weight*final_weight;
   }
   clear_temp_3DS(data_union);
 }
@@ -548,7 +576,6 @@ INITIALIZE
   */
   // D3 is in poisition 1, because that gives continous memory in XY plane for easy plotting
   
-  
   this_storage.Detector_3D.Array_N = allocate3Ddouble_3DS(n3,n1,n2,storage_N); // Here the n1 double is cast to an int
   this_storage.Detector_3D.Array_p = allocate3Ddouble_3DS(n3,n1,n2,storage_p);
   this_storage.Detector_3D.Array_p2 = allocate3Ddouble_3DS(n3,n1,n2,storage_2p);
@@ -645,13 +672,27 @@ INITIALIZE
   this_storage.temp_3DS_data.elements = malloc(this_storage.temp_3DS_data.allocated_elements*sizeof(struct temp_3DS_data_element_struct));
   
   
+  this_storage.position = POS_A_CURRENT_COMP;
+  add_position_pointer_to_list(&global_positions_to_transform_list,&this_storage.position);
+  
+  rot_copy(this_storage.rotation,ROT_A_CURRENT_COMP);
+  add_rotation_pointer_to_list(&global_rotations_to_transform_list,&this_storage.rotation);
+  
+  rot_transpose(ROT_A_CURRENT_COMP,this_storage.t_rotation);
+  add_rotation_pointer_to_list(&global_rotations_to_transform_list,&this_storage.t_rotation);
+  
+  
   //printf("past direction choices sanitation \n");
   
   // Book keeping
   this_logger.logger_extend_index = logger_conditional_extend_index;
   this_logger.function_pointers.active_record_function = &record_to_perm_3DS;  // Assume no conditional
   this_logger.function_pointers.inactive_record_function = &record_to_temp_3DS; // If an assume is present, these two pointers are switched
+  
+  // Temp to perm functions, and standard identifier
+  this_logger.function_pointers.select_t_to_p = 1; // 1: temp_to_perm, 2: temp_to_perm_final_p
   this_logger.function_pointers.temp_to_perm = &write_temp_to_perm_3DS;
+  this_logger.function_pointers.temp_to_perm_final_p = &write_temp_to_perm_final_p_3DS;
   this_logger.function_pointers.clear_temp = &clear_temp_3DS;
   // Initializing for conditional
   this_logger.conditional_list.num_elements = 0;
@@ -725,7 +766,7 @@ SAVE
 for (loop_index=0;loop_index<this_storage.Detector_3D.bins_3;loop_index++) {
   sprintf(number_string,"%d",loop_index);
   sprintf(part_filename,"%s_%s",this_storage.Detector_3D.Filename,number_string);
-
+  
   DETECTOR_OUT_2D(
    this_storage.Detector_3D.title_string,
    this_storage.Detector_3D.string_axis_1,

--- a/mcstas-comps/samples/PowderN.comp
+++ b/mcstas-comps/samples/PowderN.comp
@@ -15,6 +15,7 @@
 * Modified by: PW, LC 04.10.05   (Merge with Chapon Powder_multi)
 * Modified by: PW, KL 05.06.07   (Concentricity)
 * Modified by: EF,    17.10.08   (added any shape sample geometry)
+* Modified by: MB,    25.07.18   (fixed indexing bug in calc_xsect)
 *
 * General powder sample (N lines, single scattering, incoherent scattering)
 *
@@ -519,7 +520,7 @@ int calc_xsect(double v, double *qv, double *my_sv2, int count, double *sum,
       line_info->xs_sum[line]= *sum;
       line_info->xs_compute++;
     } else line_info->xs_reuse++;
-    line0 = Nq - 1;
+    line0 = Nq;
   }
 
   line_info->xs_calls++;


### PR DESCRIPTION
Fixed indexing bug in PowderN cross section calculation that was visible in transmission geometry. I did not have the time to thoroughly test the new code, but the issues with transmission geometry did disappear with this change.

Also fixed an important bug in Union_logger_space_3D that resulted in memory errors and wrong placment of the monitor.