### PR TITLE
correct absorption cross-section

### DIFF
--- a/mcxtrace-comps/samples/Single_crystal.comp
+++ b/mcxtrace-comps/samples/Single_crystal.comp
@@ -742,6 +742,7 @@ SHARE
   struct sx_abs_data
   {
     int muc; /*column where mu is to be found*/
+    double atomic_weight;
     t_Table table;
   };
 
@@ -759,6 +760,12 @@ SHARE
       }else{
         abs->muc=5;
       }
+      
+      if(strlen(parsing[1])){
+        abs->atomic_weight=strtod(parsing[1],NULL);
+        printf("atomic_weight %g\n",abs->atomic_weight);
+      }      
+      
       Table_Stat(&(abs->table));
       if(10*(double)mcget_ncount()>(abs->table.max_x-abs->table.min_x)/(abs->table.step_x)){
         /*it is probably worth Rebinning*/
@@ -914,10 +921,20 @@ TRACE
     event_counter = 0;
       
     /*absorption cross-section */
-    do {
+    do { 
       double mu=Table_Value(abs_info.table,ki*K2E,abs_info.muc);
-      abs_xsect = hkl_info.sigma_a*mu;
-      /*assume the given sigma a is like taken from the NIST file*/
+      abs_xsect = (abs_info.atomic_weight/(6.02214076*10E23))*mu; //this is in cm^2: 
+      //atomic weight = [g . mol^-1]
+      //Avogadro number = [mol^-1]
+      //mu = [cm squared . g⁻1]
+      //therefore convert to barns if barns set to 1, otherwise to fm^2
+
+      if (barns) { //convert cm^2 into barns
+        abs_xsect *= 10E24; 
+      }
+      else {  //convert cm^2 into fm^2, else we assume fm^2
+        abs_xsect *= 10E26;
+      }      
     }while (0);
     V0= hkl_info.V0;
     abs_xlen  = abs_xsect/V0;


### PR DESCRIPTION
Changed the absorption cross-section to:

`(mu[cm^-1]/rho[g*cm^-3])*(ma[g*mol^-1]/NA[mol^-1]) = sigma[cm^2]`

See [here](https://en.wikipedia.org/wiki/Absorption_cross_section).