### PR TITLE
Change of logic in Monitor_nD for Banana shape

### DIFF
--- a/mcstas-comps/monitors/Monitor_nD.comp
+++ b/mcstas-comps/monitors/Monitor_nD.comp
@@ -429,28 +429,59 @@ TRACE
      || (geometry && strlen(geometry) && strcmp(geometry,"0") && strcmp(geometry, "NULL")) )
     {
       /* check if we have to remove the top/bottom with BANANA shape */
-      if ((abs(Vars.Flag_Shape) == DEFS.SHAPE_BANANA) && (intersect != 1)) {
-        double y0,y1;
-        /* propagate to intersection point as temporary variable to check top/bottom */
-        y0 = y+t0*vy;
-        y1 = y+t1*vy;
-        if (fabs(y0) >= Vars.Cylinder_Height/2) t0 = t1;
-        if (fabs(y1) >= Vars.Cylinder_Height/2) t1 = t0;
-      }
-      if (t0 < 0 && t1 > 0)
-        t0 = t;  /* neutron was already inside ! */
-      if (t1 < 0 && t0 > 0) /* neutron exit before entering !! */
-        t1 = t;
-      /* t0 is now time of incoming intersection with the detection area */
-      if ((Vars.Flag_Shape < 0) && (t1 > 0))
-        PROP_DT(t1); /* t1 outgoing beam */
-      else
-        PROP_DT(t0); /* t0 incoming beam */
-      /* Final test if we are on lid / bottom of banana/sphere */
-      if (abs(Vars.Flag_Shape) == DEFS.SHAPE_BANANA || abs(Vars.Flag_Shape) == DEFS.SHAPE_SPHERE) {
-        if (Vars.Cylinder_Height && fabs(y) >= Vars.Cylinder_Height/2 - FLT_EPSILON) {
-          intersect=0;
-          Flag_Restore=1;
+      if (abs(Vars.Flag_Shape) == DEFS.SHAPE_BANANA) {
+        
+        if (intersect == 1) { // Entered and left through sides
+            if (t0 < 0 && t1 > 0) {
+              t0 = t;  /* neutron was already inside ! */
+            }
+            if (t1 < 0 && t0 > 0) { /* neutron exit before entering !! */
+              t1 = t;
+            }
+            /* t0 is now time of incoming intersection with the detection area */
+            if ((Vars.Flag_Shape < 0) && (t1 > 0)) {
+              PROP_DT(t1); /* t1 outgoing beam */
+            } else {
+              PROP_DT(t0); /* t0 incoming beam */
+            }
+          
+        } else if (intersect == 3 || intersect == 5) { // Entered from top or bottom
+            if ((Vars.Flag_Shape < 0) && (t1 > 0)) {
+              PROP_DT(t1); /* t1 outgoing beam */
+            } else {
+              intersect=0;
+              Flag_Restore=1;
+            }
+        } else if (intersect == 9 || intersect == 17) { // Left from top or bottom
+            if ((Vars.Flag_Shape < 0) && (t1 > 0)) {
+              intersect=0;
+              Flag_Restore=1;
+            } else {
+              PROP_DT(t0); /* t0 incoming beam */
+            }
+        } else if (intersect == 13 || intersect == 19) { // Went through top/bottom on entry and exit
+            intersect=0;
+            Flag_Restore=1;
+        } else {
+            printf("Cylinder_intersect returned unexpected value %l\n", intersect);
+        }
+      
+      } else {
+        if (t0 < 0 && t1 > 0)
+          t0 = t;  /* neutron was already inside ! */
+        if (t1 < 0 && t0 > 0) /* neutron exit before entering !! */
+          t1 = t;
+        /* t0 is now time of incoming intersection with the detection area */
+        if ((Vars.Flag_Shape < 0) && (t1 > 0))
+          PROP_DT(t1); /* t1 outgoing beam */
+        else
+          PROP_DT(t0); /* t0 incoming beam */
+        /* Final test if we are on lid / bottom of banana/sphere */
+        if (abs(Vars.Flag_Shape) == DEFS.SHAPE_BANANA || abs(Vars.Flag_Shape) == DEFS.SHAPE_SPHERE) {
+          if (Vars.Cylinder_Height && fabs(y) >= Vars.Cylinder_Height/2 - FLT_EPSILON) {
+            intersect=0;
+            Flag_Restore=1;
+          }
         }
       }
     }


### PR DESCRIPTION
Before the component checked if the intersection position was on the top/bottom of the cylinder, yet this requires comparisons of doubles and the result of the intersection calculation has some error, making it flaky. Some rays leaving through the top/bottom of the cylinder were included in the results.

Updated to use the return value from the intersection function to identify whether or not to keep events.

Fix to issue #1381 