### PR TITLE
Traceless optimization

### DIFF
--- a/mcstas/src/cogen.c.in
+++ b/mcstas/src/cogen.c.in
@@ -2813,48 +2813,59 @@ int get_codeblock_vars(struct code_block *code, List vars, List types,
   return(ans);
 } // get_codeblock_vars
 
-
+/*******************************************************************************
+* detect_skipable_transforms: Finds components where coordinate transform can be skipped
+*   Checks for trace / extend and if origin or target of a jump.
+*******************************************************************************/
 void detect_skipable_transforms(struct instr_def *instr) {
     //
     // analyze component sequence to find coordinate transformations that can be skipped
     //
     List_handle liter;
     struct comp_inst *comp = NULL;
+    struct comp_inst *target_comp = NULL;
     
-    liter = list_iterate_back(instr->complist);
-    while((comp = list_previous(liter)) != NULL) {
-        // proceed if comp type has trace code or EXTEND
-        if ((!comp->def->trace_code || list_len(comp->def->trace_code->lines) <= 0) && list_len(comp->extend->lines) == 0) {
-            comp->has_trace = 0;
-        } else {
-            comp->has_trace = 1;
-        }
-        comp->n_references = 0; // Initialize n_references to 0
-    }
-    list_iterate_end(liter);
-    
-    liter = list_iterate_back(instr->complist);
-    while((comp = list_previous(liter)) != NULL) {
-        // Find pointer to comp for RELATIVE AT
-        if (comp->pos->place_rel != NULL) {
-            // Increment with has_trace + n_references
-            comp->pos->place_rel->n_references += comp->has_trace + comp->n_references;
-        }
-        
-        // Find pointer to comp for RELATIVE ROTATED
-        if (comp->pos->orientation_rel != NULL) {
-            // Increment with has_trace + n_references
-            comp->pos->orientation_rel->n_references += comp->has_trace + comp->n_references;
-        }
-    }
-    list_iterate_end(liter);
-    
+    // Assume all can be skipped
     liter = list_iterate(instr->complist);
     while((comp = list_next(liter)) != NULL) {
-        if (comp->n_references + comp->has_trace > 0) {
+        comp->skip_trace = 1;
+    }
+    list_iterate_end(liter);
+    
+    // Detect those components that can not
+    liter = list_iterate(instr->complist);
+    while((comp = list_next(liter)) != NULL) {
+
+        if ((comp->def->trace_code && list_len(comp->def->trace_code->lines) > 0) || list_len(comp->extend->lines) > 0) {
+            // If component has trace or extend, do not skip it
             comp->skip_trace = 0;
-        } else {
-            comp->skip_trace = 1;
+        }
+        
+        if(list_len(comp->jump) > 0) {
+            // If this component jumps elsewhere, it can not be skipped
+            comp->skip_trace = 0;
+            
+            // Its target can not be skipped either
+            struct jump_struct *this_jump;
+            List_handle literJ = list_iterate(comp->jump);
+            while (this_jump = list_next(literJ)) {
+                
+                // Find target (not initialized yet)
+                List_handle liter3 = list_iterate(instr->complist);
+                struct comp_inst *target=NULL;
+                while((target = list_next(liter3)) != NULL) {
+                  if (!strcmp(target->name, this_jump->target))
+                    this_jump->target_index = target->index;
+                }
+                list_iterate_end(liter3);
+                if (!this_jump->target_index) /* JUMP e.g. PREVIOUS/NEXT is relative -> absolute */
+                  this_jump->target_index += comp->index;
+
+                // component list is 1 indexed so subtract one from target_index
+                target_comp = list_access(instr->complist, this_jump->target_index - 1);
+                target_comp->skip_trace = 0;
+            }
+            list_iterate_end(literJ);
         }
     }
     list_iterate_end(liter);

--- a/mcstas/src/cogen.c.in
+++ b/mcstas/src/cogen.c.in
@@ -747,8 +747,8 @@ int cogen_comp_section_class(
     list_iterate_end(liter);
   }
 
-  // proceed if comp type has trace code or EXTEND */
-  if ((!code || list_len(code->lines) <= 0) && cnt_extend == 0)
+  // proceed if comp type has trace code or EXTEND
+  if ((!code || list_len(code->lines) <= 0) && cnt_extend == 0) //{
     return(0);
 
   /* generate class functions (unless flagged already done) */
@@ -1286,10 +1286,12 @@ int cogen_section(struct instr_def *instr, char *section, char *section_lower,
   /* generate setpos instance functions */
   if (!strcmp(section, "INITIALISE")) {
     liter = list_iterate(instr->complist);
-    while((comp = list_next(liter)) != NULL)
-    {
-      warnings += cogen_comp_setpos(comp, last, instr);
-      last = comp;
+    while((comp = list_next(liter)) != NULL) {
+        warnings += cogen_comp_setpos(comp, last, instr);
+      if (comp->skip_trace == 0) {
+        // Ensure useless components skipped
+        last = comp;
+      }
     }
   }
 
@@ -1625,7 +1627,7 @@ int cogen_raytrace(struct instr_def *instr)
     #endif
     };
   List l;
-
+    
   //
   // write the raytrace function
   //
@@ -1679,6 +1681,7 @@ int cogen_raytrace(struct instr_def *instr)
       list_iterate_end(liter2);
     }
   }
+  list_iterate_end(liter);
 
   cout("  _particle->flag_nocoordschange=0; /* Init */");
   cout("  _class_particle _particle_save;");
@@ -1715,28 +1718,34 @@ int cogen_raytrace(struct instr_def *instr)
     }
     // coordinate transformations (wrt to PREVIOUS)
     coutf("    /* begin component %s=%s() [%i] */", comp->name, comp->def->name, comp->index);
-    cout( "    if (!_particle->flag_nocoordschange) { // flag activated by JUMP to pass coords change");
-    coutf("      if (_%s_var._rotation_is_identity) {", comp->name);
-    coutf("        if(!_%s_var._position_relative_is_zero) {", comp->name);
-    coutf("          coords_get("
-	  "coords_add(coords_set(x,y,z), _%s_var._position_relative),"
-	  "&x, &y, &z);", comp->name);
-    cout( "        }");
-    cout( "      } else {");
-    coutf("          mccoordschange(_%s_var._position_relative, _%s_var._rotation_relative, _particle);", comp->name, comp->name);
-    cout( "      }");
-    cout( "    }");
+    if (comp->skip_trace == 0) {
+    //if (1==1) {
+          cout( "    if (!_particle->flag_nocoordschange) { // flag activated by JUMP to pass coords change");
+          coutf("      if (_%s_var._rotation_is_identity) {", comp->name);
+          coutf("        if(!_%s_var._position_relative_is_zero) {", comp->name);
+          coutf("          coords_get("
+                "coords_add(coords_set(x,y,z), _%s_var._position_relative),"
+                "&x, &y, &z);", comp->name);
+          cout( "        }");
+          cout( "      } else {");
+          coutf("          mccoordschange(_%s_var._position_relative, _%s_var._rotation_relative, _particle);", comp->name, comp->name);
+          cout( "      }");
+          cout( "    }");
+    }
     coutf("    if (!ABSORBED && _particle->_index == %i) {", comp->index);
     coutf("      _particle->flag_nocoordschange=0; /* Reset if we came here from a JUMP */");
     if (!comp->group || (comp->group && comp->group->first_comp_index == comp->index)) {
-      cout( "      _particle_save = *_particle;");
+        if (comp->skip_trace == 0) {
+            cout( "      _particle_save = *_particle;");
+        }
     } else {
       coutf("      // 2nd or higher GROUP member, \"reuse\" coordinate-changed _particle_save from 1st GROUP element.");
       coutf("      mccoordschange(_%s_var._position_relative, _%s_var._rotation_relative, &_particle_save);", comp->name, comp->name);
     }
-    coutf("      DEBUG_COMP(_%s_var._name);", comp->name);
-    cout ("      DEBUG_STATE();");
-
+    if (comp->skip_trace == 0) {
+      coutf("      DEBUG_COMP(_%s_var._name);", comp->name);
+      cout ("      DEBUG_STATE();");
+    }
     /* call the component when there are TRACE and/or EXTEND lines */
     if (list_len(comp->def->trace_code->lines) > 0 || list_len(comp->extend->lines) > 0) {
       // WHEN
@@ -1797,7 +1806,9 @@ int cogen_raytrace(struct instr_def *instr)
     }
 
     coutf("      _particle->_index++;");
-    coutf("      if (!ABSORBED) { DEBUG_STATE(); }");
+    if (comp->skip_trace == 0) {
+      coutf("      if (!ABSORBED) { DEBUG_STATE(); }");
+    }
     coutf("    } /* end component %s [%i] */", comp->name, comp->index);
 
   } /* end while comp list (case) */
@@ -2803,6 +2814,52 @@ int get_codeblock_vars(struct code_block *code, List vars, List types,
 } // get_codeblock_vars
 
 
+void detect_skipable_transforms(struct instr_def *instr) {
+    //
+    // analyze component sequence to find coordinate transformations that can be skipped
+    //
+    List_handle liter;
+    struct comp_inst *comp = NULL;
+    
+    liter = list_iterate_back(instr->complist);
+    while((comp = list_previous(liter)) != NULL) {
+        // proceed if comp type has trace code or EXTEND
+        if ((!comp->def->trace_code || list_len(comp->def->trace_code->lines) <= 0) && list_len(comp->extend->lines) == 0) {
+            comp->has_trace = 0;
+        } else {
+            comp->has_trace = 1;
+        }
+        comp->n_references = 0; // Initialize n_references to 0
+    }
+    list_iterate_end(liter);
+    
+    liter = list_iterate_back(instr->complist);
+    while((comp = list_previous(liter)) != NULL) {
+        // Find pointer to comp for RELATIVE AT
+        if (comp->pos->place_rel != NULL) {
+            // Increment with has_trace + n_references
+            comp->pos->place_rel->n_references += comp->has_trace + comp->n_references;
+        }
+        
+        // Find pointer to comp for RELATIVE ROTATED
+        if (comp->pos->orientation_rel != NULL) {
+            // Increment with has_trace + n_references
+            comp->pos->orientation_rel->n_references += comp->has_trace + comp->n_references;
+        }
+    }
+    list_iterate_end(liter);
+    
+    liter = list_iterate(instr->complist);
+    while((comp = list_next(liter)) != NULL) {
+        if (comp->n_references + comp->has_trace > 0) {
+            comp->skip_trace = 0;
+        } else {
+            comp->skip_trace = 1;
+        }
+    }
+    list_iterate_end(liter);
+}
+    
 /*******************************************************************************
 * cogen: the code generator
 *   Generate the output file (in C).
@@ -2832,6 +2889,7 @@ cogen(char *output_name, struct instr_def *instr)
   /* and we now call the writers */
   cogen_header(instr, output_name);
   warnings += cogen_decls(instr);
+  detect_skipable_transforms(instr);
   warnings += cogen_section(instr, "INITIALISE", "init", instr->inits);
 
   // TRACE section requires a bit more flexibility

--- a/mcstas/src/cogen.c.in
+++ b/mcstas/src/cogen.c.in
@@ -748,7 +748,7 @@ int cogen_comp_section_class(
   }
 
   // proceed if comp type has trace code or EXTEND
-  if ((!code || list_len(code->lines) <= 0) && cnt_extend == 0) //{
+  if ((!code || list_len(code->lines) <= 0) && cnt_extend == 0)
     return(0);
 
   /* generate class functions (unless flagged already done) */
@@ -1287,8 +1287,8 @@ int cogen_section(struct instr_def *instr, char *section, char *section_lower,
   if (!strcmp(section, "INITIALISE")) {
     liter = list_iterate(instr->complist);
     while((comp = list_next(liter)) != NULL) {
-        warnings += cogen_comp_setpos(comp, last, instr);
-      if (comp->skip_trace == 0) {
+      warnings += cogen_comp_setpos(comp, last, instr);
+      if (comp->skip_transform == 0) {
         // Ensure useless components skipped
         last = comp;
       }
@@ -1718,31 +1718,30 @@ int cogen_raytrace(struct instr_def *instr)
     }
     // coordinate transformations (wrt to PREVIOUS)
     coutf("    /* begin component %s=%s() [%i] */", comp->name, comp->def->name, comp->index);
-    if (comp->skip_trace == 0) {
-    //if (1==1) {
-          cout( "    if (!_particle->flag_nocoordschange) { // flag activated by JUMP to pass coords change");
-          coutf("      if (_%s_var._rotation_is_identity) {", comp->name);
-          coutf("        if(!_%s_var._position_relative_is_zero) {", comp->name);
-          coutf("          coords_get("
-                "coords_add(coords_set(x,y,z), _%s_var._position_relative),"
-                "&x, &y, &z);", comp->name);
-          cout( "        }");
-          cout( "      } else {");
-          coutf("          mccoordschange(_%s_var._position_relative, _%s_var._rotation_relative, _particle);", comp->name, comp->name);
-          cout( "      }");
-          cout( "    }");
+    if (comp->skip_transform == 0) {
+      cout( "    if (!_particle->flag_nocoordschange) { // flag activated by JUMP to pass coords change");
+      coutf("      if (_%s_var._rotation_is_identity) {", comp->name);
+      coutf("        if(!_%s_var._position_relative_is_zero) {", comp->name);
+      coutf("          coords_get("
+            "coords_add(coords_set(x,y,z), _%s_var._position_relative),"
+            "&x, &y, &z);", comp->name);
+      cout( "        }");
+      cout( "      } else {");
+      coutf("          mccoordschange(_%s_var._position_relative, _%s_var._rotation_relative, _particle);", comp->name, comp->name);
+      cout( "      }");
+      cout( "    }");
     }
     coutf("    if (!ABSORBED && _particle->_index == %i) {", comp->index);
     coutf("      _particle->flag_nocoordschange=0; /* Reset if we came here from a JUMP */");
     if (!comp->group || (comp->group && comp->group->first_comp_index == comp->index)) {
-        if (comp->skip_trace == 0) {
-            cout( "      _particle_save = *_particle;");
-        }
+      if (comp->skip_transform == 0) {
+        cout( "      _particle_save = *_particle;");
+      }
     } else {
       coutf("      // 2nd or higher GROUP member, \"reuse\" coordinate-changed _particle_save from 1st GROUP element.");
       coutf("      mccoordschange(_%s_var._position_relative, _%s_var._rotation_relative, &_particle_save);", comp->name, comp->name);
     }
-    if (comp->skip_trace == 0) {
+    if (comp->skip_transform == 0) {
       coutf("      DEBUG_COMP(_%s_var._name);", comp->name);
       cout ("      DEBUG_STATE();");
     }
@@ -1806,7 +1805,7 @@ int cogen_raytrace(struct instr_def *instr)
     }
 
     coutf("      _particle->_index++;");
-    if (comp->skip_trace == 0) {
+    if (comp->skip_transform == 0) {
       coutf("      if (!ABSORBED) { DEBUG_STATE(); }");
     }
     coutf("    } /* end component %s [%i] */", comp->name, comp->index);
@@ -2828,7 +2827,7 @@ void detect_skipable_transforms(struct instr_def *instr) {
     // Assume all can be skipped
     liter = list_iterate(instr->complist);
     while((comp = list_next(liter)) != NULL) {
-        comp->skip_trace = 1;
+        comp->skip_transform = 1;
     }
     list_iterate_end(liter);
     
@@ -2838,12 +2837,12 @@ void detect_skipable_transforms(struct instr_def *instr) {
 
         if ((comp->def->trace_code && list_len(comp->def->trace_code->lines) > 0) || list_len(comp->extend->lines) > 0) {
             // If component has trace or extend, do not skip it
-            comp->skip_trace = 0;
+            comp->skip_transform = 0;
         }
         
         if(list_len(comp->jump) > 0) {
             // If this component jumps elsewhere, it can not be skipped
-            comp->skip_trace = 0;
+            comp->skip_transform = 0;
             
             // Its target can not be skipped either
             struct jump_struct *this_jump;
@@ -2863,7 +2862,7 @@ void detect_skipable_transforms(struct instr_def *instr) {
 
                 // component list is 1 indexed so subtract one from target_index
                 target_comp = list_access(instr->complist, this_jump->target_index - 1);
-                target_comp->skip_trace = 0;
+                target_comp->skip_transform = 0;
             }
             list_iterate_end(literJ);
         }

--- a/mcstas/src/list.c
+++ b/mcstas/src/list.c
@@ -135,6 +135,16 @@ list_iterate_back(List l)
   return lh;
 }
 
+/*******************************************************************************
+* Access element of list
+*******************************************************************************/
+void *
+list_access(List l, int index)
+{
+    if (index >= l->size)
+        fatal_error("list_access: Accesing beyond size, index (%d) of (%d).", index, l->size);
+    return l->elements[index];
+}
 
 /*******************************************************************************
 * Get the next element during a traversal of a list. Returns NULL when no

--- a/mcstas/src/mccode.h.in
+++ b/mcstas/src/mccode.h.in
@@ -483,6 +483,9 @@ struct comp_inst
     CExp split;     /* NULL or number of SPLITs as an Expr */
     int removable;  /* this comp is removed when included from an %include "instr" */
     int cpuonly;    /* this comp should be executed CPU only */
+    int has_trace;    /* this component has trace or EXTEND */
+    int n_references; /* trace weighted n RELATIVE references to this component */
+    int skip_trace;   /* if 1 coordinate transform is skipped */
   };
 
 /* Instrument formal parameters. */

--- a/mcstas/src/mccode.h.in
+++ b/mcstas/src/mccode.h.in
@@ -484,7 +484,7 @@ struct comp_inst
     CExp split;     /* NULL or number of SPLITs as an Expr */
     int removable;  /* this comp is removed when included from an %include "instr" */
     int cpuonly;    /* this comp should be executed CPU only */
-    int skip_trace;   /* if 1 coordinate transform is skipped */
+    int skip_transform;   /* if 1 coordinate transform is skipped */
   };
 
 /* Instrument formal parameters. */

--- a/mcstas/src/mccode.h.in
+++ b/mcstas/src/mccode.h.in
@@ -143,6 +143,7 @@ typedef struct List_position *List_handle;
 
 List list_create(void);             /* Create list. */
 void list_add(List, void *);        /* Add element at end. */
+void* list_access(List, int);       /* Get element in list. */
 void list_free(List, void (*)(void *)); /* Deallocate a list. */
 int list_len(List l);               /* Get list length. */
 List_handle list_iterate(List);     /* Prepare to traverse list. */
@@ -483,8 +484,6 @@ struct comp_inst
     CExp split;     /* NULL or number of SPLITs as an Expr */
     int removable;  /* this comp is removed when included from an %include "instr" */
     int cpuonly;    /* this comp should be executed CPU only */
-    int has_trace;    /* this component has trace or EXTEND */
-    int n_references; /* trace weighted n RELATIVE references to this component */
     int skip_trace;   /* if 1 coordinate transform is skipped */
   };
 


### PR DESCRIPTION
Optimization of the code generator that removes coordinate transformations from components if all of the following is true:

- Has no trace code
- Has no extend code
- Does not jump anywhere
- Is not jumped to

The component is skipped in the transformation chain too, so the transformation is still correct when the rays goes over a sequence of skipped components.

Introduced list access function in List, the review should check the index is handled correctly. It turned out components where 1 indexed in the code generator, but I don't think that is general for all lists, and so I made the index change in the code gen optimization.