### PR TITLE
cogen: allow vectors with non static value

### DIFF
--- a/mcstas/src/cogen.c.in
+++ b/mcstas/src/cogen.c.in
@@ -540,7 +540,10 @@ static void cogen_comp_init_par(struct comp_inst *comp, struct instr_def *instr,
           coutf("  _%s_var._parameters.%s[0]='\\0';", comp->name, par->id);
         }
         else if (par->type == instr_type_vector) {
-          coutf("  _%s_var._parameters.%s = (double [])%s; // static pointer allocation", comp->name, par->id, val);
+          if (val[0] == '{')
+            coutf("  _%s_var._parameters.%s = (double [])%s; // static pointer allocation", comp->name, par->id, val);
+          else
+            coutf("  _%s_var._parameters.%s = %s; // default pointer allocation", comp->name, par->id, val);
         }
         else if (par->type == instr_type_symbol) {
           // the user vars value is particle specific, init to null


### PR DESCRIPTION
Allow comp parameters of type vector==double* to have non static value. This allow compilation of some examples that would fail otherwise. 
Comp parameters of  type 'vector' can be used for some old DEFINITION parameters.

On other PR relating to instrument.y follows.