### PR TITLE
instrument.y: display meaningfull comp instance names

### DIFF
--- a/mcstas/src/instrument.y
+++ b/mcstas/src/instrument.y
@@ -948,7 +948,6 @@ instref: "COPY" '(' compref ')' actuallist /* make a copy of a previous instance
         comp->actuals= symtab_create();
         symtab_cat(comp->actuals, $5);
         symtab_cat(comp->actuals, comp_src->actuals);
-        comp_formals_actuals(comp, comp->actuals);
         $$ = comp;
       }
     | "COPY" '(' compref ')'
@@ -980,12 +979,6 @@ instref: "COPY" '(' compref ')' actuallist /* make a copy of a previous instance
         comp->jump   = list_create();
         comp->when   = NULL;
         comp->actuals= $2;
-        if(def != NULL)
-        {
-          /* Check actual parameters against definition and
-                         setting parameters. */
-          comp_formals_actuals(comp, comp->actuals);
-        }
         $$ = comp;
       }
 ;
@@ -1010,6 +1003,13 @@ component: removable split "COMPONENT" instname '=' instref
         comp->split = $2;
         comp->removable = $1;
         comp->index = ++comp_current_index;     /* index of comp instance */
+        
+        if(comp->def != NULL)
+        {
+          /* Check actual parameters against definition and
+                         setting parameters. */
+          comp_formals_actuals(comp, comp->actuals);
+        }
       }
       when place orientation groupref extend jumps
       {


### PR DESCRIPTION
Now display meaningfull error messages when a component parameter is not set correctly. A "(null)" was given as component instance name. Now more informative.

For instance we now have:
```
ERROR: Unassigned SETTING parameter l for component guide2=Elliptic_guide_gravity() at line Reflectometer.instr:302. Please set its value.
```
and it was before:
```
ERROR: Unassigned SETTING parameter l for component (null)=Elliptic_guide_gravity() at line Reflectometer.instr:302. Please set its value.
```