### PR TITLE
[Add] McStas SEARCH grammar for adding to file search path

### DIFF
--- a/mcstas/src/instrument.l
+++ b/mcstas/src/instrument.l
@@ -144,6 +144,7 @@ CPU           return TOK_CPUONLY;       /* extended McStas grammar with GPU-CPU 
 NOACC         return TOK_NOACC; 
 DEPENDENCY    return TOK_DEPENDENCY;
 SHELL         return TOK_SHELL;         /* extended McStas grammar with SHELL commands pre-cogen */
+SEARCH        return TOK_SEARCH;        /* additional Instrument/Component search directories */
 
 "("|")"|"["|"]"|"{"|"}"|"," return yytext[0]; /* Punctuation. */
 "="|"*"       return yytext[0]; /* Operator. */


### PR DESCRIPTION
## Goal
To simplify the user-level configuration of a McStas instrument to interface with external libraries, it should be possible to modify the component search path from within an instrument or component file.

## Previous behavior
It was possible to extend the `mcstas` component search path by providing either the `-I` or `--search-dir` flags directly to the executable at runtime. This would require a user of McStas to add the option every time the instrument file changed and needed to be re-parsed into a C source file. Additionally, those flags were not understood by `mcrun` so the parsing step was required to be executed separately.

## New behavior
If a user needs to extend the component search path for an instrument, they can add a statement of the form
```
SEARCH "/the/path/to/add/"
```
which is then prepended to the searched directories every time `mcstas` is called.

If they have a tool which provides one or more paths, they can alternatively make use of the `SHELL` grammar to provide those:
```
SEARCH SHELL "the_executable --and --some --options"
```

The `SEARCH` statement can be added
- at the instrument level (between `SHELL` and `DEPENDENCY`)
- within a component definition (also between `SHELL` and `DEPENDENCY`)
- or in between components in the `TRACE section of an instrument file

### Extending `SEARCH` from a component
The motivation for supporting this functionality is to allow gateway components.
One such component could be the `Union_init` component, where if this component is not present and the instrument file parses successfully a failure will occur only at runtime.

If `Union_init` contained within it a statement that extended the component search path and all other `Union` components were normally hidden from the search, the error could be moved from binary runtime to instrument-parsing time.
This may allow for easier debugging for the end user.

### Extending `SEARCH` within `TRACE`
The motivation for supporting this functionality is to allow easy-use of specialized external libraries that are not suitable for inclusion within the McStas distribution.

Such libraries will install one or more component files and an executable which identifies their location on the user's machine. Then a user can add to their instrument `TRACE` section, e.g.,

```
SEARCH SHELL "library-configuration-helper --show comppath"
COMPONENT library_component = Library_component(...) AT ...
```

Placing this command within the `TRACE` allows for multiple `SEARCH` statements which may be required if a user utilizes multiple such libraries.


## Limitations
- The implementation in this PR only applies to `McStas`, but the same functionality could be provided for `McXtrace`
- Adding a directory to the search paths requires a `char *` which has a lifetime greater than the last search, or functionally until the end of the `mcstas` process. `SEARCH SHELL` allocates new `char *` values for every line returned by the executed program but *does not* keep track of them, and therefore leaks this memory. Since the runtime of `mcstas` is typically short, this may not be a significant problem; but actually tracking the `char *` pointers and freeing them before closing-out the executable may be a worthwhile addition to this PR.