### PR TITLE
Initial support for podman and a newer Dockerfile

### DIFF
--- a/Docker/mcstas/mcstasscript/Dockerfile.podman
+++ b/Docker/mcstas/mcstasscript/Dockerfile.podman
@@ -1,0 +1,36 @@
+FROM ubuntu:focal
+LABEL maintainer="Daniel Webster <dsw@cloudbusting.io>"
+
+ENV VERSION=2.6.1
+
+RUN apt update -y && DEBIAN_FRONTEND=noninteractive apt -y --no-install-recommends install \
+    tzdata keyboard-configuration git coreutils curl xbase-clients \
+    xdg-utils firefox libosmesa6 mesa-utils libgl1-mesa-glx openmpi-bin \
+    libopenmpi-dev libnexus1 libnexus-dev emacs vim fonts-liberation \
+    python3-pip python3-dev jupyter && \
+    curl http://packages.mccode.org/debian/mccode.list > /etc/apt/sources.list.d/mccode.list      && \
+    apt update -y && apt install -y --no-install-recommends mcstas-suite-python mcstas-suite-perl && \
+    curl https://raw.githubusercontent.com/McStasMcXtrace/McCode/master/tools/Python/mcgui/mcgui.py >\
+    /usr/share/mcstas/2.6.1/tools/Python/mcgui/mcgui.py && \
+    curl https://raw.githubusercontent.com/McStasMcXtrace/McCode/master/tools/Python/mccodelib/mccode_config.py >\
+    /usr/share/mcstas/2.6.1/tools/Python/mccodelib/mccode_config.py && \
+    python3 -m pip install McStasScript --upgrade && \
+    curl https://raw.githubusercontent.com/McStasMcXtrace/McCode/master/Docker/mcstas/mcstasscript/mcstasscript-setup.py >\
+    /tmp/mcstasscript-setup.py         && \
+    python3 /tmp/mcstasscript-setup.py && \
+    python3 -m pip install jupyter     && \
+    # The following works around https://github.com/sphinx-doc/sphinx/issues/8198
+    python3 -m pip install pygments==2.6.1 && \
+    update-alternatives --install /bin/sh sh /bin/bash 200 && \
+    update-alternatives --install /bin/sh sh /bin/dash 100 && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV HOME /home/docker
+WORKDIR /home/docker
+
+RUN groupadd docker && useradd -m -g docker docker && \
+    mkdir /home/mcstasscript && \
+    cd /home/mcstasscript    && \
+    curl -O https://raw.githubusercontent.com/McStasMcXtrace/McCode/master/Docker/mcstas/mcstasscript/McStasScript_demo.ipynb && \
+    chown -R docker:docker /home/mcstasscript
+

--- a/Docker/mcstas/mcstasscript/build_podman.sh
+++ b/Docker/mcstas/mcstasscript/build_podman.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+containername="cloudbusting/mcstasscript:1.1"
+podman build -t $containername -f Dockerfile.podman .
+
+echo Build of $containername done.

--- a/Docker/mcstas/mcstasscript/podman_mcstasscript.sh
+++ b/Docker/mcstas/mcstasscript/podman_mcstasscript.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+containername="cloudbusting/mcstasscript"
+XSOCK=/tmp/.X11-unix
+
+DOCK_UID=$(id -u)
+DOCK_GID=$(id -g)
+
+export XAUTH=/tmp/.docker.xauth
+
+# Different handling of xauth and --dev on linux than macOS
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  export DEVICESTRING="--device /dev/dri"
+  export DISPLAYVAR=$DISPLAY
+  export DISPLAY_TO_USE=$DISPLAY
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  export DISPLAY_TO_USE=host.docker.internal:0
+  # Hack to start XQuartz without raising a host-based xterm
+  xhost > /dev/null
+fi
+
+xauth nlist $DISPLAYVAR | sed -e 's/^..../ffff/' | xauth -f ${XAUTH} nmerge -
+FAKE_HOME=$HOME/McStas-podman
+mkdir -p $FAKE_HOME
+podman run -ti -e QT_X11_NO_MITSHM=1 -e JUPYTER_RUNTIME_DIR=/tmp -v $XSOCK:$XSOCK -v XAUTH:$XAUTH -e DISPLAY:${DISPLAY_TO_USE} -v $FAKE_HOME:/home/docker:Z -e XAUTHORITY=$XAUTH $DEVICESTRING -p 8080:8080 $containername jupyter notebook --allow-root --no-browser --ip 0.0.0.0 --port 8080 /home/mcstasscript

--- a/Docker/mcstas/mcstasscript/podman_mcstasscript.sh
+++ b/Docker/mcstas/mcstasscript/podman_mcstasscript.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-containername="cloudbusting/mcstasscript"
+containername="cloudbusting/mcstasscript:1.1"
 XSOCK=/tmp/.X11-unix
 
 DOCK_UID=$(id -u)
 DOCK_GID=$(id -g)
 
-export XAUTH=/tmp/.docker.xauth
+export XAUTH=/tmp/.podman.xauth
 
 # Different handling of xauth and --dev on linux than macOS
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
@@ -13,12 +13,14 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   export DISPLAYVAR=$DISPLAY
   export DISPLAY_TO_USE=$DISPLAY
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-  export DISPLAY_TO_USE=host.docker.internal:0
+  echo "Currently not implemented on MacOS"
+  exit
+  #export DISPLAY_TO_USE=host.docker.internal:0
   # Hack to start XQuartz without raising a host-based xterm
-  xhost > /dev/null
+  #xhost > /dev/null
 fi
 
 xauth nlist $DISPLAYVAR | sed -e 's/^..../ffff/' | xauth -f ${XAUTH} nmerge -
 FAKE_HOME=$HOME/McStas-podman
 mkdir -p $FAKE_HOME
-podman run -ti -e QT_X11_NO_MITSHM=1 -e JUPYTER_RUNTIME_DIR=/tmp -v $XSOCK:$XSOCK -v XAUTH:$XAUTH -e DISPLAY:${DISPLAY_TO_USE} -v $FAKE_HOME:/home/docker:Z -e XAUTHORITY=$XAUTH $DEVICESTRING -p 8080:8080 $containername jupyter notebook --allow-root --no-browser --ip 0.0.0.0 --port 8080 /home/mcstasscript
+podman run -ti -e QT_X11_NO_MITSHM=1 -e JUPYTER_RUNTIME_DIR=/tmp -v $XSOCK:$XSOCK -v XAUTH:$XAUTH -e DISPLAY:${DISPLAY_TO_USE} -v $FAKE_HOME:/home/podman:Z -e XAUTHORITY=$XAUTH $DEVICESTRING -p 8080:8080 $containername jupyter notebook --allow-root --no-browser --ip 0.0.0.0 --port 8080 /home/mcstasscript


### PR DESCRIPTION
Dear maintainers,

For your consideration - a newer Dockerfile{.podman} and a slightly modified script to support `podman`, which is largely becoming the de-facto container engine (RHEL 8+).

This is work which originated from a WP5 Sprint of [PaNOSC ViNYL](https://github.com/PaNOSC-ViNYL/ViNYL-project), and perhaps is helpful to your project. I worked in collaboration with @mads-bertelsen.

Happy to discuss if necessary.

Cheers

Dan.