### PR TITLE
Internal accessors

### DIFF
--- a/common/lib/share/mccode-r.h.in
+++ b/common/lib/share/mccode-r.h.in
@@ -362,6 +362,8 @@ char  *mcsig_message;
 /* the body of this function depends on component instances, and is cogen'd */
 void* _getvar_parameters(char* compname);
 
+int _getcomp_index(char* compname);
+
 /* Note: The two-stage approach to COMP_GETPAR is NOT redundant; without it,
 * after #define C sample, COMP_GETPAR(C,x) would refer to component C, not to
 * component sample. Such are the joys of ANSI C.

--- a/mcstas/src/cogen.c.in
+++ b/mcstas/src/cogen.c.in
@@ -995,6 +995,27 @@ void cogen_getvarpars_fct(struct instr_def *instr)
   cout("");
 }
 
+/*
+ * Generates the function that returns the index of a named component or -1 if 
+ * it does not exist in the instrument
+ */
+void cogen_getcompindex_fct(struct instr_def *instr){
+  cout("int _getcomp_index(char* compname)");
+  cout("/* Enables retrieving the component position & rotation when the index is not known.");
+  cout(" * Component indexing into MACROS, e.g., POS_A_COMP_INDEX, are 1-based! */");
+  cout("{");
+  List_handle iter;
+  iter = list_iterate(instr->complist);
+  struct comp_inst *comp;
+  int index=1;
+  while ((comp = list_next(iter)) != NULL) {
+    coutf("  if (!strcmp(compname, \"%s\")) return %i;", comp->name, index++);
+  }
+  cout("  return -1;");
+  cout("}");
+  cout("");
+}
+
 /*******************************************************************************
 * Generates the function that returns a particle var ptr of type void*,
 * based on the variable name as a string.
@@ -2337,6 +2358,25 @@ cogen_header(struct instr_def *instr, char *output_name)
   cout("  return rval;");
   cout("}");
   cout("");
+  
+  liter = list_iterate(instr->user_vars);
+  cout("#pragma acc routine");
+  cout("int particle_setvar(_class_particle *, char *, double);");
+  cout("");
+  cout("int particle_setvar(_class_particle *p, char *name, double value){");
+  cout("#ifndef OPENACC");
+  cout("#define str_comp strcmp");
+  cout("#endif");
+  cout("  int rval=1;");
+  char *invar;
+  while((invar = list_next(liter))) {
+    coutf("  if(!str_comp(\"%s\",name)){p->%s = value; rval = 0;}",invar,invar);
+  }
+  list_iterate_end(liter);
+  cout("  return rval;");
+  cout("}");
+  cout("");
+  
 
   liter = list_iterate(instr->user_vars);
   cout("#pragma acc routine");
@@ -2714,7 +2754,7 @@ cogen(char *output_name, struct instr_def *instr)
   // API macro support functions
   cogen_getvarpars_fct(instr);
   cogen_getparticlevar_fct(instr);
-
+  cogen_getcompindex_fct(instr);
 
   embed_file("mccode_main.c");
 

--- a/tools/Python/mccodelib/pqtgfrontend.py
+++ b/tools/Python/mccodelib/pqtgfrontend.py
@@ -77,8 +77,8 @@ def create_plotwindow(title):
     
     # window size
     rect = QtGui.QApplication.desktop().screenGeometry()
-    w = 0.7 * rect.width()
-    h = 0.7 * rect.height()
+    w = int(0.7 * rect.width())
+    h = int(0.7 * rect.height())
     mw.resize(w, h)
     
     global g_window
@@ -381,7 +381,7 @@ def add_plot(layout, node, plot_node_func, i, n, viewmodel):
     options = get_plot_func_opts(viewmodel.logstate(), viewmodel.legendstate(), viewmodel.cmapindex(), verbose, fontsize, cbmin, cbmax)
     view_box, plt_itm = plot_node_func(node, i, plt, options)
     if (view_box):
-        layout.addItem(plt_itm, i / rowlen, i % rowlen)
+        layout.addItem(plt_itm, i // rowlen, i % rowlen)
     
     return view_box
 

--- a/tools/Python/mcgui/viewclasses.py
+++ b/tools/Python/mcgui/viewclasses.py
@@ -789,7 +789,7 @@ class McStartSimDialog(QtWidgets.QDialog):
 
             i = i + 1
             x = i % (int(mccode_config.configuration["GUICOLS"])*2)
-            y = i / (int(mccode_config.configuration["GUICOLS"])*2)
+            y = i // (int(mccode_config.configuration["GUICOLS"])*2)
 
             lbl = QtWidgets.QLabel(self.ui.gbxGrid)
             lbl.setAlignment(QtCore.Qt.AlignRight|QtCore.Qt.AlignTrailing|QtCore.Qt.AlignVCenter)


### PR DESCRIPTION
## Add new functionality
### Construct a component-name lookup table to identify `instrument` components
If two components rely upon each other, it may be useful to allow one to access properties of the other *including its position and orientation*. This functionality already exists via, e.g., the `POS_A_COMP_INDEX` macro and its friends, but it requires that the *entry-ordered* index for the target component be provided. Some components, like the `Source _simple`, use this machinery to determine the position and extent of *nearby* components, e.g., the **next** component, `INDEX_CURRENT_COMP+1`.
This machinery becomes cumbersome, however, if there are large number of components or the distance between components is large, since the possibility of counting errors scales with the number.

Instead a new mechanism, `_getcomp_index`, is provided to component authors which takes a component name and returns an integer appropriate to be used with `POS_A_COMP_INDEX` and the like.
Since component names must be unique, the returned number is therefore also unique.
A component that uses this functionality can therefore allow users the ease of providing a targeted-component *name* instead of needing to accurately count the possibly-changing number of components between the current and target components.

### Set particle parameters
Instruments can define `USERVARS` which are appended to the properties of the `_class_particle` struct. These properties can easily be retrieved in a component via the `particle_getvar` routine, but there is no straightforward way for a component to *set* the particle user properties. 

A new function, `particle_setvar`, is provided to remedy this issue. It requires that each user property be *assignable* from a `double` value passed-in, and therefore the thus-used `USERVARS` should **probably** *be* `double` valued.
In contrast to the variable retrieval routine, setting is limited to *only* the user-defined particle parameters.

## Fix floating point API errors
I have run-across two additional places in the Python code where integer values are expected by floating point values are provided. This PR fixes the two new issues in addition to (at least partly) addressing #1270. 