### PR TITLE
Add check for Union_init component name to Union components

### DIFF
--- a/mcstas-comps/union/IncoherentPhonon_process.comp
+++ b/mcstas-comps/union/IncoherentPhonon_process.comp
@@ -4669,8 +4669,15 @@ INITIALIZE
   sprintf(global_process_element.name,NAME_CURRENT_COMP);
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
-  
-  struct pointer_to_global_process_list *global_process_list = COMP_GETPAR3(Union_init, init, global_process_list);
+
+  if (_getcomp_index(init) < 0) {
+  fprintf(stderr,"IncoherentPhonon_process:%s: Error identifying Union_init component, %s is not a known component name.\n",
+  NAME_CURRENT_COMP, init);
+  exit(-1);
+  }
+
+
+struct pointer_to_global_process_list *global_process_list = COMP_GETPAR3(Union_init, init, global_process_list);
   add_element_to_process_list(global_process_list,global_process_element);
 
   fprintf(IncoherentPhonon_storage.filep,"Initialization done\n");

--- a/mcstas-comps/union/Incoherent_process.comp
+++ b/mcstas-comps/union/Incoherent_process.comp
@@ -166,7 +166,13 @@ INITIALIZE
   sprintf(global_process_element.name,NAME_CURRENT_COMP);
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
-  
+
+  if (_getcomp_index(init) < 0) {
+    fprintf(stderr,"Incoherent_process:%s: Error identifying Union_init component, %s is not a known component name.\n",
+            NAME_CURRENT_COMP, init);
+    exit(-1);
+  }
+
   struct pointer_to_global_process_list *global_process_list = COMP_GETPAR3(Union_init, init, global_process_list);
   add_element_to_process_list(global_process_list, global_process_element);
  %}

--- a/mcstas-comps/union/NCrystal_process.comp
+++ b/mcstas-comps/union/NCrystal_process.comp
@@ -393,8 +393,14 @@ INITIALIZE
   sprintf(global_process_element.name,NAME_CURRENT_COMP);
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
-  
-  struct pointer_to_global_process_list *global_process_list = COMP_GETPAR3(Union_init, init, global_process_list);
+
+if (_getcomp_index(init) < 0) {
+fprintf(stderr,"NCrystal_process:%s: Error identifying Union_init component, %s is not a known component name.\n",
+NAME_CURRENT_COMP, init);
+exit(-1);
+}
+
+struct pointer_to_global_process_list *global_process_list = COMP_GETPAR3(Union_init, init, global_process_list);
   add_element_to_process_list(global_process_list, global_process_element);
  %}
 

--- a/mcstas-comps/union/Non_process.comp
+++ b/mcstas-comps/union/Non_process.comp
@@ -148,7 +148,14 @@ INITIALIZE
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
 
-  struct pointer_to_global_process_list *global_process_list = COMP_GETPAR3(Union_init, init, global_process_list);
+if (_getcomp_index(init) < 0) {
+fprintf(stderr,"Non_process:%s: Error identifying Union_init component, %s is not a known component name.\n",
+NAME_CURRENT_COMP, init);
+exit(-1);
+}
+
+
+struct pointer_to_global_process_list *global_process_list = COMP_GETPAR3(Union_init, init, global_process_list);
   add_element_to_process_list(global_process_list,global_process_element);
  %}
 

--- a/mcstas-comps/union/PhononSimple_process.comp
+++ b/mcstas-comps/union/PhononSimple_process.comp
@@ -535,6 +535,13 @@ INITIALIZE
   sprintf(global_process_element.name,NAME_CURRENT_COMP);
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
+
+if (_getcomp_index(init) < 0) {
+fprintf(stderr,"PhononSimple_process:%s: Error identifying Union_init component, %s is not a known component name.\n",
+NAME_CURRENT_COMP, init);
+exit(-1);
+}
+
   
   struct pointer_to_global_process_list *global_process_list = COMP_GETPAR3(Union_init, init, global_process_list);
   add_element_to_process_list(global_process_list,global_process_element);

--- a/mcstas-comps/union/Powder_process.comp
+++ b/mcstas-comps/union/Powder_process.comp
@@ -770,8 +770,15 @@ INITIALIZE
   sprintf(global_process_element.name,NAME_CURRENT_COMP);
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
-  
-  struct pointer_to_global_process_list *global_process_list = COMP_GETPAR3(Union_init, init, global_process_list);
+
+if (_getcomp_index(init) < 0) {
+fprintf(stderr,"Powder_process:%s: Error identifying Union_init component, %s is not a known component name.\n",
+NAME_CURRENT_COMP, init);
+exit(-1);
+}
+
+
+struct pointer_to_global_process_list *global_process_list = COMP_GETPAR3(Union_init, init, global_process_list);
   add_element_to_process_list(global_process_list,global_process_element);
  %}
 

--- a/mcstas-comps/union/Single_crystal_process.comp
+++ b/mcstas-comps/union/Single_crystal_process.comp
@@ -1095,8 +1095,15 @@ INITIALIZE
   sprintf(global_process_element.name,NAME_CURRENT_COMP);
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
-  
-  struct pointer_to_global_process_list *global_process_list = COMP_GETPAR3(Union_init, init, global_process_list);
+
+if (_getcomp_index(init) < 0) {
+fprintf(stderr,"Single_crystal_process:%s: Error identifying Union_init component, %s is not a known component name.\n",
+NAME_CURRENT_COMP, init);
+exit(-1);
+}
+
+
+struct pointer_to_global_process_list *global_process_list = COMP_GETPAR3(Union_init, init, global_process_list);
   add_element_to_process_list(global_process_list, global_process_element);
   
  %}

--- a/mcstas-comps/union/Template_process.comp
+++ b/mcstas-comps/union/Template_process.comp
@@ -164,8 +164,14 @@ INITIALIZE
   sprintf(global_process_element.name,NAME_CURRENT_COMP);
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
-  
-  struct pointer_to_global_process_list *global_process_list = COMP_GETPAR3(Union_init, init, global_process_list);
+
+if (_getcomp_index(init) < 0) {
+fprintf(stderr,"Template_process:%s: Error identifying Union_init component, %s is not a known component name.\n",
+NAME_CURRENT_COMP, init);
+exit(-1);
+}
+
+struct pointer_to_global_process_list *global_process_list = COMP_GETPAR3(Union_init, init, global_process_list);
   add_element_to_process_list(global_process_list,global_process_element);
  %}
 

--- a/mcstas-comps/union/Texture_process.comp
+++ b/mcstas-comps/union/Texture_process.comp
@@ -2287,8 +2287,14 @@ INITIALIZE
   sprintf(global_process_element.name,NAME_CURRENT_COMP);
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
-  
-  struct pointer_to_global_process_list *global_process_list = COMP_GETPAR3(Union_init, init, global_process_list);
+
+if (_getcomp_index(init) < 0) {
+fprintf(stderr,"Texture_process:%s: Error identifying Union_init component, %s is not a known component name.\n",
+NAME_CURRENT_COMP, init);
+exit(-1);
+}
+
+struct pointer_to_global_process_list *global_process_list = COMP_GETPAR3(Union_init, init, global_process_list);
   add_element_to_process_list(global_process_list,global_process_element);
  %}
 

--- a/mcstas-comps/union/Union_abs_logger_1D_space.comp
+++ b/mcstas-comps/union/Union_abs_logger_1D_space.comp
@@ -418,8 +418,15 @@ INITIALIZE
   // Added 17/11/2016, allocating some elements in initialize makes code during trace simpler
   this_abs_storage.temp_1D_abs_data.allocated_elements = 10;
   this_abs_storage.temp_1D_abs_data.elements = malloc(this_abs_storage.temp_1D_abs_data.allocated_elements*sizeof(struct temp_1D_abs_data_element_struct));
-  
-  struct global_positions_to_transform_list_struct *global_positions_to_transform_list = COMP_GETPAR3(Union_init, init, global_positions_to_transform_list);
+
+if (_getcomp_index(init) < 0) {
+fprintf(stderr,"Union_abs_logger_1D_space:%s: Error identifying Union_init component, %s is not a known component name.\n",
+NAME_CURRENT_COMP, init);
+exit(-1);
+}
+
+
+struct global_positions_to_transform_list_struct *global_positions_to_transform_list = COMP_GETPAR3(Union_init, init, global_positions_to_transform_list);
   struct global_rotations_to_transform_list_struct *global_rotations_to_transform_list = COMP_GETPAR3(Union_init, init, global_rotations_to_transform_list);
   // Test position and rotation stored in a data storage, and pointers assigned to transform lists
   this_abs_logger.position = POS_A_CURRENT_COMP;

--- a/mcstas-comps/union/Union_abs_logger_1D_space_event.comp
+++ b/mcstas-comps/union/Union_abs_logger_1D_space_event.comp
@@ -481,7 +481,13 @@ INITIALIZE
 
   sprintf(this_abs_storage.Vars.option, "mantid square x limits=[-0.0005,0.0005] bins=3 y limits=[%f %f] bins=%i", -0.5*yheight, 0.5*yheight, n);
 
-  // Need to tell the monitor from what integer its pixel id range starts, and it necessary to avoid overlaps.
+if (_getcomp_index(init) < 0) {
+fprintf(stderr,"Union_abs_logger_1D_space_event:%s: Error identifying Union_init component, %s is not a known component name.\n",
+NAME_CURRENT_COMP, init);
+exit(-1);
+}
+
+// Need to tell the monitor from what integer its pixel id range starts, and it necessary to avoid overlaps.
   // global_mantid_min_pixel_id is initialized as 0, and each monitor adds its number of pixels to avoid overlap.
   int global_mantid_min_pixel_id = COMP_GETPAR3(Union_init, init, global_mantid_min_pixel_id);
   sprintf(option_string_part,", neutron pixel min=%i t, list all neutrons", global_mantid_min_pixel_id);

--- a/mcstas-comps/union/Union_abs_logger_1D_space_tof.comp
+++ b/mcstas-comps/union/Union_abs_logger_1D_space_tof.comp
@@ -473,7 +473,14 @@ INITIALIZE
   this_abs_storage.temp_1D_time_abs_data.allocated_elements = 10;
   this_abs_storage.temp_1D_time_abs_data.elements = malloc(this_abs_storage.temp_1D_time_abs_data.allocated_elements*sizeof(struct temp_1D_time_abs_data_element_struct));
 
-  struct global_positions_to_transform_list_struct *global_positions_to_transform_list = COMP_GETPAR3(Union_init, init, global_positions_to_transform_list);
+if (_getcomp_index(init) < 0) {
+fprintf(stderr,"Union_abs_logger_1D_space_tof:%s: Error identifying Union_init component, %s is not a known component name.\n",
+NAME_CURRENT_COMP, init);
+exit(-1);
+}
+
+
+struct global_positions_to_transform_list_struct *global_positions_to_transform_list = COMP_GETPAR3(Union_init, init, global_positions_to_transform_list);
   struct global_rotations_to_transform_list_struct *global_rotations_to_transform_list = COMP_GETPAR3(Union_init, init, global_rotations_to_transform_list);
   // Test position and rotation stored in a data storage, and pointers assigned to transform lists
   this_abs_logger.position = POS_A_CURRENT_COMP;

--- a/mcstas-comps/union/Union_abs_logger_1D_space_tof_to_lambda.comp
+++ b/mcstas-comps/union/Union_abs_logger_1D_space_tof_to_lambda.comp
@@ -661,8 +661,14 @@ INITIALIZE
   // Added 17/11/2016, allocating some elements in initialize makes code during trace simpler
   this_abs_storage.temp_1D_time_to_lambda_abs_data.allocated_elements = 10;
   this_abs_storage.temp_1D_time_to_lambda_abs_data.elements = malloc(this_abs_storage.temp_1D_time_to_lambda_abs_data.allocated_elements*sizeof(struct temp_1D_time_to_lambda_abs_data_element_struct));
-  
-  struct global_positions_to_transform_list_struct *global_positions_to_transform_list = COMP_GETPAR3(Union_init, init, global_positions_to_transform_list);
+
+if (_getcomp_index(init) < 0) {
+fprintf(stderr,"Union_abs_logger_1D_space_tof_to_lambda:%s: Error identifying Union_init component, %s is not a known component name.\n",
+NAME_CURRENT_COMP, init);
+exit(-1);
+}
+
+struct global_positions_to_transform_list_struct *global_positions_to_transform_list = COMP_GETPAR3(Union_init, init, global_positions_to_transform_list);
   struct global_rotations_to_transform_list_struct *global_rotations_to_transform_list = COMP_GETPAR3(Union_init, init, global_rotations_to_transform_list);
   // Test position and rotation stored in a data storage, and pointers assigned to transform lists
   this_abs_logger.position = POS_A_CURRENT_COMP;

--- a/mcstas-comps/union/Union_abs_logger_2D_space.comp
+++ b/mcstas-comps/union/Union_abs_logger_2D_space.comp
@@ -550,8 +550,14 @@ INITIALIZE
   // Added 17/11/2016, allocating some elements in initialize makes code during trace simpler
   this_abs_storage.temp_2D_abs_data.allocated_elements = 10;
   this_abs_storage.temp_2D_abs_data.elements = malloc(this_abs_storage.temp_2D_abs_data.allocated_elements*sizeof(struct temp_2D_abs_data_element_struct));
-  
-  struct global_positions_to_transform_list_struct *global_positions_to_transform_list = COMP_GETPAR3(Union_init, init, global_positions_to_transform_list);
+
+if (_getcomp_index(init) < 0) {
+fprintf(stderr,"Union_abs_logger_2D_space:%s: Error identifying Union_init component, %s is not a known component name.\n",
+NAME_CURRENT_COMP, init);
+exit(-1);
+}
+
+struct global_positions_to_transform_list_struct *global_positions_to_transform_list = COMP_GETPAR3(Union_init, init, global_positions_to_transform_list);
   struct global_rotations_to_transform_list_struct *global_rotations_to_transform_list = COMP_GETPAR3(Union_init, init, global_rotations_to_transform_list);
   // Test position and rotation stored in a data storage, and pointers assigned to transform lists
   this_abs_logger.position = POS_A_CURRENT_COMP;

--- a/mcstas-comps/union/Union_abs_logger_event.comp
+++ b/mcstas-comps/union/Union_abs_logger_event.comp
@@ -485,8 +485,14 @@ INITIALIZE
   
   this_abs_storage.temp_abs_event_data.allocated_elements = 10;
   this_abs_storage.temp_abs_event_data.elements = malloc(this_abs_storage.temp_abs_event_data.allocated_elements*sizeof(struct temp_abs_event_data_element_struct));
-  
-  struct global_positions_to_transform_list_struct *global_positions_to_transform_list = COMP_GETPAR3(Union_init, init, global_positions_to_transform_list);
+
+if (_getcomp_index(init) < 0) {
+fprintf(stderr,"Union_abs_logger_event:%s: Error identifying Union_init component, %s is not a known component name.\n",
+NAME_CURRENT_COMP, init);
+exit(-1);
+}
+
+struct global_positions_to_transform_list_struct *global_positions_to_transform_list = COMP_GETPAR3(Union_init, init, global_positions_to_transform_list);
   struct global_rotations_to_transform_list_struct *global_rotations_to_transform_list = COMP_GETPAR3(Union_init, init, global_rotations_to_transform_list);
   // Test position and rotation stored in a data storage, and pointers assigned to transform lists
   this_abs_logger.position = POS_A_CURRENT_COMP;

--- a/mcstas-comps/union/Union_box.comp
+++ b/mcstas-comps/union/Union_box.comp
@@ -246,6 +246,12 @@ if (yheight2 <= 0 && yheight2 != -1) {
   exit(1);
 }
 
+if (_getcomp_index(init) < 0) {
+fprintf(stderr,"Union_box:%s: Error identifying Union_init component, %s is not a known component name.\n",
+NAME_CURRENT_COMP, init);
+exit(-1);
+}
+
 struct pointer_to_global_material_list *global_material_list = COMP_GETPAR3(Union_init, init, global_material_list);
 // Use sanitation
 if (global_material_list->num_elements == 0) {

--- a/mcstas-comps/union/Union_conditional_PSD.comp
+++ b/mcstas-comps/union/Union_conditional_PSD.comp
@@ -254,8 +254,14 @@ INITIALIZE
     printf("ERROR: In Union conditional %s yheight is less than 0!\n",NAME_CURRENT_COMP);
   }
   this_conditional_data.PSD_half_yheight = 0.5*yheight;
-  
-  struct global_positions_to_transform_list_struct *global_positions_to_transform_list = COMP_GETPAR3(Union_init, init, global_positions_to_transform_list);
+
+if (_getcomp_index(init) < 0) {
+fprintf(stderr,"Union_conditional_PSD:%s: Error identifying Union_init component, %s is not a known component name.\n",
+NAME_CURRENT_COMP, init);
+exit(-1);
+}
+
+struct global_positions_to_transform_list_struct *global_positions_to_transform_list = COMP_GETPAR3(Union_init, init, global_positions_to_transform_list);
   struct global_rotations_to_transform_list_struct *global_rotations_to_transform_list = COMP_GETPAR3(Union_init, init, global_rotations_to_transform_list);
   // Test position and rotation stored in a data storage, and pointers assigned to transform lists
   this_conditional_data.PSD_position = POS_A_CURRENT_COMP;

--- a/mcstas-comps/union/Union_conditional_standard.comp
+++ b/mcstas-comps/union/Union_conditional_standard.comp
@@ -317,8 +317,14 @@ INITIALIZE
   }
   this_conditional_data.Total_scat_max = total_order_max;
   this_conditional_data.Total_scat_min = total_order_min;
-  
-  struct global_positions_to_transform_list_struct *global_positions_to_transform_list = COMP_GETPAR3(Union_init, init, global_positions_to_transform_list);
+
+if (_getcomp_index(init) < 0) {
+fprintf(stderr,"Union_conditional_standard:%s: Error identifying Union_init component, %s is not a known component name.\n",
+NAME_CURRENT_COMP, init);
+exit(-1);
+}
+
+struct global_positions_to_transform_list_struct *global_positions_to_transform_list = COMP_GETPAR3(Union_init, init, global_positions_to_transform_list);
   struct global_rotations_to_transform_list_struct *global_rotations_to_transform_list = COMP_GETPAR3(Union_init, init, global_rotations_to_transform_list);
   // Test position and rotation stored in a data storage, and pointers assigned to transform lists
   this_conditional_data.test_position = POS_A_CURRENT_COMP;

--- a/mcstas-comps/union/Union_cone.comp
+++ b/mcstas-comps/union/Union_cone.comp
@@ -236,6 +236,12 @@ if (yheight <= 0) {
   exit(1);
 }
 
+if (_getcomp_index(init) < 0) {
+fprintf(stderr,"Union_cone:%s: Error identifying Union_init component, %s is not a known component name.\n",
+NAME_CURRENT_COMP, init);
+exit(-1);
+}
+
 struct pointer_to_global_material_list *global_material_list = COMP_GETPAR3(Union_init, init, global_material_list);
 // Use sanitation
 #ifdef MATERIAL_DETECTOR

--- a/mcstas-comps/union/Union_cylinder.comp
+++ b/mcstas-comps/union/Union_cylinder.comp
@@ -194,6 +194,12 @@ if (yheight <= 0) {
   exit(1);
 }
 
+if (_getcomp_index(init) < 0) {
+fprintf(stderr,"Union_cylinder:%s: Error identifying Union_init component, %s is not a known component name.\n",
+NAME_CURRENT_COMP, init);
+exit(-1);
+}
+
 struct pointer_to_global_material_list *global_material_list = COMP_GETPAR3(Union_init, init, global_material_list);
 // Use sanitation
 #ifdef MATERIAL_DETECTOR

--- a/mcstas-comps/union/Union_logger_1D.comp
+++ b/mcstas-comps/union/Union_logger_1D.comp
@@ -513,9 +513,15 @@ INITIALIZE
   
   // In order to run the logger at the right times, pointers to this logger is stored in each volume it logs,
   //  and additionally for each avaiable process. If a process is not logged, the pointer is simply not stored.
-  
-  
-  struct pointer_to_global_geometry_list *global_geometry_list = COMP_GETPAR3(Union_init, init, global_geometry_list);
+
+
+if (_getcomp_index(init) < 0) {
+fprintf(stderr,"Union_logger_1D:%s: Error identifying Union_init component, %s is not a known component name.\n",
+NAME_CURRENT_COMP, init);
+exit(-1);
+}
+
+struct pointer_to_global_geometry_list *global_geometry_list = COMP_GETPAR3(Union_init, init, global_geometry_list);
   struct pointer_to_global_logger_list *global_specific_volumes_logger_list = COMP_GETPAR3(Union_init, init, global_specific_volumes_logger_list);
   
   // Need to find the volumes for which the processes should have a reference to this logger

--- a/mcstas-comps/union/Union_logger_2DQ.comp
+++ b/mcstas-comps/union/Union_logger_2DQ.comp
@@ -567,8 +567,14 @@ INITIALIZE
   sprintf(logger_list_element.name,NAME_CURRENT_COMP);
   logger_list_element.component_index = INDEX_CURRENT_COMP;
   logger_list_element.logger = &this_logger;
-  
-  // In order to run the logger at the right times, pointers to this logger is stored in each volume it logs,
+
+if (_getcomp_index(init) < 0) {
+fprintf(stderr,"Union_logger_2DQ:%s: Error identifying Union_init component, %s is not a known component name.\n",
+NAME_CURRENT_COMP, init);
+exit(-1);
+}
+
+// In order to run the logger at the right times, pointers to this logger is stored in each volume it logs,
   //  and additionally for each avaiable process. If a process is not logged, the pointer is simply not stored.
   struct pointer_to_global_geometry_list *global_geometry_list = COMP_GETPAR3(Union_init, init, global_geometry_list);
   struct pointer_to_global_logger_list *global_specific_volumes_logger_list = COMP_GETPAR3(Union_init, init, global_specific_volumes_logger_list);

--- a/mcstas-comps/union/Union_logger_2D_kf.comp
+++ b/mcstas-comps/union/Union_logger_2D_kf.comp
@@ -573,7 +573,13 @@ INITIALIZE
   logger_list_element.logger = &this_logger;
   
   //printf("past logger_list_element assignment \n");
-  
+
+if (_getcomp_index(init) < 0) {
+fprintf(stderr,"Union_logger_2D_kf:%s: Error identifying Union_init component, %s is not a known component name.\n",
+NAME_CURRENT_COMP, init);
+exit(-1);
+}
+
   // In order to run the logger at the right times, pointers to this logger is stored in each volume it logs,
   //  and additionally for each avaiable process. If a process is not logged, the pointer is simply not stored.
   struct pointer_to_global_geometry_list *global_geometry_list = COMP_GETPAR3(Union_init, init, global_geometry_list);

--- a/mcstas-comps/union/Union_logger_2D_kf_time.comp
+++ b/mcstas-comps/union/Union_logger_2D_kf_time.comp
@@ -636,8 +636,14 @@ INITIALIZE
   logger_list_element.logger = &this_logger;
   
   //printf("past logger_list_element assignment \n");
-  
-  // In order to run the logger at the right times, pointers to this logger is stored in each volume it logs,
+
+if (_getcomp_index(init) < 0) {
+fprintf(stderr,"Union_logger_2D_kf_time:%s: Error identifying Union_init component, %s is not a known component name.\n",
+NAME_CURRENT_COMP, init);
+exit(-1);
+}
+
+// In order to run the logger at the right times, pointers to this logger is stored in each volume it logs,
   //  and additionally for each avaiable process. If a process is not logged, the pointer is simply not stored.
   struct pointer_to_global_geometry_list *global_geometry_list = COMP_GETPAR3(Union_init, init, global_geometry_list);
   struct pointer_to_global_logger_list *global_specific_volumes_logger_list = COMP_GETPAR3(Union_init, init, global_specific_volumes_logger_list);

--- a/mcstas-comps/union/Union_logger_2D_space.comp
+++ b/mcstas-comps/union/Union_logger_2D_space.comp
@@ -582,9 +582,15 @@ INITIALIZE
   // Added 17/11/2016, allocating some elements in initialize makes code during trace simpler
   this_storage.temp_2DS_data.allocated_elements = 10;
   this_storage.temp_2DS_data.elements = malloc(this_storage.temp_2DS_data.allocated_elements*sizeof(struct temp_2DS_data_element_struct));
-  
-  
-  struct global_positions_to_transform_list_struct *global_positions_to_transform_list = COMP_GETPAR3(Union_init, init, global_positions_to_transform_list);
+
+
+if (_getcomp_index(init) < 0) {
+fprintf(stderr,"Union_logger_2D_space:%s: Error identifying Union_init component, %s is not a known component name.\n",
+NAME_CURRENT_COMP, init);
+exit(-1);
+}
+
+struct global_positions_to_transform_list_struct *global_positions_to_transform_list = COMP_GETPAR3(Union_init, init, global_positions_to_transform_list);
   struct global_rotations_to_transform_list_struct *global_rotations_to_transform_list = COMP_GETPAR3(Union_init, init, global_rotations_to_transform_list);
   // Test position and rotation stored in a data storage, and pointers assigned to transform lists
   this_storage.position = POS_A_CURRENT_COMP;

--- a/mcstas-comps/union/Union_logger_2D_space_time.comp
+++ b/mcstas-comps/union/Union_logger_2D_space_time.comp
@@ -641,9 +641,15 @@ INITIALIZE
   this_storage.temp_2DS_t_data.num_elements=0;
   this_storage.temp_2DS_t_data.allocated_elements = 10;
   this_storage.temp_2DS_t_data.elements = malloc(this_storage.temp_2DS_t_data.allocated_elements*sizeof(struct temp_2DS_t_data_element_struct));
-  
-  
-  struct global_positions_to_transform_list_struct *global_positions_to_transform_list = COMP_GETPAR3(Union_init, init, global_positions_to_transform_list);
+
+
+if (_getcomp_index(init) < 0) {
+fprintf(stderr,"Union_logger_2D_space_time:%s: Error identifying Union_init component, %s is not a known component name.\n",
+NAME_CURRENT_COMP, init);
+exit(-1);
+}
+
+struct global_positions_to_transform_list_struct *global_positions_to_transform_list = COMP_GETPAR3(Union_init, init, global_positions_to_transform_list);
   struct global_rotations_to_transform_list_struct *global_rotations_to_transform_list = COMP_GETPAR3(Union_init, init, global_rotations_to_transform_list);
   this_storage.position = POS_A_CURRENT_COMP;
   add_position_pointer_to_list(global_positions_to_transform_list,&this_storage.position);

--- a/mcstas-comps/union/Union_logger_3D_space.comp
+++ b/mcstas-comps/union/Union_logger_3D_space.comp
@@ -678,9 +678,15 @@ INITIALIZE
   this_storage.temp_3DS_data.num_elements=0;
   this_storage.temp_3DS_data.allocated_elements = 10;
   this_storage.temp_3DS_data.elements = malloc(this_storage.temp_3DS_data.allocated_elements*sizeof(struct temp_3DS_data_element_struct));
-  
-  
-  // Global variables retrieved from init component
+
+
+if (_getcomp_index(init) < 0) {
+fprintf(stderr,"Union_logger_3D:%s: Error identifying Union_init component, %s is not a known component name.\n",
+NAME_CURRENT_COMP, init);
+exit(-1);
+}
+
+// Global variables retrieved from init component
   struct global_positions_to_transform_list_struct *global_positions_to_transform_list = COMP_GETPAR3(Union_init, init, global_positions_to_transform_list);
   struct global_rotations_to_transform_list_struct *global_rotations_to_transform_list = COMP_GETPAR3(Union_init, init, global_rotations_to_transform_list);
   

--- a/mcstas-comps/union/Union_make_material.comp
+++ b/mcstas-comps/union/Union_make_material.comp
@@ -202,8 +202,14 @@ INITIALIZE
     printf("ERROR, Union make material named %s have a negative absorption cross section!.\n",NAME_CURRENT_COMP);
     exit(1);
   }
-  
-  struct pointer_to_global_process_list *global_process_list = COMP_GETPAR3(Union_init, init, global_process_list);
+
+if (_getcomp_index(init) < 0) {
+fprintf(stderr,"Union_make_material:%s: Error identifying Union_init component, %s is not a known component name.\n",
+NAME_CURRENT_COMP, init);
+exit(-1);
+}
+
+struct pointer_to_global_process_list *global_process_list = COMP_GETPAR3(Union_init, init, global_process_list);
   struct pointer_to_global_material_list *global_material_list = COMP_GETPAR3(Union_init, init, global_material_list);
   
   if (absorber == 0) {

--- a/mcstas-comps/union/Union_master.comp
+++ b/mcstas-comps/union/Union_master.comp
@@ -295,6 +295,11 @@ DECLARE
 
 INITIALIZE
 %{
+if (_getcomp_index(init) < 0) {
+fprintf(stderr,"Union_master:%s: Error identifying Union_init component, %s is not a known component name.\n",
+NAME_CURRENT_COMP, init);
+exit(-1);
+}
   // Unpack global lists
   global_positions_to_transform_list_master = COMP_GETPAR3(Union_init, init, global_positions_to_transform_list);
   global_rotations_to_transform_list_master = COMP_GETPAR3(Union_init, init, global_rotations_to_transform_list);

--- a/mcstas-comps/union/Union_master_GPU.comp
+++ b/mcstas-comps/union/Union_master_GPU.comp
@@ -230,6 +230,12 @@ DECLARE
 
 INITIALIZE
 %{
+
+if (_getcomp_index(init) < 0) {
+fprintf(stderr,"Union_master_GPU:%s: Error identifying Union_init component, %s is not a known component name.\n",
+NAME_CURRENT_COMP, init);
+exit(-1);
+}
   // Unpack global lists
   global_positions_to_transform_list_master = COMP_GETPAR3(Union_init, init, global_positions_to_transform_list);
   global_rotations_to_transform_list_master = COMP_GETPAR3(Union_init, init, global_rotations_to_transform_list);

--- a/mcstas-comps/union/Union_mesh.comp
+++ b/mcstas-comps/union/Union_mesh.comp
@@ -432,6 +432,11 @@ focus_initialize(&this_mesh_volume.geometry, POS_A_COMP_INDEX(INDEX_CURRENT_COMP
 
 
 
+if (_getcomp_index(init) < 0) {
+fprintf(stderr,"Union_mesh:%s: Error identifying Union_init component, %s is not a known component name.\n",
+NAME_CURRENT_COMP, init);
+exit(-1);
+}
 struct pointer_to_global_material_list *global_material_list = COMP_GETPAR3(Union_init, init, global_material_list);
 // Use sanitation
 #ifdef MATERIAL_DETECTOR

--- a/mcstas-comps/union/Union_sphere.comp
+++ b/mcstas-comps/union/Union_sphere.comp
@@ -190,6 +190,11 @@ if (radius <= 0) {
   exit(1);
 }
 
+if (_getcomp_index(init) < 0) {
+fprintf(stderr,"Union_sphere:%s: Error identifying Union_init component, %s is not a known component name.\n",
+NAME_CURRENT_COMP, init);
+exit(-1);
+}
 // Get global variable from init component
 struct pointer_to_global_material_list *global_material_list = COMP_GETPAR3(Union_init, init, global_material_list);
 // Use sanitation


### PR DESCRIPTION
Use of `Union` in `McStas` 3.2 requires a `Union_init` component to create shared memory data structures.
Most other `Union` components then access the shared memory via the `COMP_GETPAR3` macro which takes the component instance type, the component instance name, and the name of the component parameter to retrieve.

The component instance name must be provided, and to make use of `Union` easier a default name of `"init"` is assumed in every component making use of the `COMP_GETPAR3` macro.
If the `Union_init` component is created with a name other than `"init"` _and_ the other components are not configured with the different name, the compiled instrument **will likely** crash at runtime due to its access of out-of-process memory.

By adding a check for the component name existing, via the `_getcomp_index` function, a user can be alerted to the name-mismatch *before* the running program crashes allowing for easier pinpointing of the problem.
The main potential drawback to this implementation is if there is a component with the right name but the wrong type, in which case the running program will likely still crash without any useful error message.

This proposed change has not been tested yet, and should not be merged at this time.