### PR TITLE
F static arrays in declare

### DIFF
--- a/mcstas-comps/contrib/SANS_benchmark2.comp
+++ b/mcstas-comps/contrib/SANS_benchmark2.comp
@@ -67,8 +67,8 @@
 DEFINE COMPONENT SANS_benchmark2
 DEFINITION PARAMETERS ()
 SETTING PARAMETERS (xwidth=0.01, yheight=0.01, zthick=0.001, model=1.0, dsdw_inc=0.02, sc_aim=0.97, sans_aim=0.95, singlesp = 0.0)
-OUTPUT PARAMETERS (Idsdw,Qmind,Qmaxd,
-  Qminl, Qmaxl, l10, Qtab, Itab)
+OUTPUT PARAMETERS (Qmind,Qmaxd,
+  Qminl, Qmaxl, l10)
 
 SHARE
 %{

--- a/mcstas-comps/contrib/SNS_source_analytic.comp
+++ b/mcstas-comps/contrib/SNS_source_analytic.comp
@@ -95,7 +95,7 @@ SETTING PARAMETERS (
   proton_T=0.0,
   p_power=2.0,
   n_pulses=1.0)
-OUTPUT PARAMETERS (hdiv,vdiv,p_in, CL, CU, para_sp, para_a,para_b,para_R,para_to,csfE, CItot)
+OUTPUT PARAMETERS ()
 
 
 SHARE

--- a/mcstas-comps/monitors/Pol_monitor.comp
+++ b/mcstas-comps/monitors/Pol_monitor.comp
@@ -45,7 +45,7 @@ DEFINITION PARAMETERS ()
 
 SETTING PARAMETERS (xwidth=0.1, yheight=0.1, restore_neutron=0, mx=0, my=0, mz=0)
 
-OUTPUT PARAMETERS (Pol_N, Pol_p, Pol_p2, Psum, titlestring)
+OUTPUT PARAMETERS (Pol_N, Pol_p, Pol_p2, Psum)
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */
 
 DECLARE

--- a/mcstas-comps/optics/Guide_tapering.comp
+++ b/mcstas-comps/optics/Guide_tapering.comp
@@ -83,7 +83,7 @@ Qcx=0.021,Qcy=0.021, alphax=6.07, alphay=6.07, W=0.003,
 mx=1, my=1,segno=800,curvature=0,curvature_v=0)
 OUTPUT PARAMETERS(w1c,w2c,ww,hh,whalf,hhalf,lwhalf,lhhalf,h1_in,h2_out,w1_in,w2_out,l_seg,seg,
 h12, h2, w12, w2, a_ell_q, b_ell_q, lbw, lbh, mxi ,u1 ,u2 ,div1, p2_para,
-test,Div1, seg, fu, pos, file_name, ep, num, rotation_h,rotation_v)
+test,Div1, seg, fu, pos, ep, num, rotation_h,rotation_v)
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */
 
 SHARE

--- a/mcstas-comps/samples/Single_crystal.comp
+++ b/mcstas-comps/samples/Single_crystal.comp
@@ -281,7 +281,7 @@ bx = 0, by = 0, bz = 0,
 cx = 0, cy = 0, cz = 0,
 p_transmit = -1, sigma_abs = 0, sigma_inc = 0,
 aa=0, bb=0, cc=0, order=0, RX=0, RY=0, RZ=0, powder=0, PG=0)
-OUTPUT PARAMETERS(hkl_info, hkl_list, tau_list, offdata)
+OUTPUT PARAMETERS()
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */
 SHARE
 %{

--- a/mcstas/src/cogen.c.in
+++ b/mcstas/src/cogen.c.in
@@ -2335,8 +2335,8 @@ int get_codeblock_vars(struct code_block *code, List vars, List types,
 
         // extract the varname
         pos = re_match("\\w+\\[?\\w*\\]?\\[?\\w*\\]?;", l); // match start of varname
-	if (pos > -1) {
-	  len = re_match(";", l+pos); // match end of varname
+        if (pos > -1) {
+          len = re_match(";", l+pos); // match end of varname
 
           if (len > -1) {
             vn = (char*) malloc((len + 1) * sizeof(char)); // new location

--- a/mcstas/src/cogen.c.in
+++ b/mcstas/src/cogen.c.in
@@ -438,7 +438,6 @@ int cogen_comp_declare(struct comp_inst *comp)
 	    int len = re_match("\\[",c_formal->id);
 	    if (len>=0) {
 	      c_formal->id[len]='\0';
-	      printf("Found match in %s\n",c_formal->id);
 	    }
           }
           else if (c_formal->type != instr_type_string) {
@@ -2337,7 +2336,6 @@ int get_codeblock_vars(struct code_block *code, List vars, List types,
         // extract the varname
         pos = re_match("\\w+\\[?\\w*\\]?;", l); // match start of varname
 	if (pos > -1) {
-	  // check if there is a a static array decl here
 	  len = re_match(";", l+pos); // match end of varname
 
           if (len > -1) {

--- a/mcstas/src/cogen.c.in
+++ b/mcstas/src/cogen.c.in
@@ -413,7 +413,7 @@ int cogen_comp_declare(struct comp_inst *comp)
     list_iterate_end(decliter);
 
     // -- step III: replace previous output pars list with the new (patched) list
-      // TODO: free the previous list first?
+    // TODO: free the previous list first?
     comp->def->out_par = new_out_pars;
 
     // now add setting and (patched) output vars to comp struct
@@ -435,6 +435,11 @@ int cogen_comp_declare(struct comp_inst *comp)
           nb_parameters++;
           if (c_formal->type == instr_type_custom) {
             coutf("  %s %s;", c_formal->type_custom, c_formal->id);
+	    int len = re_match("\\[",c_formal->id);
+	    if (len>=0) {
+	      c_formal->id[len]='\0';
+	      printf("Found match in %s\n",c_formal->id);
+	    }
           }
           else if (c_formal->type != instr_type_string) {
             coutf("  %s %s;", instr_formal_type_names_real[c_formal->type], c_formal->id);
@@ -2312,8 +2317,8 @@ int get_codeblock_vars(struct code_block *code, List vars, List types,
   while(l = list_next(myiter)) {
     do {
       // line must match this format
-      pos = re_match("\\w[\\s\\w\\*]+\\s+\\*?\\w+;", l); // match general var decl pattern
-
+      pos = re_match("\\w[\\s\\w\\*]+\\s+\\*?\\w+\\[?\\w*\\]?;", l); // match general var decl pattern
+      //printf("%s has %i \n",l,pos);
       if (pos <= -1) {
         // skip
       }
@@ -2322,7 +2327,7 @@ int get_codeblock_vars(struct code_block *code, List vars, List types,
         char* vn;
 
         // extract the type
-        len = re_match("\\w+;", l+pos); // end of type string
+        len = re_match("\\w+\\[?\\w*\\]?;", l+pos); // end of type string
         tpe = (char*) malloc((len + 1) * sizeof(char)); // new location
         *(tpe+len) = '\0'; // null terminate
         if (len > -1) {
@@ -2330,9 +2335,10 @@ int get_codeblock_vars(struct code_block *code, List vars, List types,
         }
 
         // extract the varname
-        pos = re_match("\\w+;", l); // match start of varname
-        if (pos > -1) {
-          len = re_match(";", l+pos); // match end of varname
+        pos = re_match("\\w+\\[?\\w*\\]?;", l); // match start of varname
+	if (pos > -1) {
+	  // check if there is a a static array decl here
+	  len = re_match(";", l+pos); // match end of varname
 
           if (len > -1) {
             vn = (char*) malloc((len + 1) * sizeof(char)); // new location

--- a/mcstas/src/cogen.c.in
+++ b/mcstas/src/cogen.c.in
@@ -2316,7 +2316,7 @@ int get_codeblock_vars(struct code_block *code, List vars, List types,
   while(l = list_next(myiter)) {
     do {
       // line must match this format
-      pos = re_match("\\w[\\s\\w\\*]+\\s+\\*?\\w+\\[?\\w*\\]?;", l); // match general var decl pattern
+      pos = re_match("\\w[\\s\\w\\*]+\\s+\\*?\\w+\\[?\\w*\\]?\\[?\\w*\\]?;", l); // match general var decl pattern
       //printf("%s has %i \n",l,pos);
       if (pos <= -1) {
         // skip
@@ -2326,7 +2326,7 @@ int get_codeblock_vars(struct code_block *code, List vars, List types,
         char* vn;
 
         // extract the type
-        len = re_match("\\w+\\[?\\w*\\]?;", l+pos); // end of type string
+        len = re_match("\\w+\\[?\\w*\\]?\\[?\\w*\\]?;", l+pos); // end of type string
         tpe = (char*) malloc((len + 1) * sizeof(char)); // new location
         *(tpe+len) = '\0'; // null terminate
         if (len > -1) {
@@ -2334,7 +2334,7 @@ int get_codeblock_vars(struct code_block *code, List vars, List types,
         }
 
         // extract the varname
-        pos = re_match("\\w+\\[?\\w*\\]?;", l); // match start of varname
+        pos = re_match("\\w+\\[?\\w*\\]?\\[?\\w*\\]?;", l); // match start of varname
 	if (pos > -1) {
 	  len = re_match(";", l+pos); // match end of varname
 

--- a/mcstas/src/cogen.c.in
+++ b/mcstas/src/cogen.c.in
@@ -2317,7 +2317,7 @@ int get_codeblock_vars(struct code_block *code, List vars, List types,
     do {
       // line must match this format
       pos = re_match("\\w[\\s\\w\\*]+\\s+\\*?\\w+\\[?\\w*\\]?\\[?\\w*\\]?;", l); // match general var decl pattern
-      //printf("%s has %i \n",l,pos);
+
       if (pos <= -1) {
         // skip
       }


### PR DESCRIPTION
This enables the use of []-type static array declarations in DECLARE. 

Important: These arrays should then NOT be declared as OUTPUT_PARAMETERS