### PR TITLE
Union clean up

### DIFF
--- a/mcstas-comps/contrib/union/AF_HB_1D_process.comp
+++ b/mcstas-comps/contrib/union/AF_HB_1D_process.comp
@@ -9,13 +9,11 @@
 * Version: $Revision: 0.1 $
 * Origin: University of Copenhagen
 *
+* 1D Antiferromagnetic Heisenberg chain
 *
 * %D
 *
-* This is a template for a new contributor to create their own physical process.
-* The comments in this file are meant to teach the user about creating their own 
-*  process file, rather than explaining this one. For comments on how this code works,
-*  look in the Incoherent_process.comp.
+* 1D Antiferromagnetic Heisenberg chain
 *
 * Part of the Union components, a set of components that work together and thus
 *  sperates geometry and physics within McStas.
@@ -37,11 +35,14 @@
 *
 * %P
 * INPUT PARAMETERS:
-* unit_cell_volume: [AA^3]   Unit cell volume (set either unit_cell_volume or number density)
-* number_density    [1/AA^3] Number of scatteres per volume
-* J_interaction:    [meV]    Exchange constant
-* A_constant        [unitless] constant from Müller paper 1981, probably somewhere between 1 and 1.5
-* atom_distance     [Å] distance between atom's in chain
+* unit_cell_volume:  [AA^3]     Unit cell volume (set either unit_cell_volume or number density)
+* number_density:    [1/AA^3]   Number of scatteres per volume
+* J_interaction:     [meV]      Exchange constant
+* A_constant:        [unitless] Constant from Müller paper 1981, probably somewhere between 1 and 1.5
+* atom_distance:     [AA]       Distance between atom's in chain
+* packing_factor:    [1]        How dense is the material compared to optimal 0-1
+* interact_fraction: [1]        How large a part of the scattering events should use this process 0-1 (sum of all processes in material = 1)
+* init:              [string] name of Union_init component (typically "init", default)
 *
 * OUTPUT PARAMETERS:
 * Template_storage          // Important to update this output paramter

--- a/mcstas-comps/contrib/union/IncoherentPhonon_process.comp
+++ b/mcstas-comps/contrib/union/IncoherentPhonon_process.comp
@@ -29,21 +29,20 @@
 *
 * %P
 * INPUT PARAMETERS:
-* T [K]             Temperature
-* density [g/cm3]   Material density
-* M [amu]           ion mass
-* sigmaCoh [barns]  Coherent scattering cross section
-* sigmaInc [barns]  Incoherent scattering cross section
-* dosfn [string]    Path to the file that contains the DoS
-* nxs [1]           Number of energy points at which the total cross sections are precomputed
-* nphe_exact [1]    Number of terms in the phonon expansion taken exact. Has to be between 1 and 3.
-* nphe_approx [1]   Number of terms in the phonon expansion taken approximate.
-* approx [1]        Approximation type: 0 gaussian, 1 saddle point
-* mph_resum         Resumate the remaining terms of the phonon expansion via a saddle point: 0 No, 1 Yes
-* kabsmin [A^-1]    Lower cut-off for the neutron wave-vector k
-* kabsmax [A^-1]    Higher cut-off for the neutron wave-vector k 
-* Interact_fraction [1]   How large a part of the scattering events should use this process 0-1 
-*                         (sum of all processes in material = 1)
+* T:                 [K]      Temperature
+* density:           [g/cm3]  Material density
+* M:                 [amu]    ion mass
+* sigmaCoh:          [barns]  Coherent scattering cross section
+* sigmaInc:          [barns]  Incoherent scattering cross section
+* dosfn:             [string] Path to the file that contains the DoS
+* nxs:               [1]      Number of energy points at which the total cross sections are precomputed
+* nphe_exact:        [1]      Number of terms in the phonon expansion taken exact. Has to be between 1 and 3.
+* nphe_approx:       [1]      Number of terms in the phonon expansion taken approximate.
+* approx:            [1]      Approximation type: 0 gaussian, 1 saddle point
+* mph_resum:         [0/1]    Resumate the remaining terms of the phonon expansion via a saddle point: 0 No, 1 Yes
+* kabsmin:           [A^-1]   Lower cut-off for the neutron wave-vector k
+* kabsmax:           [A^-1]   Higher cut-off for the neutron wave-vector k
+* interact_fraction: [1]      How large a part of the scattering events should use this process 0-1 (sum of all processes in material = 1)
 *
 * OUTPUT PARAMETERS:
 *

--- a/mcstas-comps/contrib/union/Incoherent_process.comp
+++ b/mcstas-comps/contrib/union/Incoherent_process.comp
@@ -35,12 +35,13 @@
 *
 * %P
 * INPUT PARAMETERS:
-* sigma:  [barns]         Incoherent scattering cross section
-* f_QE:                   Fraction of quasielastic scattering (rest is elastic) [1]
-* gamma:                  Lorentzian width of quasielastic broadening (HWHM) [1]
-* packing_factor [1]      How dense is the material compared to optimal 0-1
-* Unit_cell_volume [AA^3] Unit_cell_volume
-* Interact_fraction [1]   How large a part of the scattering events should use this process 0-1 (sum of all processes in material = 1)
+* sigma:             [barns] Incoherent scattering cross section
+* f_QE:              [1]     Fraction of quasielastic scattering (rest is elastic) [1]
+* gamma:             [meV]   Lorentzian width of quasielastic broadening (HWHM) [1]
+* packing_factor:    [1]     How dense is the material compared to optimal 0-1
+* unit_cell_volume:  [AA^3]  Unit cell volume
+* interact_fraction: [1]     How large a part of the scattering events should use this process 0-1 (sum of all processes in material = 1)
+* init:              [string] name of Union_init component (typically "init", default)
 *
 * OUTPUT PARAMETERS:
 *
@@ -52,7 +53,7 @@
 
 DEFINE COMPONENT Incoherent_process
 DEFINITION PARAMETERS ()
-SETTING PARAMETERS(sigma=5.08,f_QE=0,gamma=0,packing_factor=1,unit_cell_volume=13.8,interact_fraction=-1, string init="init")
+SETTING PARAMETERS(sigma=5.08, f_QE=0, gamma=0, packing_factor=1, unit_cell_volume=13.8, interact_fraction=-1, string init="init")
 OUTPUT PARAMETERS ()
 
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */

--- a/mcstas-comps/contrib/union/Non_process.comp
+++ b/mcstas-comps/contrib/union/Non_process.comp
@@ -9,13 +9,11 @@
 * Version: $Revision: 0.1 $
 * Origin: ESS DMSC
 *
+* This process dos nothing and is used for testing
 *
 * %D
 *
-* This is a Non for a new contributor to create their own physical process.
-* The comments in this file are meant to teach the user about creating their own 
-*  process file, rather than explaining this one. For comments on how this code works,
-*  look in the Incoherent_process.comp.
+* This process dos nothing and is used for testing
 *
 * Part of the Union components, a set of components that work together and thus
 *  sperates geometry and physics within McStas.

--- a/mcstas-comps/contrib/union/PhononSimple_process.comp
+++ b/mcstas-comps/contrib/union/PhononSimple_process.comp
@@ -7,14 +7,14 @@
 * Written by: Anders Komar Ravn, based on template by Mads Bertelsen and Phonon_Simple
 * Date: 20.08.15
 * Version: $Revision: 0.1 $
-* Origin:
+* Origin: University of Copenhagen
+*
+* Port of PhononSimple to Union components
 *
 * %D
 *
-* This is a template for a new contributor to create their own physical process.
-* The comments in this file are meant to teach the user about creating their own
-*  process file, rather than explaining this one. For comments on how this code works,
-*  look in the Incoherent_process.comp.
+* Port of the PhononSimple component from the McStas library to the Union
+* components.
 *
 * Part of the Union components, a set of components that work together and thus
 *  sperates geometry and physics within McStas.
@@ -36,12 +36,17 @@
 *
 * %P
 * INPUT PARAMETERS:
-* unit_cell_volume: [AA^3]   Unit cell volume
-* a: [AA]   fcc lattice constant
-* c: [meV*AA]  Velocity of sound
-* M: [unit]  Nucleus atomic mass in units
-* b: [fm] scattring length
-* MC: [1] steps in numerical integral
+* unit_cell_volume:  [AA^3]   Unit cell volume
+* a:                 [AA]     fcc lattice constant
+* c:                 [meV*AA] Velocity of sound
+* M:                 [units]  Nucleus atomic mass in units
+* b:                 [fm]     Scattring length
+* T:                 [K]      Temperature
+* longitudinal:      [0/1]    Simulate longitudinal branches
+* transverse:        [0/1]    Simulate transverse branches
+* packing_factor:    [1]      How dense is the material compared to optimal 0-1
+* interact_fraction: [1]      How large a part of the scattering events should use this process 0-1 (sum of all processes in material = 1)
+* init:              [string] Name of Union_init component (typically "init", default)
 *
 * OUTPUT PARAMETERS:
 * PhononSimple_storage      // Important to update this output paramter

--- a/mcstas-comps/contrib/union/Powder_process.comp
+++ b/mcstas-comps/contrib/union/Powder_process.comp
@@ -9,6 +9,7 @@
 * Version: $Revision: 0.1 $
 * Origin: University of Copenhagen
 *
+* Port of the PowderN process to the Union components
 *
 * %D
 *
@@ -34,9 +35,19 @@
 *
 * %P
 * INPUT PARAMETERS:
-* Interact_fraction [1]   How large a part of the scattering events should use this process 0-1 (sum of all processes in material = 1)
-* packing_factor [1]      How dense is the material compared to optimal 0-1
-* For rest, see PowderN component which this is based on
+* interact_fraction: [1]         How large a part of the scattering events should use this process 0-1 (sum of all processes in material = 1)
+* packing_factor:    [1]         How dense is the material compared to optimal 0-1
+* reflections:       [string]    Input file for reflections. No scattering if NULL or "" [string]
+* delta_d_d:         [0/1]       Global relative delta_d_d/d broadening when the 'w' column is not available. Use 0 if ideal.
+* Strain:            [ppm]       Global relative delta_d_d/d shift when the 'Strain' column is not available. Use 0 if ideal.
+* format:            [no quotes] Name of the format, or list of column indexes (see Description).
+* barns:             [1]         Flag to indicate if |F|^2 from 'reflections' is in barns or fm^2 (barns=1 for laz, barns=0 for lau type files).
+* Vc:                [AA^3]      Volume of unit cell=nb atoms per cell/density of atoms.
+* DW:                [1]         Global Debye-Waller factor when the 'DW' column is not available. Use 1 if included in F2
+* weight:            [g/mol]     Atomic/molecular weight of material.
+* density:           [g/cm^3]    Density of material. rho=density/weight/1e24*N_A.
+* nb_atoms:          [1]         Number of sub-unit per unit cell, that is ratio of sigma for chemical formula to sigma per unit cell
+* target_index:      [1]         Relative index of component to focus at, e.g. next is +1
 *
 * OUTPUT PARAMETERS:
 * V_rho:  [AA^-3] Atomic density

--- a/mcstas-comps/contrib/union/Single_crystal_process.comp
+++ b/mcstas-comps/contrib/union/Single_crystal_process.comp
@@ -9,6 +9,7 @@
 * Version: $Revision: 0.1 $
 * Origin: University of Copenhagen
 *
+* Port of the Single_crystal component to the Union components
 *
 * %D
 *
@@ -34,9 +35,34 @@
 *
 * %P
 * INPUT PARAMETERS:
-* packing_factor [1]      How dense is the material compared to optimal 0-1
-* Interact_fraction [1]   How large a part of the scattering events should use this process 0-1 (sum of all processes in material = 1)
-* For rest see Single_crystal.comp which this component is based on
+* packing_factor: [1]  How dense is the material compared to optimal 0-1
+* interact_fraction: [1] How large a part of the scattering events should use this process 0-1 (sum of all processes in material = 1)
+* delta_d_d: [1] Lattice spacing variance, gaussian RMS
+* mosaic: [arc minutes] Crystal mosaic (isotropic), gaussian RMS. Puts the crystal in the isotropic mosaic model state, thus disregarding other mosaicity parameters.
+* mosaic_a: [arc minutes]                                 Horizontal (rotation around lattice vector a) mosaic (anisotropic), gaussian RMS. Put the crystal in the anisotropic crystal vector state. I.e. model mosaicity through rotation around the crystal lattice vectors. Has precedence over in-plane mosaic model.
+* mosaic_b: [arc minutes]                                 Vertical (rotation around lattice vector b) mosaic (anisotropic), gaussian RMS.
+* mosaic_c: [arc minutes]                                 Out-of-plane (Rotation around lattice vector c) mosaic (anisotropic), gaussian RMS
+* mosaic_AB: [arc_minutes, arc_minutes,1, 1, 1, 1, 1, 1]  In Plane mosaic rotation and plane vectors (anisotropic), mosaic_A, mosaic_B, A_h,A_k,A_l, B_h,B_k,B_l. Puts the crystal in the in-plane mosaic state. Vectors A and B define plane in which  the crystal roation is defined, and mosaic_A, mosaic_B, denotes the resp. mosaicities (gaussian RMS) with respect to the two reflections chosen by A and B (Miller indices).
+* recip_cell: [1]                                         Choice of direct/reciprocal (0/1) unit cell definition
+* ax: [AA or AA^-1]                                       Coordinates of first (direct/recip) unit cell vector
+* ay: [AA or AA^-1]                                       a on y axis
+* az: [AA or AA^-1]                                       a on z axis
+* bx: [AA or AA^-1]                                       Coordinates of second (direct/recip) unit cell vector
+* bz: [AA or AA^-1]                                       b on z axis
+* by: [AA or AA^-1]                                       b on y axis
+* cx: [AA or AA^-1]                                       Coordinates of third (direct/recip) unit cell vector
+* cy: [AA or AA^-1]                                       c on y axis
+* cz: [AA or AA^-1]                                       c on z axis
+* reflections: [string]                                   File name containing structure factors of reflections. Use empty ("") or NULL for incoherent scattering only
+* order: [1]                                              Limit multiple scattering up to given order (0: all, 1: first, 2: second, ...)
+* p_transmit: [1]                                         Monte Carlo probability for neutrons to be transmitted without any scattering. Used to improve statistics from weak reflections
+* sigma_abs: [barns]                                      Absorption cross-section per unit cell at 2200 m/s
+* sigma_inc: [barns]                                      Incoherent scattering cross-section per unit cell Use -1 to unactivate
+* aa: [deg]                                               Unit cell angles alpha, beta and gamma. Then uses norms of vectors a,b and c as lattice parameters
+* bb: [deg]                                               Beta angle
+* cc: [deg]                                               Gamma angle
+* barns: [1]                                              Flag to indicate if |F|^2 from 'reflections' is in barns or fm^2. barns=1 for laz and isotropic constant elastic scattering (reflections=NULL), barns=0 for lau type files
+
 *
 * OUTPUT PARAMETERS:
 * Template_storage          // Important to update this output paramter
@@ -57,7 +83,7 @@ SETTING PARAMETERS(string reflections=0, delta_d_d=1e-4,
             cx = 0, cy = 0, cz = 0,
             //p_transmit = -1, sigma_abs = 0, sigma_inc = 0, // handled elsewhere
 		   aa=0, bb=0, cc=0, order=0, RX=0, RY=0, RZ=0, powder=0, PG=0,
-           interact_fraction=-1,packing_factor=1, string init="init")
+           interact_fraction=-1, packing_factor=1, string init="init")
 OUTPUT PARAMETERS ()
 
 SHARE

--- a/mcstas-comps/contrib/union/Template_process.comp
+++ b/mcstas-comps/contrib/union/Template_process.comp
@@ -9,6 +9,7 @@
 * Version: $Revision: 0.1 $
 * Origin: University of Copenhagen
 *
+* A template process for building Union processes
 *
 * %D
 *
@@ -37,8 +38,11 @@
 *
 * %P
 * INPUT PARAMETERS:
-* sigma:            [barns]  Scattering cross section
-* unit_cell_volume: [AA^3]   Unit cell volume
+* sigma:             [barns]  Incoherent scattering cross section
+* packing_factor:    [1]      How dense is the material compared to optimal 0-1
+* unit_cell_volume:  [AA^3]   Unit_cell_volume
+* interact_fraction: [1]      How large a part of the scattering events should use this process 0-1 (sum of all processes in material = 1)
+* init:              [string] Name of Union_init component (typically "init", default)
 *
 * OUTPUT PARAMETERS:
 * Template_storage          // Important to update this output paramter

--- a/mcstas-comps/contrib/union/Texture_process.comp
+++ b/mcstas-comps/contrib/union/Texture_process.comp
@@ -9,6 +9,7 @@
 * Version: $Revision: 0.1 $
 * Origin:
 *
+* Component for simulating textured powder in Union components
 *
 * %D
 *
@@ -28,16 +29,13 @@
 *
 * %P
 * INPUT PARAMETERS:
-* packing_factor [1]      How dense is the material compared to optimal 0-1
-* Interact_fraction [1]   How large a part of the scattering events should use 
-*                         this process 0-1 
-*                         (sum of all processes in material = 1)
-* crystal_fn [s]          Path to a file (.laz) containing crystallographic and physical information
-* fcoef_fn [s]            Path to a text file containing the Fourier coefficients of the ODF.
-*                         It must have five columns: l m n Real(Clmn) Imag(Clmn)
-* lmax [1]                Cut-off for the Fourier series.
-*                         If negative, the program uses all the coefficients provided in the file fcoef_fn
-* maxNeutronSaved [1]     Maximum number of neutron cross sections saved for reusing
+* packing_factor:    [1]      How dense is the material compared to optimal 0-1
+* interact_fraction: [1]      How large a part of the scattering events should use this process 0-1 (sum of all processes in material = 1)
+* crystal_fn:        [s]      Path to a file (.laz) containing crystallographic and physical information
+* fcoef_fn:          [s]      Path to a text file containing the Fourier coefficients of the ODF. It must have five columns: l m n Real(Clmn) Imag(Clmn)
+* lmax_user:         [1]      Cut-off for the Fourier series. If negative, the program uses all the coefficients provided in the file fcoef_fn
+* maxNeutronSaved:   [1]      Maximum number of neutron cross sections saved for reusing
+* init:              [string] Name of Union_init component (typically "init", default)
 *
 * OUTPUT PARAMETERS:
 * Template_storage          // Important to update this output paramter
@@ -53,7 +51,7 @@ DEFINE COMPONENT Texture_process // Remember to change the name of process here
 DEFINITION PARAMETERS ()
 SETTING PARAMETERS(string crystal_fn=0, string fcoef_fn=0, int lmax_user=-1,
             barns = 0, order = 0, interact_fraction = -1, packing_factor = 1,
-	    int maxNeutronSaved = 1, string init="init")
+	        int maxNeutronSaved = 1, string init="init")
 OUTPUT PARAMETERS ()
 
 SHARE

--- a/mcstas-comps/contrib/union/Union_abs_logger_1D_space.comp
+++ b/mcstas-comps/contrib/union/Union_abs_logger_1D_space.comp
@@ -9,7 +9,7 @@
 * Version: $Revision: 0.1 $
 * Origin: ESS DMSC
 *
-* A sample component to separate geometry and phsysics
+* Logger of absorption along 1D space
 *
 * %D
 * Part of the Union components, a set of components that work together and thus
@@ -66,6 +66,7 @@
 * order_total:     [1] Only log rays that have scattered n times, -1 for all orders
 * order_volume:    [1] Only log rays that have scattered n times in the same geometry, -1 for all orders
 * logger_conditional_extend_index: [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then access logger_conditional_extend[n] if logger_conditional_extend_index is set to n
+* init:              [string] name of Union_init component (typically "init", default)
 *
 * OUTPUT PARAMETERS:
 *

--- a/mcstas-comps/contrib/union/Union_abs_logger_1D_space_event.comp
+++ b/mcstas-comps/contrib/union/Union_abs_logger_1D_space_event.comp
@@ -9,7 +9,7 @@
 * Version: $Revision: 0.1 $
 * Origin: ESS DMSC
 *
-* A sample component to separate geometry and phsysics
+* Logger of absorption in 1D space stored as events
 *
 * %D
 * Part of the Union components, a set of components that work together and thus
@@ -76,6 +76,7 @@
 * order_total:     [1] Only log rays that have scattered n times, -1 for all orders
 * order_volume:    [1] Only log rays that have scattered n times in the same geometry, -1 for all orders
 * logger_conditional_extend_index: [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then access logger_conditional_extend[n] if logger_conditional_extend_index is set to n
+* init:              [string] name of Union_init component (typically "init", default)
 *
 * OUTPUT PARAMETERS:
 *

--- a/mcstas-comps/contrib/union/Union_abs_logger_1D_space_tof.comp
+++ b/mcstas-comps/contrib/union/Union_abs_logger_1D_space_tof.comp
@@ -9,7 +9,7 @@
 * Version: $Revision: 0.1 $
 * Origin: ESS DMSC
 *
-* A sample component to separate geometry and phsysics
+* Logger of absorption along 1D space and 1D time of flight
 *
 * %D
 * Part of the Union components, a set of components that work together and thus
@@ -69,7 +69,7 @@
 * order_total:     [1] Only log rays that have scattered n times, -1 for all orders
 * order_volume:    [1] Only log rays that have scattered n times in the same geometry, -1 for all orders
 * logger_conditional_extend_index: [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then access logger_conditional_extend[n] if logger_conditional_extend_index is set to n
-
+* init:              [string] name of Union_init component (typically "init", default)
 *
 * OUTPUT PARAMETERS:
 *

--- a/mcstas-comps/contrib/union/Union_abs_logger_1D_space_tof_to_lambda.comp
+++ b/mcstas-comps/contrib/union/Union_abs_logger_1D_space_tof_to_lambda.comp
@@ -9,7 +9,7 @@
 * Version: $Revision: 0.1 $
 * Origin: ESS DMSC
 *
-* A sample component to separate geometry and phsysics
+* A logger of absorption along 1D of space and 1D of tof, but converted to lambda
 *
 * %D
 * Part of the Union components, a set of components that work together and thus
@@ -70,28 +70,29 @@
 *
 * %P
 * INPUT PARAMETERS:
-* ref_component:      [1] Reference component instance index, sample position for distance calculation
-* source_sample_dist: [m] Travel distance between source and sample position, used to calculate total travelled distance
-* yheight:            [m] Height of absorption logger
-* yn:                 [1] number of bins along y axis
-* lambda_min:         [AA] Minimum wavelength recorded (sets both lambda_m_min and lambda_t_min)
-* lambda_max:         [AA] Maximum wavelength recorded (sets both lambda_m_max and lambda_t_max)
-* lambda_bins:        [1] number of wavelength bins
-* lambda_m_min:       [AA] Minimum measured wavelength recorded from tof and travelled distance (overwrites lambda_min)
-* lambda_m_max:       [AA] Maximum measured wavelength recorded from tof and travelled distance (overwrites lambda_max)
-* lambda_m_bins:      [1] number of measured wavelength bins
-* lambda_t_min:       [AA] Minimum measured wavelength recorded from tof and travelled distance (overwrites lambda_min)
-* lambda_t_max:       [AA] Maximum measured wavelength recorded from tof and travelled distance (overwrites lambda_max)
-* lambda_t_bins:      [1] number of true wavelength bins
-* relative_measured:  [1] Default 0, records measured as function of true wavelength, if this is enabled, records measured relative to true wavelength
-* relative_min:       [1] Smallest value of measured / true wavelength in histogram
-* relative_max:       [1] Largest value of measured / true wavelength in histogram
-* relative_bins:      [1] Number of bins on histogram axis with measured divided by true wavelength
+* ref_component:      [1]      Reference component instance index, sample position for distance calculation
+* source_sample_dist: [m]      Travel distance between source and sample position, used to calculate total travelled distance
+* yheight:            [m]      Height of absorption logger
+* yn:                 [1]      Number of bins along y axis
+* lambda_min:         [AA]     Minimum wavelength recorded (sets both lambda_m_min and lambda_t_min)
+* lambda_max:         [AA]     Maximum wavelength recorded (sets both lambda_m_max and lambda_t_max)
+* lambda_bins:        [1]      Number of wavelength bins
+* lambda_m_min:       [AA]     Minimum measured wavelength recorded from tof and travelled distance (overwrites lambda_min)
+* lambda_m_max:       [AA]     Maximum measured wavelength recorded from tof and travelled distance (overwrites lambda_max)
+* lambda_m_bins:      [1]      Number of measured wavelength bins
+* lambda_t_min:       [AA]     Minimum measured wavelength recorded from tof and travelled distance (overwrites lambda_min)
+* lambda_t_max:       [AA]     Maximum measured wavelength recorded from tof and travelled distance (overwrites lambda_max)
+* lambda_t_bins:      [1]      Number of true wavelength bins
+* relative_measured:  [1]      Default 0, records measured as function of true wavelength, if this is enabled, records measured relative to true wavelength
+* relative_min:       [1]      Smallest value of measured / true wavelength in histogram
+* relative_max:       [1]      Largest value of measured / true wavelength in histogram
+* relative_bins:      [1]      Number of bins on histogram axis with measured divided by true wavelength
 * target_geometry:    [string] Comma separated list of geometry names that will be logged, leave empty for all volumes (even not defined yet)
 * filename:           [string] Filename of produced data file
-* order_total:        [1] Only log rays that have scattered n times, -1 for all orders
-* order_volume:       [1] Only log rays that have scattered n times in the same geometry, -1 for all orders
+* order_total:        [1]      Only log rays that have scattered n times, -1 for all orders
+* order_volume:       [1]      Only log rays that have scattered n times in the same geometry, -1 for all orders
 * logger_conditional_extend_index: [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then access logger_conditional_extend[n] if logger_conditional_extend_index is set to n
+* init:               [string] Name of Union_init component (typically "init", default)
 *
 * OUTPUT PARAMETERS:
 *

--- a/mcstas-comps/contrib/union/Union_abs_logger_2D_space.comp
+++ b/mcstas-comps/contrib/union/Union_abs_logger_2D_space.comp
@@ -9,7 +9,7 @@
 * Version: $Revision: 0.1 $
 * Origin: ESS DMSC
 *
-* A sample component to separate geometry and phsysics
+* Logger of absorption along two dimensions of space
 *
 * %D
 * Part of the Union components, a set of components that work together and thus
@@ -64,18 +64,19 @@
 * %P
 * INPUT PARAMETERS:
 * D_direction_1:   [string] Direction for first axis ("x", "y" or "z")
-* D1_max:          [1] histogram boundary, max position value for first axis
-* D1_min:          [1] histogram boundary, min position value for first axis
-* n1:              [1] number of bins for first axis
+* D1_max:          [m]      Histogram boundary, max position value for first axis
+* D1_min:          [m]      Histogram boundary, min position value for first axis
+* n1:              [1]      Number of bins for first axis
 * D_direction_2:   [string] Direction for second axis ("x", "y" or "z")
-* D2_max:          [1] histogram boundary, max position value for second axis
-* D2_min:          [1] histogram boundary, min position value for second axis
-* n2:              [1] number of bins for second axis
+* D2_max:          [m]      Histogram boundary, max position value for second axis
+* D2_min:          [m]      Histogram boundary, min position value for second axis
+* n2:              [1]      Number of bins for second axis
 * target_geometry: [string] Comma separated list of geometry names that will be logged, leave empty for all volumes (even not defined yet)
 * filename:        [string] Filename of produced data file
-* order_total:     [1] Only log rays that have scattered n times, -1 for all orders
-* order_volume:    [1] Only log rays that have scattered n times in the same geometry, -1 for all orders
+* order_total:     [1]      Only log rays that have scattered n times, -1 for all orders
+* order_volume:    [1]      Only log rays that have scattered n times in the same geometry, -1 for all orders
 * logger_conditional_extend_index: [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then access logger_conditional_extend[n] if logger_conditional_extend_index is set to n
+* init:            [string] Name of Union_init component (typically "init", default)
 *
 * OUTPUT PARAMETERS:
 *

--- a/mcstas-comps/contrib/union/Union_abs_logger_event.comp
+++ b/mcstas-comps/contrib/union/Union_abs_logger_event.comp
@@ -9,7 +9,7 @@
 * Version: $Revision: 0.1 $
 * Origin: ESS DMSC
 *
-* A sample component to separate geometry and phsysics
+* A logger of absorption as events
 *
 * %D
 * Part of the Union components, a set of components that work together and thus
@@ -57,9 +57,10 @@
 * INPUT PARAMETERS:
 * target_geometry: [string] Comma separated list of geometry names that will be logged, leave empty for all volumes (even not defined yet)
 * filename:        [string] Filename of produced data file
-* order_total:     [1] Only log rays that have scattered n times, -1 for all orders
-* order_volume:    [1] Only log rays that have scattered n times in the same geometry, -1 for all orders
+* order_total:     [1]      Only log rays that have scattered n times, -1 for all orders
+* order_volume:    [1]      Only log rays that have scattered n times in the same geometry, -1 for all orders
 * logger_conditional_extend_index: [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then access logger_conditional_extend[n] if logger_conditional_extend_index is set to n
+* init:            [string] Name of Union_init component (typically "init", default)
 *
 * OUTPUT PARAMETERS:
 *

--- a/mcstas-comps/contrib/union/Union_box.comp
+++ b/mcstas-comps/contrib/union/Union_box.comp
@@ -8,7 +8,7 @@
 * Date: 20.08.15
 * Origin: University of Copenhagen
 *
-* A sample component to separate geometry and phsysics
+* A box geometry component for the Union components
 *
 * %D
 * Part of the Union components, a set of components that work together and thus
@@ -36,28 +36,28 @@
 *
 * %P
 * INPUT PARAMETERS:
-* xwidth: [m]          width of the box volume
-* yheight: [m]         height of the box volume
-* zdepth: [m]          depth of the box volume
-* xwidth2: [m]         optional different width at the +z box face
-* yheight2: [m]        optional different height at the +z box face
-* material_string: []  material name of this volume, defined using Union_make_material
-* priority: [1]        priotiry of the volume (can not be the same as another volume) A high priority is on top of low.
-* p_interact [1]  probability to interact with this geometry [0-1]
-* visualize  [1]  set to 0 if you wish to hide this geometry in mcdisplay
-* number_of_activations [1]  Number of subsequent Union_master components that will simulate this geometry
-* mask_string: []      Comma seperated list of geometry names which this geometry should mask
-* mask_setting: []     "All" or "Any", should the masked volume be simulated when the ray is in just one mask, or all.
-*
-* Focusing options, if left blank, there will be no focusing.
-* target_x   [m]:
-* target_y   [m]: Position of target to focus at
-* target_z   [m]:
-* focus_aw   [deg] horiz. angular dimension of a rectangular area
-* focus_ah   [deg] vert. angular dimension of a rectangular area
-* focus_xw   [m]   horiz. dimension of a rectangular area
-* focus_xh   [m]   vert. dimension of a rectangular area
-* focus_r    [m]   focusing on circle with this radius
+* xwidth:                [m]      Width of the box volume
+* yheight:               [m]      Height of the box volume
+* zdepth:                [m]      Depth of the box volume
+* xwidth2:               [m]      Optional different width at the +z box face
+* yheight2:              [m]      Optional different height at the +z box face
+* material_string:       [string] Material name of this volume, defined using Union_make_material
+* priority:              [1]      Priotiry of the volume (can not be the same as another volume) A high priority is on top of low.
+* p_interact:            [1]      Probability to interact with this geometry [0-1]
+* visualize:             [1]      Set to 0 if you wish to hide this geometry in mcdisplay
+* number_of_activations: [1]      Number of subsequent Union_master components that will simulate this geometry
+* mask_string:           [string] Comma seperated list of geometry names which this geometry should mask
+* mask_setting:          [string]  "All" or "Any", should the masked volume be simulated when the ray is in just one mask, or all.
+* target_index:          [string]  Focuses on component a component this many steps further in the component sequence
+* target_x:              [m]      X position of target to focus at
+* target_y:              [m]      Y position of target to focus at
+* target_z:              [m]      Z position of target to focus at
+* focus_aw:              [deg]    Horiz. angular dimension of a rectangular area
+* focus_ah:              [deg]    Vert. angular dimension of a rectangular area
+* focus_xw:              [m]      Horiz. dimension of a rectangular area
+* focus_xh:              [m]      Vert. dimension of a rectangular area
+* focus_r:               [m]      Focusing on circle with this radius
+* init:                  [string] name of Union_init component (typically "init", default)
 * OUTPUT PARAMETERS:
 *
 * %L

--- a/mcstas-comps/contrib/union/Union_conditional_PSD.comp
+++ b/mcstas-comps/contrib/union/Union_conditional_PSD.comp
@@ -9,7 +9,7 @@
 * Version: $Revision: 0.1 $
 * Origin: University of Copenhagen
 *
-* A sample component to separate geometry and phsysics
+* A conditional component in the shape of an area the neutrons must hit
 *
 * %D
 * Part of the Union components, a set of components that work together and thus
@@ -48,14 +48,17 @@
 *
 * %P
 * INPUT PARAMETERS:
-* target_loggers:     [string] Comma seperated list of loggers this conditional should affect
-* master_tagging=0    [1] Apply this conditional to the tagging system in next master
-* tagging_extend_index[1] Not currently used
-* time_min            [s] Min time (on psd), if not set ignored
-* time_max            [s] Max time (on psd), if not set ignored
-* overwrite_logger_weight [1] Default = 0, overwrite = 1
-* end_volume          [1] Not used yet
-* last_volume_index   [1] Not used yet
+* xwidth:               [m]      Width of target area
+* yheight:              [m]      Height of target area
+* target_loggers:       [string] Comma seperated list of loggers this conditional should affect
+* master_tagging:       [1]      Apply this conditional to the tagging system in next master
+* tagging_extend_index: [1]      Not currently used
+* time_min:             [s]      Min time (on psd), if not set ignored
+* time_max:             [s]      Max time (on psd), if not set ignored
+* overwrite_logger_weight: [1]   Default = 0, overwrite = 1
+* end_volume:           [1]      Not used yet
+* last_volume_index:    [1]      Not used yet
+* init:                 [string] Name of Union_init component (typically "init", default)
 *
 * OUTPUT PARAMETERS:
 * this_material:            Structure that contains information on this material

--- a/mcstas-comps/contrib/union/Union_conditional_standard.comp
+++ b/mcstas-comps/contrib/union/Union_conditional_standard.comp
@@ -9,7 +9,7 @@
 * Version: $Revision: 0.1 $
 * Origin: University of Copenhagen
 *
-* A sample component to separate geometry and phsysics
+* A conditional component that filter on basic variables of exit state
 *
 * %D
 * Part of the Union components, a set of components that work together and thus
@@ -45,17 +45,18 @@
 *
 * %P
 * INPUT PARAMETERS:
-* target_loggers:     [string] Comma seperated list of loggers this conditional should affect
-* master_tagging=0    [1] Apply this conditional to the tagging system in next master
-* tagging_extend_index[1] Not currently used
-* time_min            [s] Min time, if not set ignored
-* time_max            [s] Max time, if not set ignored
-* E_min               [meV] Max energy, if not set ignored
-* E_max               [meV] Min energy, if not set ignored
-* total_order_min     [1] Min scattering order, if not set ignored
-* total_order_max     [1] Max scattering order, if not set ignored
-* overwrite_logger_weight [1] Default = 0, overwrite = 1
-* last_volume_index   [1] Not used yet
+* target_loggers:       [string] Comma seperated list of loggers this conditional should affect
+* master_tagging:       [1]      Apply this conditional to the tagging system in next master
+* tagging_extend_index: [1]      Not currently used
+* time_min:             [s]      Min time, if not set ignored
+* time_max:             [s]      Max time, if not set ignored
+* E_min:                [meV]    Max energy, if not set ignored
+* E_max:                [meV]    Min energy, if not set ignored
+* total_order_min:      [1]      Min scattering order, if not set ignored
+* total_order_max:      [1]      Max scattering order, if not set ignored
+* overwrite_logger_weight: [1]   Default = 0, overwrite = 1
+* last_volume_index:    [1]      Not used yet
+* init:                 [string] Name of Union_init component (typically "init", default)
 *
 *
 * OUTPUT PARAMETERS:

--- a/mcstas-comps/contrib/union/Union_cone.comp
+++ b/mcstas-comps/contrib/union/Union_cone.comp
@@ -7,9 +7,9 @@
 * Written by: Martin Olsen
 * On a template by: Mads Bertelsen
 * Date: 17.09.18
-* Origin: Niels Bohr Instituttet, Universitetsparken 5
+* Origin: University of Copenhagen
 *
-* A sample component to separate geometry and phsysics
+* Cone geometry component for Union components
 *
 * %D
 * Part of the Union components, a set of components that work together and thus
@@ -35,27 +35,27 @@
 *
 * %P
 * INPUT PARAMETERS:
-* radius_top: [m]      Top radius volume in (x,z) plane
-* radius_bottom: [m]   Bottom radius volume in (x,z) plane
-* radius: [m]          Radius volume in (x,z) plane
-* yheight: [m]         Cone height in (y) direction
-* material_string: []  material name of this volume, defined using Union_make_material
-* priority   [1]  priotiry of the volume (can not be the same as another volume) A high priority is on top of low.
-* p_interact [1]  probability to interact with this geometry [0-1]
-* visualize  [1]  set to 0 if you wish to hide this geometry in mcdisplay
-* number_of_activations [1]  Number of subsequent Union_master components that will simulate this geometry
-* mask_string: []      Comma seperated list of geometry names which this geometry should mask
-* mask_setting: []     "All" or "Any", should the masked volume be simulated when the ray is in just one mask, or all.
-*
-* Focusing options, if left blank, there will be no focusing.
-* target_x   [m]:
-* target_y   [m]: Position of target to focus at
-* target_z   [m]:
-* focus_aw   [deg] horiz. angular dimension of a rectangular area
-* focus_ah   [deg] vert. angular dimension of a rectangular area
-* focus_xw   [m]   horiz. dimension of a rectangular area
-* focus_xh   [m]   vert. dimension of a rectangular area
-* focus_r    [m]   focusing on circle with this radius
+* radius_top:            [m]      Top radius volume in (x,z) plane
+* radius_bottom:         [m]      Bottom radius volume in (x,z) plane
+* radius:                [m]      Radius volume in (x,z) plane
+* yheight:               [m]      Cone height in (y) direction
+* material_string:       [string] Material name of this volume, defined using Union_make_material
+* priority:              [1]      Priotiry of the volume (can not be the same as another volume) A high priority is on top of low.
+* p_interact:            [1]      Probability to interact with this geometry [0-1]
+* visualize:             [1]      Set to 0 if you wish to hide this geometry in mcdisplay
+* number_of_activations: [1]      Number of subsequent Union_master components that will simulate this geometry
+* mask_string:           [string] Comma seperated list of geometry names which this geometry should mask
+* mask_setting:          [string] "All" or "Any", should the masked volume be simulated when the ray is in just one mask, or all.
+* target_index:          [1]      Focuses on component a component this many steps further in the component sequence
+* target_x:              [m]      X position of target to focus at
+* target_y:              [m]      Y position of target to focus at
+* target_z:              [m]      Z position of target to focus at
+* focus_aw:              [deg]    Horiz. angular dimension of a rectangular area
+* focus_ah:              [deg]    Vert. angular dimension of a rectangular area
+* focus_xw:              [m]      Horiz. dimension of a rectangular area
+* focus_xh:              [m]      Vert. dimension of a rectangular area
+* focus_r:               [m]      Focusing on circle with this radius
+* init:                  [string] Name of Union_init component (typically "init", default)
 *
 * OUTPUT PARAMETERS:
 *

--- a/mcstas-comps/contrib/union/Union_cylinder.comp
+++ b/mcstas-comps/contrib/union/Union_cylinder.comp
@@ -8,7 +8,7 @@
 * Date: 20.08.15
 * Origin: University of Copenhagen
 *
-* A sample component to separate geometry and phsysics
+* Cylinder geometry component for Union components
 *
 * %D
 * Part of the Union components, a set of components that work together and thus
@@ -34,25 +34,25 @@
 *
 * %P
 * INPUT PARAMETERS:
-* radius: [m]          Outer radius volume in (x,z) plane
-* yheight: [m]         Cylinder height in (y) direction
-* material_string: []  material name of this volume, defined using Union_make_material
-* priority   [1]  priotiry of the volume (can not be the same as another volume) A high priority is on top of low.
-* p_interact [1]  probability to interact with this geometry [0-1]
-* visualize  [1]  set to 0 if you wish to hide this geometry in mcdisplay
-* number_of_activations [1]  Number of subsequent Union_master components that will simulate this geometry
-* mask_string: []      Comma seperated list of geometry names which this geometry should mask
-* mask_setting: []     "All" or "Any", should the masked volume be simulated when the ray is in just one mask, or all.
-*
-* Focusing options, if left blank, there will be no focusing.
-* target_x   [m]:
-* target_y   [m]: Position of target to focus at
-* target_z   [m]:
-* focus_aw   [deg] horiz. angular dimension of a rectangular area
-* focus_ah   [deg] vert. angular dimension of a rectangular area
-* focus_xw   [m]   horiz. dimension of a rectangular area
-* focus_xh   [m]   vert. dimension of a rectangular area
-* focus_r    [m]   focusing on circle with this radius
+* radius:                [m]      Outer radius volume in (x,z) plane
+* yheight:               [m]      Cylinder height in (y) direction
+* material_string:       [string] Material name of this volume, defined using Union_make_material
+* priority:              [1]      Priotiry of the volume (can not be the same as another volume) A high priority is on top of low.
+* p_interact:            [1]      Probability to interact with this geometry [0-1]
+* visualize:             [1]      Set to 0 if you wish to hide this geometry in mcdisplay
+* number_of_activations: [1]      Number of subsequent Union_master components that will simulate this geometry
+* mask_string:           [string] Comma seperated list of geometry names which this geometry should mask
+* mask_setting:          [string] "All" or "Any", should the masked volume be simulated when the ray is in just one mask, or all.
+* target_index:          [1]      Focuses on component a component this many steps further in the component sequence
+* target_x:              [m]      X Position of target to focus at
+* target_y:              [m]      Y Position of target to focus at
+* target_z:              [m]      Z Position of target to focus at
+* focus_aw:              [deg]    Horiz. angular dimension of a rectangular area
+* focus_ah:              [deg]    Vert. angular dimension of a rectangular area
+* focus_xw:              [m]      Horiz. dimension of a rectangular area
+* focus_xh:              [m]      Vert. dimension of a rectangular area
+* focus_r:               [m]      Focusing on circle with this radius
+* init:                  [string] Name of Union_init component (typically "init", default)
 *
 * OUTPUT PARAMETERS:
 *

--- a/mcstas-comps/contrib/union/Union_init.comp
+++ b/mcstas-comps/contrib/union/Union_init.comp
@@ -9,6 +9,8 @@
 * Version: $Revision: 0.1 $
 * Origin: ESS DMSC
 *
+* Initialize component that needs to be place before any Union component
+*
 * %D
 * Part of the Union components, a set of components that work together and thus
 *  sperates geometry and physics within McStas.

--- a/mcstas-comps/contrib/union/Union_logger_1D.comp
+++ b/mcstas-comps/contrib/union/Union_logger_1D.comp
@@ -9,7 +9,7 @@
 * Version: $Revision: 0.1 $
 * Origin: University of Copenhagen
 *
-* A sample component to separate geometry and phsysics
+* One dimensional Union logger for several possible variables
 *
 * %D
 * Part of the Union components, a set of components that work together and thus
@@ -46,16 +46,18 @@
 *
 * %P
 * INPUT PARAMETERS:
-* variable:        [string] time for time in seconds, q for magnitude of scattering vector in 1/AA.
-* min_value:       [1] histogram boundery for logged value
-* max_value:       [1] histogram boundery for logged value
-* n1:              [1] Number of bins in histogram
-* target_geometry: [string] Comma seperated list of geometry names that will be logged, leave empty for all volumes (even not defined yet)
-* target_process:  [string] Comma seperated names of physical processes, if volumes are selected, one can select Union_process names
-* order_total:     [1] Only log rays that scatter for the n'th time, 0 for all orders
-* order_volume:    [1] Only log rays that scatter for the n'th time in the same geometry
-* order_volume_process [1] Only log rays that scatter for the n'th time in the same geometry, using the same process
-* logger_conditional_extend_index [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then acces logger_conditional_extend[n] if logger_conditional_extend_index is set to n
+* variable:             [string] Time for time in seconds, q for magnitude of scattering vector in 1/AA.
+* min_value:            [1]      Histogram boundery for logged value
+* max_value:            [1]      Histogram boundery for logged value
+* n1:                   [1]      Number of bins in histogram
+* filename:             [string] Filename of produced data file
+* target_geometry:      [string] Comma seperated list of geometry names that will be logged, leave empty for all volumes (even not defined yet)
+* target_process:       [string] Comma seperated names of physical processes, if volumes are selected, one can select Union_process names
+* order_total:          [1]      Only log rays that scatter for the n'th time, 0 for all orders
+* order_volume:         [1]      Only log rays that scatter for the n'th time in the same geometry
+* order_volume_process: [1]      Only log rays that scatter for the n'th time in the same geometry, using the same process
+* logger_conditional_extend_index: [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then acces logger_conditional_extend[n] if logger_conditional_extend_index is set to n
+* init:                 [string] Name of Union_init component (typically "init", default)
 *
 * OUTPUT PARAMETERS:
 *

--- a/mcstas-comps/contrib/union/Union_logger_2DQ.comp
+++ b/mcstas-comps/contrib/union/Union_logger_2DQ.comp
@@ -9,7 +9,7 @@
 * Version: $Revision: 0.1 $
 * Origin: University of Copenhagen
 *
-* A sample component to separate geometry and phsysics
+* Two dimensional logger of scattering vector for Union components
 *
 * %D
 * Part of the Union components, a set of components that work together and thus
@@ -44,20 +44,22 @@
 *
 * %P
 * INPUT PARAMETERS:
-* Q_direction_1:   [string] Q direction for first axis ("x", "y" or "z")
-* Q1_max:          [1] histogram boundery, max q value for first axis
-* Q1_min:          [1] histogram boundery, min q value for first axis
-* n1:              [1] number of bins for first axis
-* Q_direction_2:   [string] Q direction for second axis ("x", "y" or "z")
-* Q2_max:          [1] histogram boundery, max q value for second axis
-* Q2_min:          [1] histogram boundery, min q value for second axis
-* n2:              [1] number of bins for second axis
-* target_geometry: [string] Comma seperated list of geometry names that will be logged, leave empty for all volumes (even not defined yet)
-* target_process:  [string] Comma seperated names of physical processes, if volumes are selected, one can select Union_process names
-* order_total:     [1] Only log rays that scatter for the n'th time, 0 for all orders
-* order_volume:    [1] Only log rays that scatter for the n'th time in the same geometry
-* order_volume_process [1] Only log rays that scatter for the n'th time in the same geometry, uwsing the same process
-* logger_conditional_extend_index [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then acces logger_conditional_extend[n] if logger_conditional_extend_index is set to n
+* Q_direction_1:        [string] Q direction for first axis ("x", "y" or "z")
+* Q1_max:               [AA^-1]  Histogram boundery, max q value for first axis
+* Q1_min:               [AA^-1]  Histogram boundery, min q value for first axis
+* n1:                   [1]      Number of bins for first axis
+* Q_direction_2:        [string] Q direction for second axis ("x", "y" or "z")
+* Q2_max:               [AA^-1]  Histogram boundery, max q value for second axis
+* Q2_min:               [AA^-1]  Histogram boundery, min q value for second axis
+* n2:                   [1]      Number of bins for second axis
+* filename:             [string] Filename of produced data file
+* target_geometry:      [string] Comma seperated list of geometry names that will be logged, leave empty for all volumes (even not defined yet)
+* target_process:       [string] Comma seperated names of physical processes, if volumes are selected, one can select Union_process names
+* order_total:          [1]      Only log rays that scatter for the n'th time, 0 for all orders
+* order_volume:         [1]      Only log rays that scatter for the n'th time in the same geometry
+* order_volume_process: [1]      Only log rays that scatter for the n'th time in the same geometry, uwsing the same process
+* logger_conditional_extend_index: [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then acces logger_conditional_extend[n] if logger_conditional_extend_index is set to n
+* init:                 [string] Name of Union_init component (typically "init", default)
 *
 * OUTPUT PARAMETERS:
 *

--- a/mcstas-comps/contrib/union/Union_logger_2D_kf.comp
+++ b/mcstas-comps/contrib/union/Union_logger_2D_kf.comp
@@ -9,7 +9,7 @@
 * Version: $Revision: 0.1 $
 * Origin: University of Copenhagen
 *
-* A sample component to separate geometry and phsysics
+* Two dimensional logger of final wavevector for Union components
 *
 * %D
 * Part of the Union components, a set of components that work together and thus
@@ -45,22 +45,22 @@
 *
 * %P
 * INPUT PARAMETERS:
-* // To be changed to kf instead of Q
-* Q_direction_1:   [string] kf direction for first axis ("x", "y" or "z")
-* Q1_max:          [1] histogram boundery, max kf value for first axis
-* Q1_min:          [1] histogram boundery, min kf value for first axis
-* n1:              [1] number of bins for first axis
-* Q_direction_2:   [string] kf direction for second axis ("x", "y" or "z")
-* Q2_max:          [1] histogram boundery, max kf value for second axis
-* Q2_min:          [1] histogram boundery, min kf value for second axis
-* n2:              [1] number of bins for second axis
-* target_geometry: [string] Comma seperated list of geometry names that will be logged, leave empty for all volumes (even not defined yet)
-* target_process:  [string] Comma seperated names of physical processes, if volumes are selected, one can select Union_process names
-* order_total:     [1] Only log rays that scatter for the n'th time, 0 for all orders
-* order_volume:    [1] Only log rays that scatter for the n'th time in the same geometry
-* order_volume_process [1] Only log rays that scatter for the n'th time in the same geometry, using the same process
-* logger_conditional_extend_index [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then acces logger_conditional_extend[n] if logger_conditional_extend_index is set to n
-*
+* Q_direction_1:        [string] kf direction for first axis ("x", "y" or "z")
+* Q1_max:               [AA^-1]  Histogram boundery, max kf value for first axis
+* Q1_min:               [AA^-1]  Histogram boundery, min kf value for first axis
+* n1:                   [1]      Number of bins for first axis
+* Q_direction_2:        [string] kf direction for second axis ("x", "y" or "z")
+* Q2_max:               [AA^-1]  Histogram boundery, max kf value for second axis
+* Q2_min:               [AA^-1]  Histogram boundery, min kf value for second axis
+* n2:                   [1]      Number of bins for second axis
+* filename:             [string] Filename of produced data file
+* target_geometry:      [string] Comma seperated list of geometry names that will be logged, leave empty for all volumes (even not defined yet)
+* target_process:       [string] Comma seperated names of physical processes, if volumes are selected, one can select Union_process names
+* order_total:          [1]      Only log rays that scatter for the n'th time, 0 for all orders
+* order_volume:         [1]      Only log rays that scatter for the n'th time in the same geometry
+* order_volume_process: [1]      Only log rays that scatter for the n'th time in the same geometry, using the same process
+* logger_conditional_extend_index: [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then acces logger_conditional_extend[n] if logger_conditional_extend_index is set to n
+* init:                 [string] Name of Union_init component (typically "init", default)
 *
 * OUTPUT PARAMETERS:
 *
@@ -73,7 +73,7 @@
 
 DEFINE COMPONENT Union_logger_2D_kf
 DEFINITION PARAMETERS ()
-SETTING PARAMETERS(string target_geometry="NULL",string target_process="NULL",Q1_min=-5,Q1_max=5,Q2_min=-5,Q2_max=5,string Q_direction_1="x", string Q_direction_2="z",string filename="NULL", n1=90, n2=90, order_total=0,order_volume=0,order_volume_process=0,logger_conditional_extend_index=-1, string init="init")
+SETTING PARAMETERS(string target_geometry="NULL",string target_process="NULL", Q1_min=-5, Q1_max=5, Q2_min=-5, Q2_max=5, string Q_direction_1="x", string Q_direction_2="z",string filename="NULL", n1=90, n2=90, order_total=0,order_volume=0,order_volume_process=0,logger_conditional_extend_index=-1, string init="init")
 OUTPUT PARAMETERS ()
 
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */

--- a/mcstas-comps/contrib/union/Union_logger_2D_kf_time.comp
+++ b/mcstas-comps/contrib/union/Union_logger_2D_kf_time.comp
@@ -7,9 +7,9 @@
 * Written by: Mads Bertelsen
 * Date: 20.08.15
 * Version: $Revision: 0.1 $
-* Origin: Svanevej 19
+* Origin: University of Copenhagen
 *
-* A sample component to separate geometry and phsysics
+* Two dimensional logger of wavevector for a range of time bins
 *
 * %D
 * Part of the Union components, a set of components that work together and thus
@@ -46,23 +46,25 @@
 *
 * %P
 * INPUT PARAMETERS:
-* Q_direction_1:   [string] kf direction for first axis ("x", "y" or "z")
-* Q1_max:          [1] histogram boundery, max kf value for first axis
-* Q1_min:          [1] histogram boundery, min kf value for first axis
-* n1:              [1] number of bins for first axis
-* Q_direction_2:   [string] kf direction for second axis ("x", "y" or "z")
-* Q2_max:          [1] histogram boundery, max kf value for second axis
-* Q2_min:          [1] histogram boundery, min kf value for second axis
-* n2:              [1] number of bins for second axis
-* time_bins        [1] Number of time bins
-* time_min         [1] Minimum time
-* time_max         [1] Maximum time
-* target_geometry: [string] Comma seperated list of geometry names that will be logged, leave empty for all volumes (even not defined yet)
-* target_process:  [string] Comma seperated names of physical processes, if volumes are selected, one can select Union_process names
-* order_total:     [1] Only log rays that scatter for the n'th time, 0 for all orders
-* order_volume:    [1] Only log rays that scatter for the n'th time in the same geometry
-* order_volume_process [1] Only log rays that scatter for the n'th time in the same geometry, using the same process
-* logger_conditional_extend_index [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then acces logger_conditional_extend[n] if logger_conditional_extend_index is set to n
+* Q_direction_1:        [string] kf direction for first axis ("x", "y" or "z")
+* Q1_max:               [A^-1]   Histogram boundery, max kf value for first axis
+* Q1_min:               [A^-1]   Histogram boundery, min kf value for first axis
+* n1:                   [1]      Number of bins for first axis
+* Q_direction_2:        [string] kf direction for second axis ("x", "y" or "z")
+* Q2_max:               [A^-1]   Histogram boundery, max kf value for second axis
+* Q2_min:               [A^-1]   Histogram boundery, min kf value for second axis
+* n2:                   [1]      Number of bins for second axis
+* time_bins:            [1]      Number of time bins
+* time_min:             [s]      Minimum time
+* time_max:             [s]      Maximum time
+* filename:             [string] Filename of produced data file
+* target_geometry:      [string] Comma seperated list of geometry names that will be logged, leave empty for all volumes (even not defined yet)
+* target_process:       [string] Comma seperated names of physical processes, if volumes are selected, one can select Union_process names
+* order_total:          [1]      Only log rays that scatter for the n'th time, 0 for all orders
+* order_volume:         [1]      Only log rays that scatter for the n'th time in the same geometry
+* order_volume_process: [1]      Only log rays that scatter for the n'th time in the same geometry, using the same process
+* logger_conditional_extend_index: [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then acces logger_conditional_extend[n] if logger_conditional_extend_index is set to n
+* init:                 [string] Name of Union_init component (typically "init", default)
 *
 * OUTPUT PARAMETERS:
 *

--- a/mcstas-comps/contrib/union/Union_logger_2D_space.comp
+++ b/mcstas-comps/contrib/union/Union_logger_2D_space.comp
@@ -7,9 +7,9 @@
 * Written by: Mads Bertelsen
 * Date: 20.08.15
 * Version: $Revision: 0.1 $
-* Origin: Svanevej 19
+* Origin: University of Copenhagen
 *
-* A sample component to separate geometry and phsysics
+* Two dimensional spatial logger for the Union components
 *
 * %D
 * Part of the Union components, a set of components that work together and thus
@@ -47,19 +47,21 @@
 * %P
 * INPUT PARAMETERS:
 * D_direction_1:   [string] Direction for first axis ("x", "y" or "z")
-* D1_max:          [1] histogram boundery, max position value for first axis
-* D1_min:          [1] histogram boundery, min position value for first axis
-* n1:              [1] number of bins for first axis
+* D1_max:          [m]      Histogram boundery, max position value for first axis
+* D1_min:          [m]      Histogram boundery, min position value for first axis
+* n1:              [1]      Number of bins for first axis
 * D_direction_2:   [string] Direction for second axis ("x", "y" or "z")
-* D2_max:          [1] histogram boundery, max position value for second axis
-* D2_min:          [1] histogram boundery, min position value for second axis
-* n2:              [1] number of bins for second axis
+* D2_max:          [m]      Histogram boundery, max position value for second axis
+* D2_min:          [m]      Histogram boundery, min position value for second axis
+* n2:              [1]      Number of bins for second axis
+* filename:        [string] Filename of produced data file
 * target_geometry: [string] Comma seperated list of geometry names that will be logged, leave empty for all volumes (even not defined yet)
 * target_process:  [string] Comma seperated names of physical processes, if volumes are selected, one can select Union_process names
-* order_total:     [1] Only log rays that scatter for the n'th time, 0 for all orders
-* order_volume:    [1] Only log rays that scatter for the n'th time in the same geometry
-* order_volume_process [1] Only log rays that scatter for the n'th time in the same geometry, using the same process
-* logger_conditional_extend_index [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then acces logger_conditional_extend[n] if logger_conditional_extend_index is set to n
+* order_total:     [1]      Only log rays that scatter for the n'th time, 0 for all orders
+* order_volume:    [1]      Only log rays that scatter for the n'th time in the same geometry
+* order_volume_process: [1] Only log rays that scatter for the n'th time in the same geometry, using the same process
+* logger_conditional_extend_index: [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then acces logger_conditional_extend[n] if logger_conditional_extend_index is set to n
+* init:            [string] Name of Union_init component (typically "init", default)
 *
 * OUTPUT PARAMETERS:
 *

--- a/mcstas-comps/contrib/union/Union_logger_2D_space_time.comp
+++ b/mcstas-comps/contrib/union/Union_logger_2D_space_time.comp
@@ -7,9 +7,9 @@
 * Written by: Mads Bertelsen
 * Date: 20.08.15
 * Version: $Revision: 0.1 $
-* Origin: Svanevej 19
+* Origin: University of Copenhagen
 *
-* A sample component to separate geometry and phsysics
+* Two dimensional spatail logger for a number of time bins
 *
 * %D
 * Part of the Union components, a set of components that work together and thus
@@ -46,23 +46,25 @@
 *
 * %P
 * INPUT PARAMETERS:
-* D_direction_1:   [string] Direction for first axis ("x", "y" or "z")
-* D1_max:          [1] histogram boundery, max position value for first axis
-* D1_min:          [1] histogram boundery, min position value for first axis
-* n1:              [1] number of bins for first axis
-* D_direction_2:   [string] Direction for second axis ("x", "y" or "z")
-* D2_max:          [1] histogram boundery, max position value for second axis
-* D2_min:          [1] histogram boundery, min position value for second axis
-* n2:              [1] number of bins for second axis
-* time_bins        [1] Number of time bins
-* time_min         [1] Minimum time
-* time_max         [1] Maximum time
-* target_geometry: [string] Comma seperated list of geometry names that will be logged, leave empty for all volumes (even not defined yet)
-* target_process:  [string] Comma seperated names of physical processes, if volumes are selected, one can select Union_process names
-* order_total:     [1] Only log rays that scatter for the n'th time, 0 for all orders
-* order_volume:    [1] Only log rays that scatter for the n'th time in the same geometry
-* order_volume_process [1] Only log rays that scatter for the n'th time in the same geometry, using the same process
-* logger_conditional_extend_index [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then acces logger_conditional_extend[n] if logger_conditional_extend_index is set to n
+* D_direction_1:        [string] Direction for first axis ("x", "y" or "z")
+* D1_max:               [m]      Histogram boundery, max position value for first axis
+* D1_min:               [m]      Histogram boundery, min position value for first axis
+* n1:                   [1]      Number of bins for first axis
+* D_direction_2:        [string] Direction for second axis ("x", "y" or "z")
+* D2_max:               [m]      Histogram boundery, max position value for second axis
+* D2_min:               [m]      Histogram boundery, min position value for second axis
+* n2:                   [1]      Number of bins for second axis
+* time_bins:            [1]      Number of time bins
+* time_min:             [s]      Minimum time
+* time_max:             [s]      Maximum time
+* filename:             [string] Filename of produced data file
+* target_geometry:      [string] Comma seperated list of geometry names that will be logged, leave empty for all volumes (even not defined yet)
+* target_process:       [string] Comma seperated names of physical processes, if volumes are selected, one can select Union_process names
+* order_total:          [1]      Only log rays that scatter for the n'th time, 0 for all orders
+* order_volume:         [1]      Only log rays that scatter for the n'th time in the same geometry
+* order_volume_process: [1]      Only log rays that scatter for the n'th time in the same geometry, using the same process
+* logger_conditional_extend_index: [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then acces logger_conditional_extend[n] if logger_conditional_extend_index is set to n
+* init:                 [string] Name of Union_init component (typically "init", default)
 *
 * OUTPUT PARAMETERS:
 *

--- a/mcstas-comps/contrib/union/Union_logger_3D_space.comp
+++ b/mcstas-comps/contrib/union/Union_logger_3D_space.comp
@@ -9,7 +9,7 @@
 * Version: $Revision: 0.1 $
 * Origin: University of Copenhagen
 *
-* A sample component to separate geometry and phsysics
+* Three dimensional logger for spatial dimensions
 *
 * %D
 * Part of the Union components, a set of components that work together and thus
@@ -47,24 +47,26 @@
 *
 * %P
 * INPUT PARAMETERS:
-* D_direction_1:   [string] Direction for first axis ("x", "y" or "z")
-* D1_max:          [1] histogram boundery, max position value for first axis
-* D1_min:          [1] histogram boundery, min position value for first axis
-* n1:              [1] number of bins for first axis
-* D_direction_2:   [string] Direction for second axis ("x", "y" or "z")
-* D2_max:          [1] histogram boundery, max position value for second axis
-* D2_min:          [1] histogram boundery, min position value for second axis
-* n2:              [1] number of bins for second axis
-* D_direction_3:   [string] Direction for second axis ("x", "y" or "z")
-* D3_max:          [1] histogram boundery, max position value for third axis
-* D3_min:          [1] histogram boundery, min position value for third axis
-* n3:              [1] number of bins for third axis
-* target_geometry: [string] Comma seperated list of geometry names that will be logged, leave empty for all volumes (even not defined yet)
-* target_process:  [string] Comma seperated names of physical processes, if volumes are selected, one can select Union_process names
-* order_total:     [1] Only log rays that scatter for the n'th time, 0 for all orders
-* order_volume:    [1] Only log rays that scatter for the n'th time in the same geometry
-* order_volume_process [1] Only log rays that scatter for the n'th time in the same geometry, using the same process
-* logger_conditional_extend_index [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then acces logger_conditional_extend[n] if logger_conditional_extend_index is set to n
+* D_direction_1:        [string] Direction for first axis ("x", "y" or "z")
+* D1_max:               [m] histogram boundery, max position value for first axis
+* D1_min:               [m] histogram boundery, min position value for first axis
+* n1:                   [1] number of bins for first axis
+* D_direction_2:        [string] Direction for second axis ("x", "y" or "z")
+* D2_max:               [m] histogram boundery, max position value for second axis
+* D2_min:               [m] histogram boundery, min position value for second axis
+* n2:                   [1] number of bins for second axis
+* D_direction_3:        [string] Direction for second axis ("x", "y" or "z")
+* D3_max:               [m] histogram boundery, max position value for third axis
+* D3_min:               [m] histogram boundery, min position value for third axis
+* n3:                   [1] number of bins for third axis
+* filename:             [string] Filename of produced data file
+* target_geometry:      [string] Comma seperated list of geometry names that will be logged, leave empty for all volumes (even not defined yet)
+* target_process:       [string] Comma seperated names of physical processes, if volumes are selected, one can select Union_process names
+* order_total:          [1] Only log rays that scatter for the n'th time, 0 for all orders
+* order_volume:         [1] Only log rays that scatter for the n'th time in the same geometry
+* order_volume_process: [1] Only log rays that scatter for the n'th time in the same geometry, using the same process
+* logger_conditional_extend_index: [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then acces logger_conditional_extend[n] if logger_conditional_extend_index is set to n
+* init:                 [string] name of Union_init component (typically "init", default)
 *
 * OUTPUT PARAMETERS:
 *

--- a/mcstas-comps/contrib/union/Union_make_material.comp
+++ b/mcstas-comps/contrib/union/Union_make_material.comp
@@ -9,6 +9,8 @@
 * Version: $Revision: 0.1 $
 * Origin: University of Copenhagen
 *
+* Component that takes a number of Union processes and constructs a Union material
+*
 * %D
 * Part of the Union components, a set of components that work together and thus
 *  sperates geometry and physics within McStas.
@@ -29,9 +31,10 @@
 *
 * %P
 * INPUT PARAMETERS:
-* process_string:  [string] Comma seperated names of physical processes
-* my_absorption:   [1/m]    Inverse penetration depth from absorption at standard energy
-* absorber:        [0/1]    Control parameter, if set to 1 the material will have no scattering processes
+* process_string: [string] Comma seperated names of physical processes
+* my_absorption:  [1/m]    Inverse penetration depth from absorption at standard energy
+* absorber:       [0/1]    Control parameter, if set to 1 the material will have no scattering processes
+* init:           [string] Name of Union_init component (typically "init", default)
 *
 * OUTPUT PARAMETERS:
 * this_material:            Structure that contains information on this material

--- a/mcstas-comps/contrib/union/Union_master.comp
+++ b/mcstas-comps/contrib/union/Union_master.comp
@@ -9,6 +9,7 @@
 * Version: $Revision: 0.8 $
 * Origin: University of Copenhagen
 *
+* Master component for Union components that performs the overall simulation
 *
 * %D
 * Part of the Union components, a set of components that work together and thus
@@ -30,16 +31,15 @@
 *
 * %P
 * INPUT PARAMETERS:
-*   allow_inside_start:     Set to 1 if rays are expected to start inside a volume in this master
-*   history_limit:          Limits how many histories are recorded before stopping
-*   verbal:                 Toogles terminal output describing the defined simulation
-*   list_verbal:            Toogles information of all internal lists in intersection network
-*   finally_verbal:         Toogles information about cleanup performed in finally section
-*   allow_inside_start      Set to 1 to allow rays to start inside the defined geometry
-*   enable_tagging          Enable tagging of ray history (geometry, scattering process)
-*   history_limit=300000    Limit the number of unique histories that are saved
-*   enable_conditionals     Use conditionals with this master
-*   inherit_number_of_scattering_events Inherit the number of scattering events from last master
+*   verbal:                        [0/1] Toogles terminal output describing the defined simulation
+*   list_verbal:                  [0/1] Toogles information of all internal lists in intersection network
+*   allow_inside_start:     [0/1] Set to 1 if rays are expected to start inside a volume in this master
+*   finally_verbal:             [0/1]Toogles information about cleanup performed in finally section
+*   enable_tagging:          [0/1]  Enable tagging of ray history (geometry, scattering process)
+*   history_limit:               [1]Limit the number of unique histories that are saved
+*   enable_conditionals:  [0/1] Use conditionals with this master
+*   inherit_number_of_scattering_events: [0/1] Inherit the number of scattering events from last master
+ * init:                             [string] Name of Union_init component (typically "init", default)
 *
 * OUTPUT PARAMETERS:
 *
@@ -58,7 +58,6 @@ SETTING PARAMETERS(verbal = 1,
                    history_limit=300000,
                    enable_conditionals=1,
                    inherit_number_of_scattering_events=0,
-                   record_absorption=0,
                    string init="init")
 OUTPUT PARAMETERS ()
 DEPENDENCY "-I@MCCODE_LIB@/share/"
@@ -82,12 +81,10 @@ struct logger_with_data_struct loggers_with_data_array;
 struct abs_logger_with_data_struct abs_loggers_with_data_array;
 
 #ifndef MASTER_DETECTOR
-    //struct pointer_to_global_master_list_master global_master_list_master = {0,NULL};
     #define MASTER_DETECTOR dummy
 #endif
 
 %}
-
 
 DECLARE
 %{
@@ -104,7 +101,7 @@ DECLARE
   struct global_tagging_conditional_list_struct *global_tagging_conditional_list_master;
   struct pointer_to_global_master_list *global_master_list_master;
 
-  // New precompiler settings for verbal / tagging
+  // New precompiler settings for verbal / tagging, remove // to include verbal in trace and/or tagging
   //#define Union_trace_verbal_setting
   //#define Union_enable_tagging_setting
 
@@ -311,7 +308,6 @@ INITIALIZE
   global_tagging_conditional_list_master = COMP_GETPAR3(Union_init, init, global_tagging_conditional_list);
   global_master_list_master = COMP_GETPAR3(Union_init, init, global_master_list);
 
-
   // It is possible to surpress warnings on starting volume by setting this to 1
   starting_volume_warning = 0;
   
@@ -376,7 +372,6 @@ INITIALIZE
         if (global_geometry_list_master->elements[iterator].Volume->geometry.is_masked_volume == 1) number_of_masked_volumes++;
     } else global_geometry_list_master->elements[iterator].active = 0;
   }
-  //printf("Found number of volumes to be %d \n",number_of_volumes);
   
   // Allocation of global lists
   geometry_component_index_list.num_elements = number_of_volumes;
@@ -450,9 +445,6 @@ INITIALIZE
       printf("number_of_masked_volumes = %d\n",number_of_masked_volumes);
   }
   
-  if (record_absorption == 1) {
-    initialize_absorption_file();
-  }
   ); // End MPI_MASTER
   
   
@@ -488,10 +480,8 @@ INITIALIZE
   
   // Position transformation
   for (iterator=0;iterator<global_positions_to_transform_list_master->num_elements;iterator++) {
-    //print_position(*global_positions_to_transform_list_master.positions[iterator],"Position to transform before");
     non_rotated_position = coords_sub(*(global_positions_to_transform_list_master->positions[iterator]),POS_A_CURRENT_COMP);
     *(global_positions_to_transform_list_master->positions[iterator]) = rot_apply(ROT_A_CURRENT_COMP,non_rotated_position);
-    //print_position(*global_positions_to_transform_list_master.positions[iterator],"Position to transform after");
   }
   if (global_positions_to_transform_list_master->num_elements > 0) {
     global_positions_to_transform_list_master->num_elements = 0;
@@ -587,12 +577,9 @@ INITIALIZE
       if (global_geometry_list_master->elements[geometry_list_index].activation_counter == 0) {
         // This is the last time this volume is used, use the hard copy from the geometry component
         Volumes[volume_index] = global_geometry_list_master->elements[geometry_list_index].Volume;
-        //printf("used hard copy of volume %d \n",volume_index);
       } else {
         // Since this volume is still needed more than this once, we need to make a shallow copy and use instead
         
-        //printf("\n");
-        //printf("making local copy of volume %d \n",volume_index);
         Volume_copies[volume_index] = malloc(sizeof(struct Volume_struct));
         *(Volume_copies[volume_index]) = *global_geometry_list_master->elements[geometry_list_index].Volume; // Makes shallow copy
         Volumes[volume_index] = Volume_copies[volume_index];
@@ -680,8 +667,6 @@ INITIALIZE
           Volumes[volume_index]->geometry.focus_array_indices.elements[iterator] = 0;
           
       }
-      //print_1d_int_list(Volumes[volume_index]->geometry.focus_array_indices,"focus_array_indices");
-      
       
       // This component works in its local coordinate system, and thus all information from the input components should be transformed to its coordinate system.
       // All the input components saved their absolute rotation/position into their Volume structure, and the absolute rotation of the current component is known.
@@ -701,7 +686,7 @@ INITIALIZE
       non_rotated_position.z = Volumes[volume_index]->geometry.center.z - POS_A_CURRENT_COMP.z;
 
       rot_transpose(ROT_A_CURRENT_COMP,temp_rotation_matrix); // REVIEW LINE
-      rotated_position = rot_apply(ROT_A_CURRENT_COMP,non_rotated_position);
+      rotated_position = rot_apply(ROT_A_CURRENT_COMP, non_rotated_position);
 
       Volumes[volume_index]->geometry.center.x = rotated_position.x;
       Volumes[volume_index]->geometry.center.y = rotated_position.y;
@@ -779,18 +764,14 @@ INITIALIZE
       if (Volumes[volume_index]->geometry.is_mask_volume == 1) mask_volume_index_list.elements[mask_index_main++] = volume_index;
      
       // Check all loggers assosiated with this volume and update the max_conditional_extend_index if necessary
-      //printf("reached max_test for volume %d \n",volume_index);
       for (iterator=0;iterator<Volumes[volume_index]->loggers.num_elements;iterator++) {
-        //printf("iterator = %d \n",iterator);
         for (process_index=0;process_index<Volumes[volume_index]->loggers.p_logger_volume[iterator].num_elements;process_index++) {
-        //printf("process_index = %d \n",process_index);
           if (Volumes[volume_index]->loggers.p_logger_volume[iterator].p_logger_process[process_index] != NULL) {
             if (Volumes[volume_index]->loggers.p_logger_volume[iterator].p_logger_process[process_index]->logger_extend_index > max_conditional_extend_index)
               max_conditional_extend_index = Volumes[volume_index]->loggers.p_logger_volume[iterator].p_logger_process[process_index]->logger_extend_index;
           }
         }
       }
-      //printf("did max_test for volume %d\n",volume_index);
       
     
     }
@@ -839,13 +820,7 @@ INITIALIZE
         Volumes[volume_index]->geometry.masked_by_mask_index_list.elements[iterator] = find_on_int_list(mask_volume_index_list,Volumes[volume_index]->geometry.masked_by_list.elements[iterator]);
   }
   
-  // Optimizing speed of the within_which_volume search algorithm
-  int volume_index_main; // REVIEW_LINE
-  /*
-  for (volume_index_main=0;volume_index_main<number_of_volumes;volume_index_main++) {
-    Volumes[volume_index_main]->geometry.destinations_logic_list.elements[0] = 0;
-  }
-  */
+  int volume_index_main;
   
   // Checking for equal priorities in order to alert the user to a potential input error
   for (volume_index_main=0;volume_index_main<number_of_volumes;volume_index_main++) {
@@ -1079,7 +1054,7 @@ TRACE
   #endif
   
   // Now the initial current_volume can be found, which requires the up to date mask_status_list
-  current_volume = within_which_volume_GPU(ray_position,starting_lists.reduced_start_list,starting_lists.starting_destinations_list,Volumes,&mask_status_list,number_of_volumes,pre_allocated1,pre_allocated2,pre_allocated3);
+  current_volume = within_which_volume_GPU(ray_position, starting_lists.reduced_start_list, starting_lists.starting_destinations_list, Volumes, &mask_status_list, number_of_volumes, pre_allocated1, pre_allocated2, pre_allocated3);
   
   // Using the mask_status_list and the current volume, the current_mask_intersect_list_status can be made
   //  it contains the effective mask status of all volumes on the current volumes mask intersect list, which needs to be calculated,
@@ -1148,18 +1123,13 @@ TRACE
         if (intersection_time_table.calculated[*check] == 0) {
              #ifdef Union_trace_verbal_setting
                printf("running intersection for intersect_list with *check = %d \n",*check);
-               // printf("r = (%f,%f,%f) v = (%f,%f,%f) \n",r[0],r[1],r[2],v[0],v[1],v[2]);
              #endif
-            // Calculate intersections using intersect function imbedded in the relevant volume structure using parameters
-            //  that are also imbedded in the structure.
-            // CPU Only
-            //geometry_output = Volumes[*check]->geometry.intersect_function(intersection_time_table.intersection_times[*check],number_of_solutions,r_start,v,&Volumes[*check]->geometry);
-            
+            // Calculate intersections using intersect function imbedded in the relevant volume structure using parameters that are also imbedded in the structure.
+
             // GPU Flexible intersect_function call
             geometry_output = intersect_function(intersection_time_table.intersection_times[*check], number_of_solutions, r_start, v, &Volumes[*check]->geometry);
             
             intersection_time_table.calculated[*check] = 1;
-            // printf("succesfully calculated intersection times for volume *check = %d \n",*check);
         }
     }
     
@@ -1243,9 +1213,6 @@ TRACE
           printf("intersection_with_children = %d \n",intersection_with_children);
         #endif
         if (intersection_with_children == 0) {
-            // CPU Only
-            //geometry_output = Volumes[current_volume]->geometry.intersect_function(intersection_time_table.intersection_times[current_volume],number_of_solutions,r_start,v,&Volumes[current_volume]->geometry);
-            
             // GPU Allowed
             geometry_output = intersect_function(intersection_time_table.intersection_times[current_volume], number_of_solutions, r_start, v, &Volumes[current_volume]->geometry);
             intersection_time_table.calculated[current_volume] = 1;
@@ -1365,10 +1332,7 @@ TRACE
               focus_data_index = Volumes[current_volume]->geometry.focus_array_indices.elements[p_index];
               
               // Call the probability for scattering function assighed to this specific procress (the process pointer is updated in the for loop)
-              // CPU Only
-              //process->probability_for_scattering_function(p_my_trace,k_rotated,process->data_transfer,&Volumes[current_volume]->geometry.focus_data_array.elements[focus_data_index]);
-              // GPU Allowed
-              process = &Volumes[current_volume]->p_physics->p_scattering_array[p_index];
+              process = &Volumes[current_volume]->p_physics->p_scattering_array[p_index]; // GPU Allowed
               
               int physics_output;
               physics_output = physics_my(process->eProcess, p_my_trace, k_rotated, process->data_transfer,&Volumes[current_volume]->geometry.focus_data_array.elements[focus_data_index], _particle);
@@ -1530,7 +1494,6 @@ TRACE
                 abs_distance = -log(1.0 - rand0max(1.0 - exp(-my_sum_plus_abs*length_to_boundery)) ) / my_sum_plus_abs;
             }
 
-            //printf("abs_distance = %g (with my=%g, scattering_event=%i) \n", abs_distance, my_sum_plus_abs, scattering_event);
             t_abs_propagation = abs_distance/v_length;
 
             abs_position = coords_set(x + t_abs_propagation*vx, y + t_abs_propagation*vy, z + t_abs_propagation*vz);
@@ -1544,9 +1507,6 @@ TRACE
         
             // Logging for detector components assosiated with this volume
             for (log_index=0;log_index<Volumes[current_volume]->abs_loggers.num_elements;log_index++) {
-              //printf("logging time! Volume specific version. Volume name = %s \n",Volumes[current_volume]->name);
-              //printf("  log_index = %d \n",log_index);
-              
               // Make transformation according to the individual position of the abs_logger? This would require position / rotation for all abs_loggers
               transformed_abs_position = coords_sub(abs_position, Volumes[current_volume]->abs_loggers.p_abs_logger[log_index]->position);
               transformed_abs_position = rot_apply(Volumes[current_volume]->abs_loggers.p_abs_logger[log_index]->rotation, transformed_abs_position);
@@ -1563,7 +1523,6 @@ TRACE
               printf("Running abs_logger system for all volumes \n");
             #endif
             for (log_index=0;log_index<global_all_volume_abs_logger_list_master->num_elements;log_index++) {
-              //printf("logging time! Global version. log_index = %d \n",log_index);
               // As above, but on a global scale, meaning scattering in all volumes are logged
               
               // Problems with VN, PV, as there is no assosiated volume or process. The functions however need to have the same input to make the logger components general.
@@ -1582,9 +1541,8 @@ TRACE
         if (scattering_event == 1) {
             #ifdef Union_trace_verbal_setting
               printf("SCATTERING EVENT \n");
-              printf("current_volume            = %d \n",current_volume);
-              printf("r = (%f,%f,%f) v = (%f,%f,%f) \n",r[0],r[1],r[2],v[0],v[1],v[2]);
-            // printf("did scatter: my_trace = %E = %f \n",my_trace[selected_process],my_trace[selected_process]);
+              printf("current_volume            = %d \n", current_volume);
+              printf("r = (%f,%f,%f) v = (%f,%f,%f) \n", r[0], r[1], r[2], v[0], v[1], v[2]);
             #endif
             
             // Calculate the time to scattering
@@ -1592,15 +1550,13 @@ TRACE
             
             #ifdef Union_trace_verbal_setting
               printf("time to scattering        = %2.20f \n",time_to_scattering);
+              printf("length to boundery = %f, length to scattering = %f \n",length_to_boundery,length_to_scattering);
             #endif
             
-            //#ifdef Union_trace_verbal_setting
-            //printf("length to boundery = %f, length to scattering = %f \n",length_to_boundery,length_to_scattering);
-            //#endif
+            // May be replace by version without gravity
+            //PROP_DT(time_to_scattering);
             
-            //PROP_DT(time_to_scattering); // May be replace by version without gravity
-            
-            // Reduce the double book keeping done here // REVIEW LINE
+            // Reduce the double book keeping done here
             x += time_to_scattering*vx; y += time_to_scattering*vy; z += time_to_scattering*vz; t += time_to_scattering;
             r_start[0] = x; r_start[1] = y; r_start[2] = z;
             r[0] = x; r[1] = y; r[2] = z;
@@ -1608,7 +1564,7 @@ TRACE
             ray_velocity = coords_set(vx,vy,vz);
             
             // Safe check that should be unecessary. Used to fine tune how close to the edge of a volume a scattering event is allowed to take place (1E-14 m away currently).
-            if (r_within_function(ray_position,&Volumes[current_volume]->geometry) == 0) {
+            if (r_within_function(ray_position, &Volumes[current_volume]->geometry) == 0) {
               printf("\nERROR, propagated out of current volume instead of to a point within!\n");
               printf("length_to_scattering_specified = %2.20f\n             length propagated = %2.20f\n            length_to_boundery = %2.20f \n   current_position = (%lf,%lf,%lf) \n",length_to_scattering,sqrt(time_to_scattering*time_to_scattering*vx*vx+time_to_scattering*time_to_scattering*vy*vy+time_to_scattering*time_to_scattering*vz*vz),length_to_boundery,x,y,z);
               
@@ -1634,15 +1590,10 @@ TRACE
             }
                 
             // test_physics_scattering(double *k_final, double *k_initial, union data_transfer_union data_transfer) {
-            //k[0] = V2K*ray_velocity.x; k[1] = V2K*ray_velocity.y; k[2] = V2K*ray_velocity.z;
-            coords_get(coords_scalar_mult(ray_velocity_rotated,V2K),&k[0],&k[1],&k[2]);
+            coords_get(coords_scalar_mult(ray_velocity_rotated,V2K), &k[0], &k[1], &k[2]);
             
             // I may replace a intial and final k with one instance that serves as both input and output
-            // CPU Only
-            //if (0 == Volumes[current_volume]->p_physics->p_scattering_array[selected_process].scattering_function(k_new,k,&p,Volumes[current_volume]->p_physics->p_scattering_array[selected_process].data_transfer,&Volumes[current_volume]->geometry.focus_data_array.elements[0])) {
-            // GPU Version with flexible function
-
-            process = &Volumes[current_volume]->p_physics->p_scattering_array[selected_process];
+            process = &Volumes[current_volume]->p_physics->p_scattering_array[selected_process]; // CPU Only
             if (0 == physics_scattering(process->eProcess, k_new, k, &p, process->data_transfer, &Volumes[current_volume]->geometry.focus_data_array.elements[0], _particle)) {
               /*
               // PowderN and Single_crystal requires the option of absorbing the neutron, which is weird. If there is a scattering probability, there should be a new direction.
@@ -1668,8 +1619,7 @@ TRACE
             }
             
             // Write velocity to global variable (temp, only really necessary at final)
-            //vx = ray_velocity.x; vy = ray_velocity.y; vz = ray_velocity.z;
-            coords_get(ray_velocity_final,&vx,&vy,&vz);
+            coords_get(ray_velocity_final, &vx, &vy, &vz);
             
             // Write velocity in array format as it is still used by intersect functions (temp, they need to be updated to ray_position / ray_velocity)
             v[0] = vx; v[1] = vy; v[2] = vz;
@@ -1682,16 +1632,12 @@ TRACE
             #endif
             // Logging for detector components assosiated with this volume
             for (log_index=0;log_index<Volumes[current_volume]->loggers.num_elements;log_index++) {
-              //printf("logging time! Volume specific version. Volume name = %s \n",Volumes[current_volume]->name);
-              //printf("  log_index = %d \n",log_index);
               if (Volumes[current_volume]->loggers.p_logger_volume[log_index].p_logger_process[selected_process] != NULL) {
                 // Technically the scattering function could edit k, the wavevector before the scattering, even though there would be little point to doing that.
                 // Could save a secure copy and pass that instead to be certain that no scattering process accidently tampers with the logging.
-                // printf("  the logging function pointer was not NULL \n");
-                // PV (number of time scattered in this volume/process combination is not recorded. Need to expand scattering_flag to contain 2D, volume and process
                 
                 // This function calls a logger function which in turn stores some data among the passed, and possibly performs some basic data analysis
-                Volumes[current_volume]->loggers.p_logger_volume[log_index].p_logger_process[selected_process]->function_pointers.active_record_function(&ray_position,k_new,k_old,p,p_old,t,scattered_flag[current_volume],scattered_flag_VP[current_volume][selected_process],number_of_scattering_events,Volumes[current_volume]->loggers.p_logger_volume[log_index].p_logger_process[selected_process],&loggers_with_data_array);
+                Volumes[current_volume]->loggers.p_logger_volume[log_index].p_logger_process[selected_process]->function_pointers.active_record_function(&ray_position, k_new, k_old, p, p_old, t, scattered_flag[current_volume], scattered_flag_VP[current_volume][selected_process], number_of_scattering_events, Volumes[current_volume]->loggers.p_logger_volume[log_index].p_logger_process[selected_process], &loggers_with_data_array);
                 // If the logging component have a conditional attatched, the collected data will be written to a temporary place
                 // At the end of the rays life, it will be checked if the condition is met
                 //  if it is met, the temporary data is transfered to permanent, and temp is cleared.
@@ -1703,22 +1649,19 @@ TRACE
               printf("Running logger system for all volumes \n");
             #endif
             for (log_index=0;log_index<global_all_volume_logger_list_master->num_elements;log_index++) {
-              //printf("logging time! Global version. log_index = %d \n",log_index);
               // As above, but on a global scale, meaning scattering in all volumes are logged
               
               // Problems with VN, PV, as there is no assosiated volume or process. The functions however need to have the same input to make the logger components general.
               // Could be interesting to have a monitor that just globally measurres the second scattering event in any volume (must be two in the same). Weird but not meaningless.
-              global_all_volume_logger_list_master->elements[log_index].logger->function_pointers.active_record_function(&ray_position,k_new,k_old,p,p_old,t,scattered_flag[current_volume],scattered_flag_VP[current_volume][selected_process],number_of_scattering_events,global_all_volume_logger_list_master->elements[log_index].logger,&loggers_with_data_array);
+              global_all_volume_logger_list_master->elements[log_index].logger->function_pointers.active_record_function(&ray_position, k_new, k_old, p, p_old, t, scattered_flag[current_volume], scattered_flag_VP[current_volume][selected_process], number_of_scattering_events, global_all_volume_logger_list_master->elements[log_index].logger, &loggers_with_data_array);
             }
-            
             
             SCATTER;
             ++number_of_scattering_events;
             ++scattered_flag[current_volume];
             ++scattered_flag_VP[current_volume][selected_process];
             
-
-            // Empty intersection time lists
+            // Clear intersection time lists as the direction of the ray has changed
             clear_intersection_table(&intersection_time_table);
             time_propagated_without_scattering = 0.0;
             #ifdef Union_trace_verbal_setting
@@ -1726,26 +1669,25 @@ TRACE
               printf("r = (%f,%f,%f) v = (%f,%f,%f) \n",x,y,z,vx,vy,vz);
             
 	      if (enable_tagging && stop_tagging_ray == 0) printf("Before new process node: current_tagging_node->intensity = %f\n",current_tagging_node->intensity);
-              if (enable_tagging && stop_tagging_ray == 0) printf("Before new process node: current_tagging_node->number_of_rays = %d\n",current_tagging_node->number_of_rays);
+              if (enable_tagging && stop_tagging_ray == 0) printf("Before new process node: current_tagging_node->number_of_rays = %d\n", current_tagging_node->number_of_rays);
             #endif
             
 	    if (enable_tagging && stop_tagging_ray == 0)
-                current_tagging_node = goto_process_node(current_tagging_node,selected_process,Volumes[current_volume],&stop_tagging_ray,stop_creating_nodes);
+                current_tagging_node = goto_process_node(current_tagging_node, selected_process,Volumes[current_volume], &stop_tagging_ray,stop_creating_nodes);
                         
             #ifdef Union_trace_verbal_setting
             
-              if (enable_tagging && stop_tagging_ray == 0) printf("After new process node: current_tagging_node->intensity = %f\n",current_tagging_node->intensity);
-              if (enable_tagging && stop_tagging_ray == 0) printf("After new process node: current_tagging_node->number_of_rays = %d\n",current_tagging_node->number_of_rays);            
+              if (enable_tagging && stop_tagging_ray == 0) printf("After new process node: current_tagging_node->intensity = %f\n", current_tagging_node->intensity);
+              if (enable_tagging && stop_tagging_ray == 0) printf("After new process node: current_tagging_node->number_of_rays = %d\n", current_tagging_node->number_of_rays);
             #endif
             
         } else {
             #ifdef Union_trace_verbal_setting
               printf("Propagate out of volume %d\n", current_volume);
-              printf("r = (%f,%f,%f) v = (%f,%f,%f) \n",x,y,z,vx,vy,vz);
+              printf("r = (%f,%f,%f) v = (%f,%f,%f) \n", x, y, z, vx, vy, vz);
             #endif
             // Propagate neutron to found minimum time
-            // PROP_DT(min_intersection_time - time_propagated_without_scattering);
-            //time_to_boundery = min_intersection_time - time_propagated_without_scattering;
+            // PROP_DT(time_to_boundery);
             x += time_to_boundery*vx;
             y += time_to_boundery*vy;
             z += time_to_boundery*vz;
@@ -1809,29 +1751,11 @@ TRACE
                   print_1d_int_list(current_mask_intersect_list_status,"Updated current_mask_intersect_list_status");
                 #endif
                 
-                
-                // Debugging phase
-                /*
-                if (tree_next_volume == 0) {
-                    volume_0_found=0;
-                    for (start = check = Volumes[current_volume]->geometry.destinations_list.elements;check - start < Volumes[current_volume]->geometry.destinations_list.num_elements;check++) {
-                        if (*check == 0) {
-                            volume_0_found = 1;
-                        }
-                    }
-                    if (volume_0_found==0) printf("ERROR The within_which_volume function returned 0 for a volume where volume 0 is not on the destination list!\n");
-                }
-                */
-                
             } else {
                 #ifdef Union_trace_verbal_setting
                   if (enable_tagging && stop_tagging_ray == 0) printf("Before new intersection volume node: current_tagging_node->intensity = %f\n",current_tagging_node->intensity);
                   if (enable_tagging && stop_tagging_ray == 0) printf("Before new intersection volume node: current_tagging_node->number_of_rays = %d\n",current_tagging_node->number_of_rays);
                 #endif
-            
-                //if (enable_tagging) current_tagging_node = goto_volume_node(current_tagging_node, current_volume, min_volume, Volumes);
-                
-                
                 
                 // Mask update: If the min_volume is not a mask, things are simple, current_volume = min_volume.
                 //               however, if it is a mask, the mask status will switch.
@@ -1839,14 +1763,14 @@ TRACE
                 //               if the mask status becomes zero (and the current volume is masked by min_volume), the destinations list of the mask is searched
                 //               if the mask status becomes zero (and the current volume is NOT masked by min volume), the current volume doesn't change
                 
-                
                 if (Volumes[min_volume]->geometry.is_mask_volume == 0) {
                   #ifdef Union_trace_verbal_setting
                     printf("Min volume is not a mask, next volume = min volume\n");
                   #endif
-                  if (enable_tagging && stop_tagging_ray == 0) current_tagging_node = goto_volume_node(current_tagging_node, current_volume, min_volume, Volumes,&stop_tagging_ray,stop_creating_nodes);
+                  if (enable_tagging && stop_tagging_ray == 0) {
+                    current_tagging_node = goto_volume_node(current_tagging_node, current_volume, min_volume, Volumes,&stop_tagging_ray,stop_creating_nodes);
+                  }
                   current_volume = min_volume;
-                  //update_current_mask_intersect_status(&current_mask_intersect_list_status, &mask_status_list, Volumes, &current_volume);
                 } else {
                   #ifdef Union_trace_verbal_setting
                     printf("Current volume is not a mask, complex decision tree\n");
@@ -1858,7 +1782,6 @@ TRACE
                     #endif
                     mask_status_list.elements[Volumes[min_volume]->geometry.mask_index] = 0;
                     // If the current volume is masked by this mask, run within_which_volume using the masks destination list, otherwise keep the current volume
-                    //if (on_int_list(Volumes[min_volume]->geometry.mask_list,current_volume))
                     if (on_int_list(Volumes[current_volume]->geometry.masked_by_list,min_volume) == 1) {
                       #ifdef Union_trace_verbal_setting
                         printf("The current volume was masked by this mask, and my need updating\n");
@@ -1866,7 +1789,7 @@ TRACE
                       // In case of ANY mode, need to see if another mask on the masked_by list of the current volume is active, and if so, nothing happens
                       need_to_run_within_which_volume = 1;
                       if (Volumes[current_volume]->geometry.mask_mode == 2) {
-                        for (mask_start=mask_check=Volumes[current_volume]->geometry.masked_by_mask_index_list.elements;mask_check-mask_start<Volumes[current_volume]->geometry.masked_by_mask_index_list.num_elements;mask_check++) {
+                        for (mask_start=mask_check=Volumes[current_volume]->geometry.masked_by_mask_index_list.elements; mask_check-mask_start<Volumes[current_volume]->geometry.masked_by_mask_index_list.num_elements; mask_check++) {
                           if (mask_status_list.elements[*mask_check] == 1) {
                             // Nothing needs to be done, the effective mask status of the current volume is still 1
                             need_to_run_within_which_volume = 0;
@@ -1891,7 +1814,7 @@ TRACE
                             // figure out the effective mask status of this volume
                             if (Volumes[Volumes[min_volume]->geometry.destinations_list.elements[0]]->geometry.mask_mode == 2) { // ANY mask mode
                               tree_next_volume = 0;
-                              for (mask_start=mask_check=Volumes[Volumes[min_volume]->geometry.destinations_list.elements[0]]->geometry.masked_by_mask_index_list.elements;mask_check-mask_start<Volumes[Volumes[min_volume]->geometry.destinations_list.elements[0]]->geometry.masked_by_mask_index_list.num_elements;mask_check++) {
+                              for (mask_start=mask_check=Volumes[Volumes[min_volume]->geometry.destinations_list.elements[0]]->geometry.masked_by_mask_index_list.elements; mask_check-mask_start<Volumes[Volumes[min_volume]->geometry.destinations_list.elements[0]]->geometry.masked_by_mask_index_list.num_elements; mask_check++) {
                                 if (mask_status_list.elements[*mask_check] == 1) {
                                   tree_next_volume = Volumes[min_volume]->geometry.destinations_list.elements[0];
                                   break;
@@ -1910,24 +1833,22 @@ TRACE
                           #ifdef Union_trace_verbal_setting
                             printf("The method found the next tree volume to be %d\n",tree_next_volume);
                           #endif
-                          if (enable_tagging && stop_tagging_ray == 0) current_tagging_node = goto_volume_node(current_tagging_node, current_volume, tree_next_volume, Volumes,&stop_tagging_ray,stop_creating_nodes);
+                          if (enable_tagging && stop_tagging_ray == 0) current_tagging_node = goto_volume_node(current_tagging_node, current_volume, tree_next_volume, Volumes, &stop_tagging_ray, stop_creating_nodes);
                           current_volume = tree_next_volume;
-                          //update_current_mask_intersect_status(&current_mask_intersect_list_status, &mask_status_list, Volumes, &current_volume);
                         } else {
                           #ifdef Union_trace_verbal_setting
                             printf("Many elements in destinations list, use within_which_volume\n");
                           #endif
                           ray_position = coords_set(x,y,z);
                           ray_velocity = coords_set(vx,vy,vz);
-                          tree_next_volume = within_which_volume_GPU(ray_position,Volumes[min_volume]->geometry.reduced_destinations_list,Volumes[min_volume]->geometry.destinations_list,Volumes,&mask_status_list,number_of_volumes,pre_allocated1,pre_allocated2,pre_allocated3);
-                        // } Bug fixed on 27/11/2016
+                          tree_next_volume = within_which_volume_GPU(ray_position, Volumes[min_volume]->geometry.reduced_destinations_list, Volumes[min_volume]->geometry.destinations_list, Volumes, &mask_status_list, number_of_volumes, pre_allocated1, pre_allocated2, pre_allocated3);
+
                           if (enable_tagging && stop_tagging_ray == 0) current_tagging_node = goto_volume_node(current_tagging_node, current_volume, tree_next_volume, Volumes,&stop_tagging_ray,stop_creating_nodes);
                           current_volume = tree_next_volume;
                           #ifdef Union_trace_verbal_setting
                             printf("Set new new volume to %d\n",tree_next_volume);
                           #endif
-                        } // Moved here on 27/11/2016, problem was two calls to current_tagging_node when only one element in destinations list
-                        //update_current_mask_intersect_status(&current_mask_intersect_list_status, &mask_status_list, Volumes, &current_volume);
+                        }
                       } else {
                         #ifdef Union_trace_verbal_setting
                           printf("Did not need updating, as another mask was covering the volume\n");
@@ -1941,19 +1862,17 @@ TRACE
                     // When entering a mask, the new highest priority volume may be one of the masked volumes, if not we keep the current volume
                     ray_position = coords_set(x,y,z);
                     ray_velocity = coords_set(vx,vy,vz);
-                    //tree_next_volume = within_which_volume(ray_position,Volumes[min_volume]->geometry.mask_list,Volumes[min_volume]->geometry.destinations_list,Volumes,&mask_status_list,number_of_volumes,pre_allocated1,pre_allocated2,pre_allocated3);
                     // Bug found on the 2/9 2016, the destinations_list of a mask does not contain the volumes inside it. Could make an additional list for this.
                     // The temporary fix will be to use the mask list for both reduced destinations list and destinations list.
-                    tree_next_volume = within_which_volume_GPU(ray_position,Volumes[min_volume]->geometry.mask_list,Volumes[min_volume]->geometry.mask_list,Volumes,&mask_status_list,number_of_volumes,pre_allocated1,pre_allocated2,pre_allocated3);
+                    tree_next_volume = within_which_volume_GPU(ray_position, Volumes[min_volume]->geometry.mask_list, Volumes[min_volume]->geometry.mask_list, Volumes, &mask_status_list, number_of_volumes, pre_allocated1, pre_allocated2, pre_allocated3);
                     // if within_which_volume returns 0, no result was found (volume 0 can not be masked, so it could not be on the mask list)
                     if (tree_next_volume != 0) {
                       if (Volumes[tree_next_volume]->geometry.priority_value > Volumes[current_volume]->geometry.priority_value) {
                         // In case the current volume has a higher priority, nothing happens, otherwise change current volume
-                        if (enable_tagging && stop_tagging_ray == 0) current_tagging_node = goto_volume_node(current_tagging_node, current_volume, tree_next_volume, Volumes,&stop_tagging_ray,stop_creating_nodes);
+                        if (enable_tagging && stop_tagging_ray == 0) current_tagging_node = goto_volume_node(current_tagging_node, current_volume, tree_next_volume, Volumes, &stop_tagging_ray, stop_creating_nodes);
                         current_volume = tree_next_volume;
                       }
                     }
-                    //update_current_mask_intersect_status(&current_mask_intersect_list_status, &mask_status_list, Volumes, &current_volume);
                   }
                 }
                 
@@ -1970,24 +1889,11 @@ TRACE
             if (Volumes[current_volume]->geometry.is_exit_volume==1) {
                     done = 1; // Exit volumes allow the ray to escape the component
                     ray_sucseeded = 1; // Allows the ray to
-                    /*
-                    // Moved to after while loop to collect code
-                    if (enable_tagging && stop_tagging_ray == 0)
-                        add_statistics_to_node(current_tagging_node,&ray_position, &ray_velocity, &p, &tagging_leaf_counter);
-                
-                    x += vx*1E-9; y += vy*1E-9; z += vz*1E-9; t += 1E-9;
-                    */
             }
             #ifdef Union_trace_verbal_setting
               printf(" TO VOLUME %d \n",current_volume);
             #endif
         }
-        
-        // Record final position here and write to file
-        MPI_MASTER(
-            //if (record_absorption == 1 && abs_weight_factor < 1.0) record_abs_to_file(r_old, time_old, r, t, initial_weight*(1.0-abs_weight_factor), current_volume, mcget_run_num(), &absorption_index, absorption_event_data);
-            if (record_absorption == 1) record_abs_to_file(r_old, time_old, r, t, initial_weight*(1.0-abs_weight_factor), current_volume, mcget_run_num(), &absorption_index, absorption_event_data);
-        );
         
     } else { // Here because a shortest time is not found
         if (current_volume == 0) {
@@ -2013,16 +1919,8 @@ TRACE
               printf("r = (%f,%f,%f) v = (%f,%f,%f) \n",x,y,z,vx,vy,vz);
               
               printf("Trace error number (%d/100) \n",component_error_msg);
-              //print_intersection_table(intersection_time_table);
-              //printf("Cluster is loosing the thread, debug for this behavior\n");
-              //printf("global_all_volume_logger_list_master->num_elements = %d\n",global_all_volume_logger_list_master->num_elements);
-              //printf("global_specific_volumes_logger_list_master->num_elements = %d\n",global_specific_volumes_logger_list_master->num_elements);
-              
-              //exit(1); // Temporary
             }
             error_msg++;
-            
-            //exit(1); // temp for debug
             
             if (component_error_msg > 100) {
                 printf("To many errors encountered, exiting. \n");
@@ -2031,56 +1929,35 @@ TRACE
             }
         }
     }
-    /*
-    */
-    if (limit == 0) {done = 1; ray_sucseeded = 0; printf("Reached limit on number of interactions, and discarded the neutron, was in volume %d\n",current_volume);ABSORB;}
+    
+    if (limit == 0) {done = 1; ray_sucseeded = 0; printf("Reached limit on number of interactions, and discarded the neutron, was in volume %d\n", current_volume); ABSORB;}
     #ifdef Union_trace_verbal_setting
       printf("----------- END OF WHILE LOOP --------------------------------------\n");
     #endif
-    //printf("This ray did %d iterations in the while loop\n",1000-limit);
     
   }
   // Could move all add_statistics and similar to this point, but need to filter for failed rays
   if (ray_sucseeded == 1) {
     
-    /*
-    // Instead of keeping global and specific loggers apart, lets do them in one loop using the loggers_with_data_array
-    // Only needed for conditionals
-    // Loop over global loggers, may or may not have a conditional, only necessary to do anything here when they do.
-    for (log_index=0;log_index<global_all_volume_logger_list_master->num_elements;log_index++) {
-      if (global_all_volume_logger_list_master->elements[log_index].logger->has_conditional == 1) {
-        if (1 == conditional_return = global_all_volume_logger_list_master->elements[log_index].logger->conditional(scattered_flag,scattered_flag_VP,global_loggers.elements[log_index].conditional_data_union,k_final,current_volume,x,y,z)) {
-          global_all_volume_logger_list_master->elements[log_index].logger->function_pointers->temp_to_perm(global_loggers.elements[log_index].logger_data_union);
-          
-        }
-        if (global_all_volume_logger_list_master->elements[log_index].logger->conditional_extend_index != -1)
-          // The user can set a condtional_extend_index, so that the evaluation of this specific conditional can be taken easily from extend
-          conditional_extend_array.elements[global_all_volume_logger_list_master->elements[log_index].logger->conditional_extend_index] = conditional_return;
-          // Do not need to reset these to 0, as they will be manually set to 0 if not fulfilled
-      }
-    }
-    */
+    // Ray sucseeded, need to check status of conditionals
     #ifdef Union_trace_verbal_setting
       printf("----------- logger loop --------------------------------------\n");
     #endif
     // Loggers attatched to specific volumes need to be handled with care to avoid looping over all loggers for every ray
-    //for (log_index=0;log_index<loggers_with_data_array.used_elements;log_index++) {
-    // TEST
     if (enable_conditionals == 1) {
-      for (log_index=loggers_with_data_array.used_elements-1;log_index>-1;log_index--) {
+      for (log_index=loggers_with_data_array.used_elements-1; log_index>-1; log_index--) {
         // Check all conditionals attatched to the current logger
         this_logger = loggers_with_data_array.logger_pointers[log_index];
         conditional_status = 1;
         for (iterator=0;iterator<loggers_with_data_array.logger_pointers[log_index]->conditional_list.num_elements;iterator++) {
           // Call this particular conditional. If it fails, report the status and break
-          //printf("checking conditional! \n");
           #ifdef Union_trace_verbal_setting
             printf("Checking conditional number %d for logger named %s \n",iterator,loggers_with_data_array.logger_pointers[log_index]->name);
           #endif
           if (0 == this_logger->conditional_list.conditional_functions[iterator](
                          this_logger->conditional_list.p_data_unions[iterator],
-                         &ray_position,&ray_velocity,&p,&t,&current_volume,
-                         &number_of_scattering_events,scattered_flag,scattered_flag_VP)) {
+                         &ray_position, &ray_velocity, &p, &t, &current_volume,
+                         &number_of_scattering_events, scattered_flag,scattered_flag_VP)) {
             conditional_status = 0;
             break;
           }
@@ -2096,19 +1973,16 @@ TRACE
             loggers_with_data_array.logger_pointers[log_index]->function_pointers.temp_to_perm_final_p(&loggers_with_data_array.logger_pointers[log_index]->data_union,p);
           }
         
-          // Luxury feature to be added later
+            // The user can set a condtional_extend_index, so that the evaluation of this specific conditional can be taken easily from extend
           if (loggers_with_data_array.logger_pointers[log_index]->logger_extend_index != -1) {
             #ifdef Union_trace_verbal_setting
-              printf("Updating logger_conditional_extend_array[%d] to 1 (max length = %d)\n",loggers_with_data_array.logger_pointers[log_index]->logger_extend_index,max_conditional_extend_index);
+              printf("Updating logger_conditional_extend_array[%d] to 1 (max length = %d)\n", loggers_with_data_array.logger_pointers[log_index]->logger_extend_index, max_conditional_extend_index);
             #endif
-            // The user can set a condtional_extend_index, so that the evaluation of this specific conditional can be taken easily from extend
-            logger_conditional_extend_array[loggers_with_data_array.logger_pointers[log_index]->logger_extend_index] = 1;
+            logger_conditional_extend_array[loggers_with_data_array.logger_pointers[log_index]->logger_extend_index] = 1; // Can be reached from EXTEND
             // Are all reset to 0 for each new ray
             #ifdef Union_trace_verbal_setting
               printf("Updated extend index sucessfully\n");
             #endif
-          
-            //printf("extend_array[%d] = 1 \n",loggers_with_data_array.logger_pointers[log_index]->logger_extend_index);
           }
         
           // Need to remove the current element from logger_with_data as it has been cleared and written to disk
@@ -2118,27 +1992,17 @@ TRACE
             loggers_with_data_array.logger_pointers[log_index] = loggers_with_data_array.logger_pointers[loggers_with_data_array.used_elements-1];
             // Decrease logger_with_data.used_elements with 1
             loggers_with_data_array.used_elements--;
-          
           }
-        
-        
-        } else {
-           // Conditional status was 0, clear temp data for this logger, but only if this is the last Union_master,
-           //  as the logger data can be written if one of the ray fulfills the conditional afer one of the
-           //  subsequent Union masters.
-           // The job of cleaning was moved to the start of trace on 15/5/2017
-           //if (global_master_list_master->elements[global_master_list_master->num_elements-1].component_index == INDEX_CURRENT_COMP)
-           //  loggers_with_data_array.logger_pointers[log_index]->function_pointers.clear_temp(&loggers_with_data_array.logger_pointers[log_index]->data_union);
         }
       }
-      // Perform the same with abs_loggers and their conditionals
-      for (log_index=abs_loggers_with_data_array.used_elements-1;log_index>-1;log_index--) {
+        
+      // Perform the same loop with abs_loggers and their conditionals
+      for (log_index=abs_loggers_with_data_array.used_elements-1; log_index>-1; log_index--) {
         // Check all conditionals attatched to the current logger
         this_abs_logger = abs_loggers_with_data_array.abs_logger_pointers[log_index];
         conditional_status = 1;
         for (iterator=0;iterator<abs_loggers_with_data_array.abs_logger_pointers[log_index]->conditional_list.num_elements;iterator++) {
           // Call this particular conditional. If it fails, report the status and break
-          //printf("checking conditional! \n");
           #ifdef Union_trace_verbal_setting
             printf("Checking conditional number %d for abs logger named %s \n",iterator, abs_loggers_with_data_array.abs_logger_pointers[log_index]->name);
           #endif
@@ -2155,19 +2019,16 @@ TRACE
           // The input for the temp_to_perm function is a pointer to the logger_data_union for the appropriate logger
           abs_loggers_with_data_array.abs_logger_pointers[log_index]->function_pointers.temp_to_perm(&abs_loggers_with_data_array.abs_logger_pointers[log_index]->data_union);
         
-          // Luxury feature to be added later
+          // The user can set a condtional_extend_index, so that the evaluation of this specific conditional can be taken easily from extend
           if (abs_loggers_with_data_array.abs_logger_pointers[log_index]->abs_logger_extend_index != -1) {
             #ifdef Union_trace_verbal_setting
               printf("Updating logger_conditional_extend_array[%d] to 1 (max length = %d)\n",abs_loggers_with_data_array.abs_logger_pointers[log_index]->abs_logger_extend_index,max_conditional_extend_index);
             #endif
-            // The user can set a condtional_extend_index, so that the evaluation of this specific conditional can be taken easily from extend
-            abs_logger_conditional_extend_array[abs_loggers_with_data_array.abs_logger_pointers[log_index]->abs_logger_extend_index] = 1;
+            abs_logger_conditional_extend_array[abs_loggers_with_data_array.abs_logger_pointers[log_index]->abs_logger_extend_index] = 1; // Can be reached from EXTEND
             // Are all reset to 0 for each new ray
             #ifdef Union_trace_verbal_setting
               printf("Updated extend index sucessfully\n");
             #endif
-          
-            //printf("extend_array[%d] = 1 \n",loggers_with_data_array.logger_pointers[log_index]->logger_extend_index);
           }
         
           // Need to remove the current element from logger_with_data as it has been cleared and written to disk
@@ -2177,35 +2038,24 @@ TRACE
             abs_loggers_with_data_array.abs_logger_pointers[log_index] = abs_loggers_with_data_array.abs_logger_pointers[abs_loggers_with_data_array.used_elements-1];
             // Decrease logger_with_data.used_elements with 1
             abs_loggers_with_data_array.used_elements--;
-          
           }
         
-        
-        } else {
-           // Conditional status was 0, clear temp data for this logger, but only if this is the last Union_master,
-           //  as the logger data can be written if one of the ray fulfills the conditional afer one of the
-           //  subsequent Union masters.
-           // The job of cleaning was moved to the start of trace on 15/5/2017
-           //if (global_master_list_master->elements[global_master_list_master->num_elements-1].component_index == INDEX_CURRENT_COMP)
-           //  loggers_with_data_array.logger_pointers[log_index]->function_pointers.clear_temp(&loggers_with_data_array.logger_pointers[log_index]->data_union);
         }
       }
-      
     }
         
     if (enable_tagging && stop_tagging_ray == 0) {
       conditional_status = 1;
-      for (iterator=0;iterator<tagging_conditional_list->num_elements;iterator++) {
+      for (iterator=0; iterator<tagging_conditional_list->num_elements; iterator++) {
         // Call this particular conditional. If it fails, report the status and break
         // Since a conditional can work for a logger and master_tagging at the same time, it may be evaluated twice
-        //printf("checking conditional! \n");
         #ifdef Union_trace_verbal_setting
           printf("Checking tagging conditional number %d\n",iterator);
         #endif
         if (0 == tagging_conditional_list->conditional_functions[iterator](
                          tagging_conditional_list->p_data_unions[iterator],
-                         &ray_position,&ray_velocity,&p,&t,&current_volume,
-                         &number_of_scattering_events,scattered_flag,scattered_flag_VP)) {
+                         &ray_position, &ray_velocity, &p, &t, &current_volume,
+                         &number_of_scattering_events, scattered_flag,scattered_flag_VP)) {
           conditional_status = 0;
           break;
         }
@@ -2234,10 +2084,8 @@ TRACE
     // Could error log here
   }
   
-  // TEST
   // Stores nubmer of scattering events in global master list so that another master with inherit_number_of_scattering_events can continue
   global_master_list_master->elements[this_global_master_index].stored_number_of_scattering_events = number_of_scattering_events;
-  
   
 %}
 
@@ -2257,10 +2105,6 @@ if (enable_tagging) {
     write_tagging_tree(&master_tagging_node_list, Volumes, tagging_leaf_counter, number_of_volumes);
 }
 if (master_tagging_node_list.num_elements > 0) free(master_tagging_node_list.elements);
-
-MPI_MASTER(
-  if (record_absorption == 1) write_events_to_file(absorption_index, absorption_event_data);
-);
 
 
 if (finally_verbal) printf("Freeing variables which are always allocated \n");
@@ -2284,13 +2128,6 @@ free(intersection_time_table.intersection_times);
 
 if (free_tagging_conditioanl_list == 1) free(tagging_conditional_list);
 
-/*
-if (tagging_conditional_list->num_elements > 0) {
-  free(tagging_conditional_list.conditional_functions);
-  free(tagging_conditional_list.p_data_unions);
-}
-*/
-
 if (finally_verbal) printf("Freeing lists for individual volumes \n");
 for (volume_index=0;volume_index<number_of_volumes;volume_index++) {
   
@@ -2305,7 +2142,6 @@ for (volume_index=0;volume_index<number_of_volumes;volume_index++) {
   if (Volumes[volume_index]->geometry.mask_list.num_elements > 0) free(Volumes[volume_index]->geometry.mask_list.elements);
   if (Volumes[volume_index]->geometry.mask_intersect_list.num_elements > 0) free(Volumes[volume_index]->geometry.mask_intersect_list.elements);
   if (Volumes[volume_index]->geometry.next_volume_list.num_elements > 0) free(Volumes[volume_index]->geometry.next_volume_list.elements);
-  // Add dealocation of logging
   
   if (finally_verbal) printf("  Freeing physics\n");
   if (volume_index > 0) { // Volume 0 does not have physical properties allocated
@@ -2315,12 +2151,13 @@ for (volume_index=0;volume_index<number_of_volumes;volume_index++) {
           free(Volumes[volume_index]->geometry.transpose_process_rot_matrix_array);
           Volumes[volume_index]->geometry.process_rot_allocated = 0;
     }
-    if (on_int_list(Volume_copies_allocated,volume_index))
+    if (on_int_list(Volume_copies_allocated,volume_index)) {
       // This is a local copy of a volume, deallocate that local copy (all the allocated memory attachted to it was just deallocated, so this should not leave any leaks)
       free(Volumes[volume_index]);
-    else
+    } else {
       // Only free p_physics for vacuum volumes for the original at the end (there is a p_physics allocated for each vacuum volume)
       if (Volumes[volume_index]->p_physics->is_vacuum == 1 ) free(Volumes[volume_index]->p_physics);
+    }
   }
   
   if (finally_verbal) printf("  Freeing loggers\n");
@@ -2333,12 +2170,11 @@ for (volume_index=0;volume_index<number_of_volumes;volume_index++) {
   
   if (finally_verbal) printf("  Freeing abs_loggers\n");
   if (Volumes[volume_index]->abs_loggers.num_elements > 0) {
-      free(Volumes[volume_index]->abs_loggers.p_abs_logger);
+    free(Volumes[volume_index]->abs_loggers.p_abs_logger);
   }
-  // Need to free Volumes[volume_index], but that crashes??
   if (finally_verbal) printf("  Freeing Volumes[index]\n");
-  //free(Volumes[volume_index]);
-  if (finally_verbal) printf("  Managed to free Volumes[index]\n");
+  //free(Volumes[volume_index]); // Not able to free
+  //if (finally_verbal) printf("  Managed to free Volumes[index]\n");
 }
 
 free(scattered_flag_VP);
@@ -2366,28 +2202,19 @@ if (global_master_list_master->elements[global_master_list_master->num_elements-
     if (finally_verbal) printf("Freeing global arrays because this is the last Union master component\n");
     
     // Freeing lists allocated in Union_initialization
-    //#ifdef PROCESS_DETECTOR
-        if (finally_verbal) printf("Freeing global process list \n");
-        if (global_process_list_master->num_elements > 0) free(global_process_list_master->elements);
-    //#endif
+    
+    if (finally_verbal) printf("Freeing global process list \n");
+    if (global_process_list_master->num_elements > 0) free(global_process_list_master->elements);
 
-    //#ifdef MATERIAL_DETECTOR
-        if (finally_verbal) printf("Freeing global material list \n");
-        if (global_material_list_master->num_elements > 0) free(global_material_list_master->elements);
-    //#endif
+    if (finally_verbal) printf("Freeing global material list \n");
+    if (global_material_list_master->num_elements > 0) free(global_material_list_master->elements);
 
-    //#ifdef ANY_GEOMETRY_DETECTOR_DECLARE
-        if (finally_verbal) printf("Freeing global geometry list \n");
-        if (global_geometry_list_master->num_elements > 0) free(global_geometry_list_master->elements);
-    //#endif
+    if (finally_verbal) printf("Freeing global geometry list \n");
+    if (global_geometry_list_master->num_elements > 0) free(global_geometry_list_master->elements);
+
+    if (finally_verbal) printf("Freeing global master list \n");
+    if (global_master_list_master->num_elements > 0) free(global_master_list_master->elements);
     
-    //#ifdef MASTER_DETECTOR
-        if (finally_verbal) printf("Freeing global master list \n");
-        if (global_master_list_master->num_elements > 0) free(global_master_list_master->elements);
-    //#endif
-    
-    
-    //#ifdef UNION_LOGGER_DECLARE
     if (finally_verbal) printf("Freeing global logger lists \n");
     for (iterator=0;iterator<global_all_volume_logger_list_master->num_elements;iterator++) {
       if (global_all_volume_logger_list_master->elements[iterator].logger->conditional_list.num_elements > 0) {
@@ -2396,8 +2223,7 @@ if (global_master_list_master->elements[global_master_list_master->num_elements-
       }
     }
     if (global_all_volume_logger_list_master->num_elements > 0) free(global_all_volume_logger_list_master->elements);
-    
-    
+        
     for (iterator=0;iterator<global_specific_volumes_logger_list_master->num_elements;iterator++) {
       if (global_specific_volumes_logger_list_master->elements[iterator].logger->conditional_list.num_elements > 0) {
         free(global_specific_volumes_logger_list_master->elements[iterator].logger->conditional_list.conditional_functions);
@@ -2415,7 +2241,6 @@ if (global_master_list_master->elements[global_master_list_master->num_elements-
     }
     if (global_all_volume_abs_logger_list_master->num_elements > 0) free(global_all_volume_abs_logger_list_master->elements);
     
-    
     for (iterator=0;iterator<global_specific_volumes_abs_logger_list_master->num_elements;iterator++) {
       if (global_specific_volumes_abs_logger_list_master->elements[iterator].abs_logger->conditional_list.num_elements > 0) {
         free(global_specific_volumes_abs_logger_list_master->elements[iterator].abs_logger->conditional_list.conditional_functions);
@@ -2423,7 +2248,6 @@ if (global_master_list_master->elements[global_master_list_master->num_elements-
       }
     }
     if (global_specific_volumes_abs_logger_list_master->num_elements > 0) free(global_specific_volumes_abs_logger_list_master->elements);
-    //#endif
 
     if (finally_verbal) printf("Freeing global tagging conditional lists \n");
     for (iterator=0;iterator<global_tagging_conditional_list_master->num_elements;iterator++) {
@@ -2433,11 +2257,6 @@ if (global_master_list_master->elements[global_master_list_master->num_elements-
       }
     }
     if (global_tagging_conditional_list_master->num_elements>0) free(global_tagging_conditional_list_master->elements);
-    
-    /*
-    if (finally_verbal) printf("Freeing global tagging conditional list \n");
-    if (global_tagging_conditional_list_master->num_elements > 0) free(global_tagging_conditional_list_master->elements);
-    */
 }
 
 %}
@@ -2449,7 +2268,7 @@ MCDISPLAY
   //   so all the lines to be drawn for each volume are collected in a structure that is then drawn here.
   magnify("xyz");
   struct lines_to_draw lines_to_draw_master;
-  for (volume_index = 1; volume_index < number_of_volumes; volume_index++) {
+  for (volume_index=1; volume_index<number_of_volumes; volume_index++) {
         if (Volumes[volume_index]->geometry.visualization_on == 1) {
             lines_to_draw_master.number_of_lines = 0;
             
@@ -2457,13 +2276,12 @@ MCDISPLAY
             
             for (iterator = 0;iterator<lines_to_draw_master.number_of_lines;iterator++) {
                if (lines_to_draw_master.lines[iterator].number_of_dashes == 1) {
-                 line(lines_to_draw_master.lines[iterator].point1.x,lines_to_draw_master.lines[iterator].point1.y,lines_to_draw_master.lines[iterator].point1.z,lines_to_draw_master.lines[iterator].point2.x,lines_to_draw_master.lines[iterator].point2.y,lines_to_draw_master.lines[iterator].point2.z);
+                 line(lines_to_draw_master.lines[iterator].point1.x, lines_to_draw_master.lines[iterator].point1.y, lines_to_draw_master.lines[iterator].point1.z, lines_to_draw_master.lines[iterator].point2.x, lines_to_draw_master.lines[iterator].point2.y, lines_to_draw_master.lines[iterator].point2.z);
                }
                else {
-                 dashed_line(lines_to_draw_master.lines[iterator].point1.x,lines_to_draw_master.lines[iterator].point1.y,lines_to_draw_master.lines[iterator].point1.z,lines_to_draw_master.lines[iterator].point2.x,lines_to_draw_master.lines[iterator].point2.y,lines_to_draw_master.lines[iterator].point2.z,lines_to_draw_master.lines[iterator].number_of_dashes);
+                 dashed_line(lines_to_draw_master.lines[iterator].point1.x, lines_to_draw_master.lines[iterator].point1.y, lines_to_draw_master.lines[iterator].point1.z, lines_to_draw_master.lines[iterator].point2.x, lines_to_draw_master.lines[iterator].point2.y, lines_to_draw_master.lines[iterator].point2.z, lines_to_draw_master.lines[iterator].number_of_dashes);
                }
             }
-            
             if (lines_to_draw_master.number_of_lines>0) free(lines_to_draw_master.lines);
         }
    }

--- a/mcstas-comps/contrib/union/Union_mesh.comp
+++ b/mcstas-comps/contrib/union/Union_mesh.comp
@@ -7,7 +7,7 @@
 * Written by: Martin Olsen
 * On a template by: Mads Bertelsen
 * Date: 17.09.18
-* Origin: Niels Bohr Instituttet, Universitetsparken 5
+* Origin: University of Copenhagen
 *
 * Component for including 3D mesh in Union geometry
 *
@@ -38,23 +38,23 @@
 * %P
 * INPUT PARAMETERS:
 * filename: [str] Name of stl file that contains the 3D geometry
-* material_string: []  material name of this volume, defined using Union_make_material
-* priority   [1]  priotiry of the volume (can not be the same as another volume) A high priority is on top of low.
-* p_interact [1]  probability to interact with this geometry [0-1]
-* visualize  [1]  set to 0 if you wish to hide this geometry in mcdisplay
-* number_of_activations [1]  Number of subsequent Union_master components that will simulate this geometry
-* mask_string: []      Comma seperated list of geometry names which this geometry should mask
-* mask_setting: []     "All" or "Any", should the masked volume be simulated when the ray is in just one mask, or all.
-*
-* Focusing options, if left blank, there will be no focusing.
-* target_x   [m]:
-* target_y   [m]: Position of target to focus at
-* target_z   [m]:
-* focus_aw   [deg] horiz. angular dimension of a rectangular area
-* focus_ah   [deg] vert. angular dimension of a rectangular area
-* focus_xw   [m]   horiz. dimension of a rectangular area
-* focus_xh   [m]   vert. dimension of a rectangular area
-* focus_r    [m]   focusing on circle with this radius
+* material_string: [string]  material name of this volume, defined using Union_make_material
+* priority:   [1]  priotiry of the volume (can not be the same as another volume) A high priority is on top of low.
+* p_interact: [1]  probability to interact with this geometry [0-1]
+* visualize:  [1]  set to 0 if you wish to hide this geometry in mcdisplay
+* number_of_activations: [1]  Number of subsequent Union_master components that will simulate this geometry
+* mask_string: [string]      Comma seperated list of geometry names which this geometry should mask
+* mask_setting: [string]     "All" or "Any", should the masked volume be simulated when the ray is in just one mask, or all.
+* target_index:  [1]    Focuses on component a component this many steps further in the component sequence
+* target_x:      [m]
+* target_y:      [m] Position of target to focus at
+* target_z:      [m]
+* focus_aw:      [deg] horiz. angular dimension of a rectangular area
+* focus_ah:      [deg] vert. angular dimension of a rectangular area
+* focus_xw:      [m]   horiz. dimension of a rectangular area
+* focus_xh:      [m]   vert. dimension of a rectangular area
+* focus_r:       [m]   focusing on circle with this radius
+* init:          [string] name of Union_init component (typically "init", default)
 *
 * OUTPUT PARAMETERS:
 *

--- a/mcstas-comps/contrib/union/Union_sphere.comp
+++ b/mcstas-comps/contrib/union/Union_sphere.comp
@@ -8,7 +8,7 @@
 * Date: 20.08.15
 * Origin: University of Copenhagen
 *
-* A sample component to separate geometry and phsysics
+* Sphere geometry component for the Union components
 *
 * %D
 * Part of the Union components, a set of components that work together and thus
@@ -33,24 +33,24 @@
 *
 * %P
 * INPUT PARAMETERS:
-* radius: [m]          Radius of sphere
-* material_string: []  material name of this volume, defined using Union_make_material
-* priority   [1]  priotiry of the volume (can not be the same as another volume) A high priority is on top of low.
-* p_interact [1]  probability to interact with this geometry [0-1]
-* visualize  [1]  set to 0 if you wish to hide this geometry in mcdisplay
-* number_of_activations [1]  Number of subsequent Union_master components that will simulate this geometry
-* mask_string: []      Comma seperated list of geometry names which this geometry should mask
-* mask_setting: []     "All" or "Any", should the masked volume be simulated when the ray is in just one mask, or all.
-*
-* Focusing options, if left blank, there will be no focusing.
-* target_x   [m]:
-* target_y   [m]: Position of target to focus at
-* target_z   [m]:
-* focus_aw   [deg] horiz. angular dimension of a rectangular area
-* focus_ah   [deg] vert. angular dimension of a rectangular area
-* focus_xw   [m]   horiz. dimension of a rectangular area
-* focus_xh   [m]   vert. dimension of a rectangular area
-* focus_r    [m]   focusing on circle with this radius
+* radius:                [m]   Radius of sphere
+* material_string:       [string]    material name of this volume, defined using Union_make_material
+* priority:              [1]   priotiry of the volume (can not be the same as another volume) A high priority is on top of low.
+* p_interact:            [1]   probability to interact with this geometry [0-1]
+* visualize:             [1]   set to 0 if you wish to hide this geometry in mcdisplay
+* number_of_activations: [1]   Number of subsequent Union_master components that will simulate this geometry
+* mask_string:           [string]    Comma seperated list of geometry names which this geometry should mask
+* mask_setting:          [string]    "All" or "Any", should the masked volume be simulated when the ray is in just one mask, or all.
+* target_index:          [1]    Focuses on component a component this many steps further in the component sequence
+* target_x:              [m]  X position of target to focus at
+* target_y:              [m]  Y position of target to focus at
+* target_z:              [m]  Z position of target to focus at
+* focus_aw:              [deg] horiz. angular dimension of a rectangular area
+* focus_ah:              [deg] vert. angular dimension of a rectangular area
+* focus_xw:              [m]   horiz. dimension of a rectangular area
+* focus_xh:              [m]   vert. dimension of a rectangular area
+* focus_r:               [m]   focusing on circle with this radius
+* init:                  [string]    name of Union_init component (typically "init", default)
 *
 * OUTPUT PARAMETERS:
 *

--- a/mcstas-comps/contrib/union/Union_stop.comp
+++ b/mcstas-comps/contrib/union/Union_stop.comp
@@ -9,6 +9,8 @@
 * Version: $Revision: 0.1 $
 * Origin: University of Copenhagen
 *
+* Stop component that must be placed after all Union components for instrument to compile correctly
+*
 * %D
 * Part of the Union components, a set of components that work together and thus
 *  sperates geometry and physics within McStas.


### PR DESCRIPTION
Clean up of header on all Union components so they are read by mcdoc. Only PowderN and Single_crystal processes have issues at this point, any comments on how that could be rectified are welcome.

Clean up of Union_master in terms of outdated comments and unused features removed, namely writing absorption information to file which can now be done by the absorption logger components.