### PR TITLE
[Add] UNSET macro to create special NaN

### DIFF
--- a/common/lib/share/mccode-r.c
+++ b/common/lib/share/mccode-r.c
@@ -117,6 +117,21 @@ size_t str_len(const char *s)
 
 #endif
 
+/* SECTION: Predefine (component) parameters ================================= */
+
+int nans_match(double a, double b){
+  return (*(uint64_t*)&a == *(uint64_t*)&b);
+}
+int is_unset(double x){
+  return nans_match(x, UNSET);
+}
+int is_set(double x){
+  return !nans_match(x, UNSET);
+}
+int is_valid(double x){
+  return !isnan(x)||is_unset(x);
+}
+
 
 /* SECTION: Dynamic Arrays ================================================== */
 IArray1d create_iarr1d(int n){

--- a/common/lib/share/mccode-r.c
+++ b/common/lib/share/mccode-r.c
@@ -131,6 +131,38 @@ int is_set(double x){
 int is_valid(double x){
   return !isnan(x)||is_unset(x);
 }
+int all_unset(int n, ...){
+  va_list ptr;
+  va_start(ptr, n);
+  int ret=1;
+  for (int i=0; i<n; ++i) if(is_set(va_arg(ptr, double))) ret=0;
+  va_end(ptr);
+  return ret;
+}
+int all_set(int n, ...){
+  va_list ptr;
+  va_start(ptr, n);
+  int ret=1;
+  for (int i=0; i<n; ++i) if(is_unset(va_arg(ptr, double))) ret=0;
+  va_end(ptr);
+  return ret;
+}
+int any_unset(int n, ...){
+  va_list ptr;
+  va_start(ptr, n);
+  int ret=0;
+  for (int i=0; i<n; ++i) if(is_unset(va_arg(ptr, double))) ret=1;
+  va_end(ptr);
+  return ret;
+}
+int any_set(int n, ...){
+  va_list ptr;
+  va_start(ptr, n);
+  int ret=0;
+  for (int i=0; i<n; ++i) if(is_set(va_arg(ptr, double))) ret=1;
+  va_end(ptr);
+  return ret;
+}
 
 
 /* SECTION: Dynamic Arrays ================================================== */

--- a/common/lib/share/mccode-r.h.in
+++ b/common/lib/share/mccode-r.h.in
@@ -362,6 +362,10 @@ int nans_match(double, double);
 int is_unset(double);
 int is_valid(double);
 int is_set(double);
+int all_unset(int n, ...);
+int all_set(int n, ...);
+int any_unset(int n, ...);
+int any_set(int n, ...);
 
 
 /* wrapper to get absolute and relative position of comp */

--- a/common/lib/share/mccode-r.h.in
+++ b/common/lib/share/mccode-r.h.in
@@ -357,6 +357,13 @@ char  *mcsig_message;
 #define NA       6.02214179e23     /* [#atoms/g .mole] Avogadro's number*/
 
 
+#define UNSET nan("0x6E6F74736574")
+int nans_match(double, double);
+int is_unset(double);
+int is_valid(double);
+int is_set(double);
+
+
 /* wrapper to get absolute and relative position of comp */
 /* mccomp_posa and mccomp_posr are defined in McStas generated C code */
 #define POS_A_COMP_INDEX(index) (instrument->_position_absolute[index])

--- a/mcstas-comps/optics/Slit.comp
+++ b/mcstas-comps/optics/Slit.comp
@@ -61,18 +61,16 @@ void slit_warning_if(int condition, char* message, char* component){
 %}
 INITIALIZE
 %{
-r2 = 0;
-
 if (is_unset(radius)){
-  if (is_set(xwidth) && is_set(xmin) && is_set(xmax)){
+  if (all_set(3, xwidth, xmin, xmax)){
     slit_error_if(xwidth != xmax - xmin, "specifying xwidth, xmin and xmax requires consistent parameters", NAME_CURRENT_COMP);
   } else {
-    slit_error_if(is_unset(xwidth) && (is_unset(xmin) || is_unset(xmax)), "specify either xwidth or xmin & xmax", NAME_CURRENT_COMP);
+    slit_error_if(is_unset(xwidth) && any_unset(2, xmin, xmax), "specify either xwidth or xmin & xmax", NAME_CURRENT_COMP);
   }
-  if (is_set(yheight) && is_set(ymin) && is_set(ymax)){
+  if (all_set(3, yheight, ymin, ymax)){
     slit_error_if(yheight != ymax - ymin, "specifying yheight, ymin and ymax requires consistent parameters", NAME_CURRENT_COMP);
   } else {
-    slit_error_if(is_unset(yheight) && (is_unset(ymin) || is_unset(ymax)), "specify either yheight or ymin & ymax", NAME_CURRENT_COMP);
+    slit_error_if(is_unset(yheight) && any_unset(2, ymin, ymax), "specify either yheight or ymin & ymax", NAME_CURRENT_COMP);
   }
   if (is_unset(xmin)) { // xmax also unset but xwidth *is* set
     xmax = xwidth/2;
@@ -84,7 +82,7 @@ if (is_unset(radius)){
   }
   slit_warning_if(xmin == xmax || ymin == ymax, "Running with CLOSED rectangular slit - is this intentional?", NAME_CURRENT_COMP);
 } else {
-  slit_error_if(is_set(xwidth) || is_set(yheight) || is_set(xmin) || is_set(ymin) || is_set(xmax) || is_set(ymax),
+  slit_error_if(any_set(6, xwidth, xmin, xmax, yheight, ymin, ymax), 
                 "specify radius OR width and height parameters", NAME_CURRENT_COMP);
   slit_warning_if(radius == 0., "Running with CLOSED radial slit - is this intentional?", NAME_CURRENT_COMP);
 }

--- a/mcstas-comps/optics/Slit.comp
+++ b/mcstas-comps/optics/Slit.comp
@@ -103,7 +103,7 @@ TRACE
 MCDISPLAY
 %{
   
-  if (r2 == 0) {
+  if (is_unset(radius)) {
     double xw, yh;
     xw = (xmax - xmin)/2.0;
     yh = (ymax - ymin)/2.0;

--- a/mcstas-comps/optics/Slit.comp
+++ b/mcstas-comps/optics/Slit.comp
@@ -28,7 +28,7 @@
 * %P
 * INPUT PARAMETERS
 *
-* radius: [m]   Radius of slit in the z=0 plane, centered at Origo 
+* radius: [m]   Radius of slit in the z=0 plane, centered at Origin
 * xmin: [m]     Lower x bound 
 * xmax: [m]     Upper x bound 
 * ymin: [m]     Lower y bound 
@@ -43,44 +43,67 @@
 
 DEFINE COMPONENT Slit
 DEFINITION PARAMETERS ()
-  SETTING PARAMETERS (xmin=0, xmax=0, ymin=0, ymax=0, radius=0, xwidth=0, yheight=0)
+  SETTING PARAMETERS (xmin=UNSET, xmax=UNSET, ymin=UNSET, ymax=UNSET, radius=UNSET, xwidth=UNSET, yheight=UNSET)
 OUTPUT PARAMETERS ()
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */
+SHARE
+%{
+void slit_print_if(int condition, char* level, char* message, char* component){
+  if (condition) fprintf(stderr, "Slit: %s: %s: %s\n", component, level, message);
+} 
+void slit_error_if(int condition, char* message, char* component){
+  slit_print_if(condition, "Error", message, component);
+  if (condition) exit(-1);
+}
+void slit_warning_if(int condition, char* message, char* component){
+  slit_print_if(condition, "Warning", message, component);
+}
+%}
 INITIALIZE
 %{
-if (xwidth > 0)  { 
-  if (!xmin && !xmax) {
-    xmax=xwidth/2;  xmin=-xmax;
+r2 = 0;
+
+if (is_unset(radius)){
+  if (is_set(xwidth) && is_set(xmin) && is_set(xmax)){
+    slit_error_if(xwidth != xmax - xmin, "specifying xwidth, xmin and xmax requires consistent parameters", NAME_CURRENT_COMP);
   } else {
-    fprintf(stderr,"Slit: %s: Error: please specify EITHER xmin & xmax or xwidth\n", NAME_CURRENT_COMP); exit(-1);
+    slit_error_if(is_unset(xwidth) && (is_unset(xmin) || is_unset(xmax)), "specify either xwidth or xmin & xmax", NAME_CURRENT_COMP);
   }
- }
- if (yheight > 0) { 
-   if (!ymin && !ymax) {
-     ymax=yheight/2; ymin=-ymax; 
-   } else {
-     fprintf(stderr,"Slit: %s: Error: please specify EITHER ymin & ymax or ywidth\n", NAME_CURRENT_COMP); exit(-1);
-   }
- }
- if (xmin == 0 && xmax == 0 && ymin == 0 && ymax == 0 && radius == 0)
-    { fprintf(stderr,"Slit: %s: Warning: Running with CLOSED slit - is this intentional?? \n", NAME_CURRENT_COMP); }
+  if (is_set(yheight) && is_set(ymin) && is_set(ymax)){
+    slit_error_if(yheight != ymax - ymin, "specifying yheight, ymin and ymax requires consistent parameters", NAME_CURRENT_COMP);
+  } else {
+    slit_error_if(is_unset(yheight) && (is_unset(ymin) || is_unset(ymax)), "specify either yheight or ymin & ymax", NAME_CURRENT_COMP);
+  }
+  if (is_unset(xmin)) { // xmax also unset but xwidth *is* set
+    xmax = xwidth/2;
+    xmin = -xmax;
+  }
+  if (is_unset(ymin)) { // ymax also unset but yheight *is* set
+    ymax = yheight/2;
+    ymin = -ymax;
+  }
+  slit_warning_if(xmin == xmax || ymin == ymax, "Running with CLOSED rectangular slit - is this intentional?", NAME_CURRENT_COMP);
+} else {
+  slit_error_if(is_set(xwidth) || is_set(yheight) || is_set(xmin) || is_set(ymin) || is_set(xmax) || is_set(ymax),
+                "specify radius OR width and height parameters", NAME_CURRENT_COMP);
+  slit_warning_if(radius == 0., "Running with CLOSED radial slit - is this intentional?", NAME_CURRENT_COMP);
+}
 
 %}
 
 TRACE
 %{
     PROP_Z0;
-    if (((radius == 0) && (x<xmin || x>xmax || y<ymin || y>ymax))
-    || ((radius != 0) && (x*x + y*y > radius*radius)))
+    if (is_unset(radius) ? (x < xmin || x > xmax || y < ymin || y > ymax) : (x * x + y * y > radius * radius))
       ABSORB;
     else
-        SCATTER;
+      SCATTER;
 %}
 
 MCDISPLAY
 %{
   
-  if (radius == 0) {
+  if (r2 == 0) {
     double xw, yh;
     xw = (xmax - xmin)/2.0;
     yh = (ymax - ymin)/2.0;


### PR DESCRIPTION
- Currently there is no special value used for component parameters which are optional or mutually exclusive. Component authors may use an unphysical value in some cases, but there are examples where no suitable value exists.
- A new macro, `#define UNSET nan("0x...")`, allows components to use the special NaN value to keep track of whether a user has provided any input for the specific parameter(s). Helper functions have been added in the form of `is_unset`, `is_set`, and `is_valid`, to check whether a specific double value is the special NaN. The standard Slit.comp component has been modified to use the new NaN value, and now has logic at initialization to verify that a consistent set of parameter(s) have been provided.
- The specific NaN chosen for UNSET should not be created as the result of bad calculations elsewhere, but if it is that may lead to confusion for component authors and users. This possiblity is left for further consideration in the future.