### PR TITLE
[Fix] mcrun binary execution logic

### DIFF
--- a/tools/Python/mcrun/mcrun.py
+++ b/tools/Python/mcrun/mcrun.py
@@ -427,7 +427,7 @@ def main():
         scanner.run()
     else:
         # Only run a simulation if we have a nonzero ncount
-        if not options.ncount == 0.0:
+        if options.ncount != 0.0 or options.trace:
             mcstas.run()
 
     if isdir(options.dir):


### PR DESCRIPTION
Closed #1314 by adding a check for trace being turned on to allow running the binary with no requested particles.