### PR TITLE
Make Table_Read use relative memory allocation

### DIFF
--- a/common/lib/share/read_table-lib.c
+++ b/common/lib/share/read_table-lib.c
@@ -542,7 +542,7 @@ void *Table_File_List_store(t_Table *tab){
                 } else { /* store into data array */
                   if (count_in_array >= malloc_size) {
                     /* realloc data buffer if necessary */
-                    malloc_size = count_in_array+CHAR_BUF_LENGTH;
+                    malloc_size = count_in_array*1.5;
                     Data = (double*) realloc(Data, malloc_size*sizeof(double));
                     if (Data == NULL) {
                       fprintf(stderr, "Error: Can not re-allocate memory %li (Table_Read_Handle).\n",


### PR DESCRIPTION
Growing the memory allocated to Data by a constant amount is very inefficient on Windows. The standard appears to be to increase the allocated memory by 1.5 (50%) when the previously allocated memory is full. Results from testing the time spent for reallocation on a file of approx. 32MB is as follows (times given are CPU time):
**Windows 10:**
constant allocation: 90s
relative factor 1.5 allocation: 0.1s
relative factor 2 allocation: 0.03s
**Ubuntu 18.04:**
constant allocation: 0.3s
relative factor 1.5 allocation: 0.03s

This is for one process, running 10+ MPI processes results in a overhead which can be longer than the trace time. Note that any excess allocated memory is deallocated before the function returns.
The optimal solution would probably be to determine the memory needed before reading the data.