### PR TITLE
Grating_reflect fix and czerny_turner monoch

### DIFF
--- a/mcxtrace-comps/examples/Test_grating_reflect.instr
+++ b/mcxtrace-comps/examples/Test_grating_reflect.instr
@@ -1,0 +1,119 @@
+/*******************************************************************************
+*         McXtrace instrument definition URL=http://www.mcxtrace.org
+*
+* Instrument: Test_grating_reflect
+*
+* %Identification
+* Written by: Stephane Bac, Antoine Padovani
+* Date: Jul 21st 2022
+* Origin: Synchrotron Soleil
+* %INSTRUMENT_SITE: Tests
+*
+* Unit-test instrument for the Grating reflect component.
+*
+* Simply a bending magnet illuminating a reflection grating.
+*
+* %Parameters
+* E0: [keV] Source's center of emitted energy spectrum
+* dE: [keV] Source's half-width of emitted energy spectrum
+* angle_grating_norm: [deg.] Angle between the norm of the grating and the incident ray
+* number_lines_per_mm: Number of lines pr mm of the grating
+* order: The target order of the grating 
+* dphi: [deg.] Range of diffraction angle that is to be simulated -d_phi/2 ; d_phi/2
+*
+* %End
+*******************************************************************************/
+//n=1e8 rays is good for default values
+//Only for the trace viewer, (because one would need to change the monitors dimensions,dphi for a simulation to see the different orders) one can also try an angle_grating_norm of 8.6833 and -8.6833 with E0=0.00248, dE=0, number_lines_per_mm=1200, and order = 0, 1 or -1. These values are relevant for the czerny_turner monochromator
+DEFINE INSTRUMENT Test_grating_reflect(E0=1, dE=0.1, angle_grating_norm=88, number_lines_per_mm=100, order=0, dphi=1)
+
+DECLARE
+%{
+
+double period;
+double angle_order_grating;
+double sign;
+double angle_grating_norm_pos;
+
+%}
+
+INITIALIZE
+%{
+
+sign=1; //sign is here to take into account the ray arriving on the other side of the norm. Test angle_grating_norm=-88 for example.
+
+period = 1/(1e3*number_lines_per_mm);
+fprintf(stdout,"Grating period: %g \n", period);
+
+angle_grating_norm_pos = angle_grating_norm;
+
+if(angle_grating_norm<0){
+  angle_grating_norm_pos = -angle_grating_norm;
+  sign=-1;
+}
+
+angle_order_grating = RAD2DEG*asin(-(12.39842/(E0))/1e10*order/period+sin(DEG2RAD*angle_grating_norm_pos));
+fprintf(stdout,"Angle for order %g is %g degrees \n", order, angle_order_grating);
+
+%}
+
+TRACE
+
+COMPONENT origin = Progress_bar()
+AT (0, 0, 0) RELATIVE ABSOLUTE
+
+COMPONENT Source = Bending_magnet(
+    E0=E0,   
+    dE = dE,
+    B=1.72,
+    Ee=2.75
+    )
+AT (0, 0, 0) RELATIVE origin
+
+COMPONENT Grating_position = Arm()
+AT (0, 0, 844e-3) RELATIVE PREVIOUS	
+
+COMPONENT Grating_rotation = Arm()
+AT (0, 0, 0) RELATIVE PREVIOUS	
+ROTATED (-(90-angle_grating_norm), 0, 0) RELATIVE PREVIOUS	
+
+COMPONENT reflective_grating = Grating_reflect(
+    d_phi=dphi,order=order,
+    rho_l=number_lines_per_mm,
+    zdepth=102e-3,xwidth=102e-3)    
+AT (0, 0, 0) RELATIVE PREVIOUS
+ROTATED (0, 0, 0) RELATIVE PREVIOUS
+
+//4PI monitor for debugging purposes
+/*COMPONENT psd_monitor_4pi = PSD_monitor_4PI(
+filename="3D.dat",restore_xray=1)
+AT (0, 0, 0) RELATIVE PREVIOUS*/
+
+COMPONENT Mgrating_arm_back = Arm()
+AT (0,0,0) RELATIVE PREVIOUS
+ROTATED (sign*angle_order_grating, 0, 0) RELATIVE PREVIOUS
+
+COMPONENT Monitor_location = Arm()
+AT (0,749.1e-3,0) RELATIVE PREVIOUS
+ROTATED (90, 0, 0) RELATIVE PREVIOUS
+
+COMPONENT psd_mosnitor = PSD_monitor(
+    filename="psd", 
+    xmin=-0.01, 
+    xmax=0.01,
+    ymin=-0.01, 
+    ymax=0.01,             
+    nx=100,
+    ny=100,
+    restore_xray = 1
+    )
+AT (0, 0, 0) RELATIVE PREVIOUS
+
+COMPONENT psd_giant = PSD_monitor(xwidth=0.02, yheight=0.02, filename="psd_giant",ny=2000,nx=1)
+AT(0,0,0) RELATIVE PREVIOUS
+
+FINALLY
+%{
+%}
+
+END

--- a/mcxtrace-comps/examples/czerny_turner.instr
+++ b/mcxtrace-comps/examples/czerny_turner.instr
@@ -1,0 +1,281 @@
+/*******************************************************************************
+*         McXtrace instrument definition URL=http://www.mcxtrace.org
+*
+* Instrument: czerny_turner
+*
+* %Identification
+* Written by: Stephane Bac, Antoine Padovani
+* Date: Jul 21st 2022
+* Origin: Synchrotron Soleil
+* %INSTRUMENT_SITE: BARC
+*
+* Czerny-turner monochromator.
+*
+* This Czerny-turner monochromator was built from "Design and fabrication of a Czerny-Turner monochromator-cum-spectrograph" by
+* Murty, M.V.R.K.; Shukla, R.P.; Bhattacharya, S.S.; Krishnamurthy, G. (Bhabha Atomic Research Centre, Bombay (India). Spectroscopy Div.)
+* Bhabha Atomic Research Centre, Bombay (India)
+* 1987
+* It can be found here: https://inis.iaea.org/collection/NCLCollectionStore/_Public/19/019/19019134.pdf
+* Example: Do a scan (scan parameter =1) from x_screw=20 to 103 mm. The calculated monitor "Wavelength(Ang) as a function of x_screw(mm)" will be a linear function. The monochromator functions properly.
+*
+* %Parameters
+* x_screw: [mm] Displacement perpendicular to initial position of the lever (sine drive mechanism)
+* scan: [0 or 1] 1 is to activate wavelength monitor while scanning the x_screw parameter
+*
+* %End
+*******************************************************************************/
+
+DEFINE INSTRUMENT czerny_turner(x_screw=0, scan=0)
+
+DECLARE
+%{
+double E0;
+double dE;
+
+double grazing_angle_reflect_grating;
+
+double number_lines_per_mm; //Number of lines pr mm of the grating
+double grazing_angle_order_grating;
+double order;
+double period;
+
+double x_screw; //x_screw=L*sin(theta_calculated), L=164.61 and x_screw goes from 0 to 100 mm (0 to 10K Angstroms)
+double theta_calculated;
+
+double w_monitor_value;
+double x_screw_var;
+double w_monitor_error;
+double number_events_w_monitor;
+%}
+
+INITIALIZE
+%{
+
+//For 5k Ang, give a d_phi=0 to the grating to verify with the 3D views that the ray behaves correctly
+//E0=0.00248;
+//dE=0;
+
+//Our source range: 1.2 to 6.2 eV
+E0 = 0.0037;
+dE = 0.0025;
+
+number_lines_per_mm = 1200;
+
+theta_calculated = RAD2DEG*asin(x_screw/164.61);
+
+fprintf(stdout,"theta_calculated %g degrees, should be 17.6833 for x_screw 50 mm approximately \n", theta_calculated);
+
+order=1;
+
+if (theta_calculated<9){ //to take into account the ray arriving on the other side of the norm. The order 1 does not go towards the M2 when theta_calculated is inferior to 9 degrees, so 
+//better to be centered on the order -1.
+order=-1;
+}
+
+period = 1/(1e3*number_lines_per_mm);
+fprintf(stdout,"Grating period %g \n", period);
+
+
+//Information purposes only:
+//For 5K Angstroms (x_screw = 50 mm), the angle between the grating's norm and the incident ray arrives at 8.6833 degrees
+//and the angle between the grating's norm and the order m=1 is equal to 26.6833 deg
+//the angle between the incident ray and the order m=1 equals to 26.6833-8.6833 = 18 degrees (angle called phi)
+//we position the grating angle's norm on the bisector of phi
+//then a sine drive mechanism gives us a simple linear relation: lambda = 2*period*cos(pĥi)*x_screw/L
+//grazing_angle_reflect_grating = 90-8.6833;
+//grazing_angle_order_grating = RAD2DEG*acos(-(12.39842/(E0))/1e10*order/period+cos(DEG2RAD*grazing_angle_reflect_grating));
+//fprintf(stdout,"Grazing angle for order %g is %g degrees \n", order, grazing_angle_order_grating);
+
+%}
+
+TRACE
+
+COMPONENT origin = Progress_bar()
+AT (0, 0, 0) RELATIVE ABSOLUTE
+
+COMPONENT Source = Bending_magnet(
+    E0=E0,   
+    dE = dE,
+    B=1.72,
+    Ee=2.75
+    )
+AT (0, 0, 0) RELATIVE origin
+
+COMPONENT M1_position = Arm()
+AT (0, 0, 844e-3) RELATIVE PREVIOUS	
+
+COMPONENT M1_rotation = Arm()
+AT (0, 0, 0) RELATIVE PREVIOUS	
+ROTATED (0, 0, 90) RELATIVE PREVIOUS	
+
+COMPONENT mirror_m1 = Mirror_elliptic(
+    length=150e-3, 
+    width=150e-3,
+    x_a=1.025, 
+    y_b=1.025, 
+    z_c=1.025)
+AT (0, 0, 0) RELATIVE PREVIOUS
+ROTATED (-(90-4.5), 0, 0) RELATIVE PREVIOUS
+EXTEND
+%{ 
+	if (!SCATTERED) ABSORB;
+%}
+
+COMPONENT arm = Arm()
+AT (0, 0, 0) RELATIVE PREVIOUS
+ROTATED (-(90-4.5), 0, 0) RELATIVE PREVIOUS
+
+//rotate 90 back so our frame is normal again
+COMPONENT M1_arm_back = Arm()
+AT (0,0,0) RELATIVE PREVIOUS
+ROTATED (0, 0, -90) RELATIVE PREVIOUS
+
+COMPONENT Grating_position = Arm()
+AT (0, 0, 834.35e-3) RELATIVE PREVIOUS	
+
+COMPONENT Grating_rotation = Arm()
+AT (0, 0, 0) RELATIVE PREVIOUS	
+ROTATED (-90, 0, 0) RELATIVE PREVIOUS	
+
+COMPONENT Grating_rotation_lines_grating = Arm()
+AT (0, 0, 0) RELATIVE PREVIOUS	
+ROTATED (0, -90, 0) RELATIVE PREVIOUS	
+
+COMPONENT Grating_rotation_nine_degrees = Arm()
+AT (0, 0, 0) RELATIVE PREVIOUS	
+ROTATED (-9, 0, 0) RELATIVE PREVIOUS	
+
+COMPONENT reflective_grating = Grating_reflect(
+    d_phi=1,order=order,
+    rho_l=number_lines_per_mm,
+    zdepth=102e-3,xwidth=102e-3)    
+AT (0, 0, 0) RELATIVE PREVIOUS
+ROTATED (theta_calculated, 0, 0) RELATIVE PREVIOUS //theta_calculated will change, angle between the bisector of phi and the grating's norm
+
+//4PI monitor for debugging purposes
+//COMPONENT psd_monitor_4pi = PSD_monitor_4PI(
+//filename="3D.dat",restore_xray=1)
+//AT (0, 0, 0) RELATIVE PREVIOUS
+
+COMPONENT Grating_rotation_lines_grating_back = Arm()
+AT (0, 0, 0) RELATIVE PREVIOUS	
+ROTATED (0, 90, 0) RELATIVE PREVIOUS
+
+//rotate 90 back so our frame is normal again
+COMPONENT Grating_arm_back = Arm()
+AT (0,0,0) RELATIVE PREVIOUS
+ROTATED (90, 0, 0) RELATIVE PREVIOUS
+
+COMPONENT Grating_arm_back_2 = Arm()
+AT (0,0,0) RELATIVE PREVIOUS
+ROTATED (0, 180, 0) RELATIVE PREVIOUS
+
+COMPONENT Grating_arm_back_3 = Arm()
+AT (0,0,0) RELATIVE PREVIOUS
+ROTATED (0, -theta_calculated-9, 0) RELATIVE PREVIOUS
+
+COMPONENT M2_location = Arm()
+AT (0,0,749.1e-3) RELATIVE PREVIOUS
+
+COMPONENT M2_rotated = Arm()
+AT (0,0,0) RELATIVE PREVIOUS
+ROTATED (0,0,90) RELATIVE PREVIOUS
+
+COMPONENT mirror_m2 = Mirror_elliptic(
+    length=150e-3, 
+    width=150e-3,
+    x_a=0.925, 
+    y_b=0.925, 
+    z_c=0.925)
+AT (0, 0, 0) RELATIVE PREVIOUS
+ROTATED (-(90-5), 0, 0) RELATIVE PREVIOUS
+EXTEND
+%{ 
+	if (!SCATTERED) ABSORB;
+%}
+
+COMPONENT arm2 = Arm()
+AT (0, 0, 0) RELATIVE PREVIOUS
+ROTATED (-(90-5), 0, 0) RELATIVE PREVIOUS
+
+//rotate 90 back so our frame is normal again
+COMPONENT M4_arm_back = Arm()
+AT (0,0,0) RELATIVE PREVIOUS
+ROTATED (0, 0, -90) RELATIVE PREVIOUS
+
+//4PI monitor for debugging purposes
+//COMPONENT psd_monitor_4pi_2 = PSD_monitor_4PI(
+//filename="3D2.dat",restore_xray=1)
+//AT (0, 0, 0) RELATIVE PREVIOUS
+
+COMPONENT arm3 = Arm()
+AT (0, 0, 760.33e-3) RELATIVE PREVIOUS
+ROTATED (0, 0, 0) RELATIVE PREVIOUS
+
+COMPONENT arm4 = Arm()
+AT (0, 0, 0) RELATIVE PREVIOUS
+ROTATED (0, 0, 0) RELATIVE PREVIOUS 
+
+COMPONENT slit = Slit(
+    xwidth=13.5e-6, 
+    yheight=0.01)
+AT (0, 0, 0) RELATIVE PREVIOUS
+
+COMPONENT psd_monitor = PSD_monitor(
+    filename="psd", 
+    xmin=-0.01, 
+    xmax=0.01,
+    ymin=-0.01, 
+    ymax=0.01,             
+    nx=100,
+    ny=100,
+    restore_xray = 1
+    )
+AT (0, 0, 10e-3) RELATIVE PREVIOUS
+
+COMPONENT psd_giant_after_grating = PSD_monitor(xwidth=1e-2, yheight=1e-2, filename="psd_giant_after_grating",nx=2001,ny=1)
+AT(0,0,0) RELATIVE PREVIOUS
+
+COMPONENT e_monitor = Monitor_nD(
+  xwidth=1e-2, yheight=1e-2, options="energy  bins=500 limits=[0 0.007],  x  bins=500", filename="e_monitor",restore_xray = 1) 
+AT (0,0,0) RELATIVE PREVIOUS
+
+COMPONENT w_monitor = Monitor_nD(
+  xwidth=1e-2, yheight=1e-2, options="wavelength  bins=500 limits=[1980 11000],  x  bins=500", filename="w_monitor",restore_xray = 1) 
+AT (0,0,0) RELATIVE PREVIOUS
+
+FINALLY
+%{
+    // If there is a scan, calculate the Wavelength(Angstroms) as a function of x_screw(mm).
+    if(scan>=1){ 
+#ifdef USE_MPI
+        //MPI_MASTER is equivalent to if(mpi_node_root>=mpi_node_rank){ //statement }
+        //If DETECTOR_OUT_0D is inside of MPI_MASTER the program hangs forever. 
+        //If outside it seems to work. Weird.
+        MPI_MASTER(
+#endif
+        MCDETECTOR w_monitor_var = MC_GETPAR(w_monitor,detector); // We have to think in terms of wavelength, the sine drive mechanism was built to linearize the wavelength.
+        w_monitor_value = w_monitor_var.centerX;
+        x_screw_var = x_screw;
+        w_monitor_error = 0; //Forgot how to get rid of the error bar.  
+        //For the error we could have dlambda = lambda*2*period*cos(phi)/L*dx_screw/x_screw, but we need to have dx_screw. Does it make sense for dx_screw to exist in an exact simulation?
+        number_events_w_monitor = w_monitor_var.events;   
+                                                 
+#ifdef USE_MPI                  
+        );
+        //MPI_Barrier(MPI_COMM_WORLD);
+#endif  
+        //Adding a legend to the graph would be good, need to find out how to do that at a later date. todo            
+        // This set of defines is to avoid getting a '.' in the component name
+        #ifdef NAME_CURRENT_COMP
+        #undef NAME_CURRENT_COMP
+        #define NAME_CURRENT_COMP "Wavelength"
+        #endif
+                  
+        DETECTOR_OUT_0D(
+                  "Wavelength(Ang) as a function of x_screw(mm)",
+                  number_events_w_monitor, w_monitor_value, w_monitor_error);                  
+    }
+%}
+
+END

--- a/mcxtrace-comps/optics/Grating_reflect.comp
+++ b/mcxtrace-comps/optics/Grating_reflect.comp
@@ -14,6 +14,7 @@
 * Date: June 2021
 * Version: 1.6
 * Origin: DTU
+* Modified by: Padovani Antoine, Bac Stephane, 21st July 2022.
 *
 * A reflective grating.
 *
@@ -21,7 +22,7 @@
 * A reflective grating that diffracts incident photons. 
 * The grating is in the XZ-plane. It then reflects the incoming photon using a MC picked angle, 
 * where the angle is picked from a uniform distribution of width d_phi, i.e. U[-d_phi/2,d_phi/2]
-* The Monte Carlo wight of the ray is then adjusted wrt. to the grating interference pattern, and
+* The Monte Carlo weight of the ray is then adjusted wrt. to the grating interference pattern, and
 * the diffraction pattern associated with each grating line. All lines are considered equal.
 * For more efficient sampling of a particular direction the centre of the d_phi may be shifted
 * using the parameters order or phi0. In the latter case a set angle is chosen as the centre of the
@@ -53,6 +54,10 @@ SETTING PARAMETERS (d_phi=1, R0=1, rho_l=800,
 OUTPUT PARAMETERS (d,pdir,b,nslits)
 /* X-ray parameters: (x,y,z,kx,ky,kz,phi,t,Ex,Ey,Ez,p) */
 
+SHARE
+%{
+  %include "read_table-lib"
+%}
 
 /********************************************************************************************
 In DECLARE section, small functions or variables can be defined and used in the entire grating.
@@ -109,6 +114,7 @@ TRACE
   }else{
     double nx,ny,nz;
     double Gamma,gamma,psi_i,psi_o,spsi_i,spsi_o;
+    double kx_notouch,ky_notouch,kz_notouch;    
     double delta_theta,pdiff;
     /* Normal vector for the grating*/
     nx=0;
@@ -119,7 +125,7 @@ TRACE
     double k=sqrt(scalar_prod(kx,ky,kz,kx,ky,kz));
     /* Outgoing grazing angle for a perfectly reflecting mirror using angle between two vectors.*/
     psi_i = acos(s/k)-M_PI_2;
-
+    
     /* outgoing vector for a perfectly reflecting mirror. Order 0.*/
     kx=kx-2*s*nx;
     ky=ky-2*s*ny;
@@ -135,17 +141,43 @@ TRACE
     /* Lamellar grating is used.
          Thus finding outgoing angle only from ingoing angle.
          using old k and n and rotation matrix.*/
-    beta=asin(order*(2*M_PI/k)/d-sin(alpha));
+    beta=asin(-order*(2*M_PI/k)/d+sin(alpha));
+    //Could have also used an angle convention where the angle between the grating's norm and the ray of order m is positive if it is on the samer side as the incident angle, negative otherwise.
     if(phi0){
       /*a target angle is specified*/
       psi_o=phi0*DEG2RAD;
     }else{
       psi_o=M_PI_2-fabs(beta);/*the fabs is necessary due to the sign convention of beta*/
     }
-    kx=kx;
-    ky=(ky*cos(-(psi_o-psi_i) + delta_theta) - kz*sin( -(psi_o-psi_i) + delta_theta));
-    kz=(ky*sin(-(psi_o-psi_i) + delta_theta) + kz*cos( -(psi_o-psi_i) + delta_theta));
 
+    kx_notouch=kx;
+    ky_notouch=ky;
+    kz_notouch=kz;
+              
+    kx=kx_notouch;
+    
+    //Still need to take into account the case where the incident ray does not hit perpendicular to the grating
+    if(beta>=0){
+        if(kz>=0){
+            ky=(ky_notouch*cos(-(psi_o-psi_i) + delta_theta) - kz_notouch*sin(-(psi_o-psi_i) + delta_theta)); 
+            kz=(ky_notouch*sin(-(psi_o-psi_i) + delta_theta) + kz_notouch*cos(-(psi_o-psi_i) + delta_theta));
+        }
+        else{
+            ky=(ky_notouch*cos((psi_o-psi_i) + delta_theta) - kz_notouch*sin((psi_o-psi_i) + delta_theta)); 
+            kz=(ky_notouch*sin((psi_o-psi_i) + delta_theta) + kz_notouch*cos((psi_o-psi_i) + delta_theta));
+        }
+    }
+    else{
+        if(kz>=0){
+            ky=(ky_notouch*cos((-2*alpha+(psi_o-psi_i)) + delta_theta) - kz_notouch*sin((-2*alpha+(psi_o-psi_i)) + delta_theta));
+            kz=(ky_notouch*sin((-2*alpha+(psi_o-psi_i)) + delta_theta) + kz_notouch*cos((-2*alpha+(psi_o-psi_i)) + delta_theta));
+        }
+        else{
+            ky=(ky_notouch*cos((2*alpha-(psi_o-psi_i)) + delta_theta) - kz_notouch*sin((2*alpha-(psi_o-psi_i)) + delta_theta));
+            kz=(ky_notouch*sin((2*alpha-(psi_o-psi_i)) + delta_theta) + kz_notouch*cos((2*alpha-(psi_o-psi_i)) + delta_theta));
+        }   
+    }
+    
     /*Finding the weight using diffraction theory.*/ 
     s=scalar_prod(kx,ky,kz,nx,ny,nz);
     psi_o = acos(s/k)-M_PI_2;


### PR DESCRIPTION
This is an initial fix of the Grating_reflect.comp component.
Will still need to take into account the case where the incident ray does not hit the grating in a perpendicular fashion.
Added is a test for the component.

Also added is a Czerny-turner monochromator based on [this](https://inis.iaea.org/collection/NCLCollectionStore/_Public/19/019/19019134.pdf).
Here is a [picture](https://imgur.com/a/jdMN11n) of a monitor that shows the Wavelength(Ang) as a function of x_screw(mm). To obtain it simply have the scan parameter be equal to 1 and scan from x_screw=20 to 103 mm in the Czerny-turner instrument.