### PR TITLE
Support CMD() and ENV() in DEPENDENCY lines

### DIFF
--- a/tools/Python/mccodelib/cflags.py
+++ b/tools/Python/mccodelib/cflags.py
@@ -1,0 +1,88 @@
+'''
+Utility function for handling flexible DEPENDENCY lines.
+'''
+import os
+import subprocess
+
+def evaluate_dependency_str( depstr, verbose=False ):
+    """Evaluates CMD() and ENV() parts of DEPENDENCY (a.k.a. "CFLAGS")
+    strings.
+
+    If neither "CMD(" or "ENV(" is found in the input string, the input
+    string will always be returned completely unchanged!
+
+    Input can either be bytes or str objects, and an object of the same type
+    will be returned.
+
+    The current implementation does not support usage of parentheses inside the
+    CMD(..) and ENV(..) blocks, nor nesting of these apart from the fact that
+    ENV(..) blocks can be used inside CMD(..) blocks.
+
+    """
+    #Make sure we can handle both raw bytes and str objects. We assume utf8 is
+    #sufficient for when we might have to convert output of environment
+    #variables or commands.:
+    is_bytes = lambda x : hasattr(x,'decode')
+    use_bytes = is_bytes( depstr )
+    if use_bytes:
+        to_target_fmt = lambda x : ( x if is_bytes(x) else x.encode() )
+    else:
+        to_target_fmt = lambda x : ( x if not is_bytes(x) else x.decode() )
+
+    s_ev = to_target_fmt('ENV(')
+    s_cmd = to_target_fmt('CMD(')
+
+    if not s_ev in depstr and not s_cmd in depstr:
+        return depstr #<--- early exit for most callers
+
+    as_str = lambda s : ( s.decode() if hasattr(s,'decode') else s )
+    s_endparan = to_target_fmt(')')
+
+    def evalmarker( s, startmarker, evalfct ):
+        if not startmarker in s:
+            return s
+        before, ca = s.split(startmarker,1)
+        if not s_endparan in ca:
+            raise ValueError( 'Missing closing parenthesis in dependency '
+                              +f'string after opening "{as_str(startmarker)}"' )
+        content, after = ca.split(s_endparan,1)
+        if startmarker in content:
+            raise ValueError( f'Must close one "{as_str(startmarker)}..)"'
+                              + ' before opening a new one.' )
+        return before + evalfct(content) + evalmarker(after,startmarker,evalfct)
+
+    def evalfct_env(s):
+        ev=as_str(s.strip())
+        val=os.environ.get(ev,'')
+        if verbose:
+            print(f"   --> resolving env var {ev} to {val}")
+        return to_target_fmt(val)
+
+    def evalfct_cmd(s):
+        cmd = as_str(s)
+        errmsg = lambda : f'Errors encountered while executing cmd: {cmd}'
+        try:
+            if verbose:
+                print(f"   --> launching cmd: {cmd}")
+            returncode = 1
+            with subprocess.Popen( cmd,
+                                   shell=True,
+                                   stdout=subprocess.PIPE,
+                                   stderr=subprocess.PIPE ) as proc:
+                output = proc.communicate()[0]
+                returncode = proc.returncode
+        except:
+            print(errmsg())
+            raise
+        if returncode != 0:
+            raise RuntimeError(errmsg())
+        #discard empty lines in output, requiring at most one line with content:
+        lines = [ e.strip() for e in as_str(output).splitlines() if e.strip() ]
+        if len(lines)>1:
+            raise RuntimeError(f'Command produced more than a single line of output: {cmd}')
+        return to_target_fmt(lines[0]) if lines else ''
+
+    s = evalmarker( depstr, s_ev, evalfct_env )
+    s = evalmarker( s, s_cmd, evalfct_cmd )
+    assert use_bytes == is_bytes(s)
+    return s

--- a/tools/Python/mcrun/mccode.py
+++ b/tools/Python/mcrun/mccode.py
@@ -13,7 +13,7 @@ from decimal import Decimal
 import sys
 sys.path.append(join(dirname(__file__), '..'))
 from mccodelib import mccode_config
-
+import mccodelib.cflags
 
 from log import getLogger
 LOG = getLogger('mcstas')
@@ -171,7 +171,10 @@ class McStas:
             line = re.sub(r'\\','/', line)
             if re.search('CFLAGS=', line) :
                 label,flags = line.split('=',1)
-                     
+
+                #Support CMD(..) and ENV(..) in cflags:
+                flags = mccodelib.cflags.evaluate_dependency_str( flags )
+
                 flags = re.sub(r'\@MCCODE_LIB\@', re.sub(r'\\','/', MCCODE_LIB), flags)
                 flags = flags.split(' ')
                 cflags += flags


### PR DESCRIPTION
As discussed with @willend, this PR injects a bit of dynamic features into the `DEPENDENCY` lines by introducing support for using environment variables or the output of commands via the keywords `CMD(..)` and `ENV(..)`. So for instance one might have dependency lines like:

```c
DEPENDENCY "-LENV(FOOLIBDIR) -lfoo"
DEPENDENCY "CMD(foo-config --cflags) CMD(foo-config --ldflags)"
DEPENDENCY "CMD(ENV(FOOPREFIX)/bin/foo-config --flags)"
```
Note that as the last example shows, one can use ENV(..) inside CMD(..), but apart from that there is no nesting allowed.

The immediate motivation for this feature is to make it easier to support usage of external projects such as NCrystal, where we would use the `ncrystal-config` script to query for the necessary flags. Thus, a user would merely need to activate a different NCrystal installation in order to make it the one used with the two McStas components which use NCrystal. That would do away with the need for my hacky workaround with the `ncrystal_preparemcstasdir` script which currently works for `NCrystal_sample.comp` but not the NCrystal process in McStas Union geometries. Hopefully it might find other uses as well down the line.

Concerning the details of my implementation, it is basically adding a new function, `evaluate_dependency_str` which parses a dependency string and as needed looks up environment variables (in os.environ) or runs commands via the subprocess module (capturing its stdout+stderr), and returns the final string after inserting the results. It is considered an error if an invoked command produces more than one non-empty line of text. The function handles both `str` and `bytes` types of arguments, and of course use the same type for the returned result. As a safety, the function immediately returns the argument unchanged if it finds neither `CMD(` or `ENV(` anywhere in the string. So hopefully it should be very unlikely that this introduces any unexpected problems on components not actually using these new features (which for now is all of the components).

As agreed, the feature is not added to the legacy-perl code. So in the future any McStas+NCrystal users who need to stick to the legacy-perl code will have to hack their DEPENDENCY lines manually.

To keep `tools/Python/mcrun/mccode.py` tidy, I added the new function in a new module `tools/Python/mccodelib/cflags.py`. If you instead wish me to add the function to `mccode.py` or in another existing module, just let me know and I will update the PR.
