### PR TITLE
GPU compatible models from sasmodels update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@
 *~
 \#*\#
 .\#*
+
+3rdparty/
+Mambaforge-Linux-x86_64.sh
+dist/

--- a/mcstas-comps/samples/SasView_model.comp
+++ b/mcstas-comps/samples/SasView_model.comp
@@ -2159,7 +2159,7 @@ DEFINITION PARAMETERS ()
 SETTING PARAMETERS (
   model_index=21,
   model_scale=1.0,
-  vector model_pars={60,0,0,0,0,0,0,0},
+  vector model_pars={60,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
   model_abs=0.5,
   xwidth=0,
   yheight=0,
@@ -2188,7 +2188,7 @@ DECLARE
 %{
   double shape;
   double my_a_v;
-  double modelpars[8];
+  double modelpars[15];
 %}
 
 INITIALIZE
@@ -2202,7 +2202,9 @@ int chosen=model_index;
   if (!(SASmodel_index==model_index)) {
       exit(fprintf(stderr, "SasView_model: %s: Your instrument was compiled with -DSASmodel_index=%i \n"
 		   "ERROR Please recompile your instrument with -DSASmodel_index=%i to enable model_index=%i\n", NAME_CURRENT_COMP, SASmodel_index, chosen, chosen));
-  }
+
+// int SASmodel_index=model_index;  
+}
 #endif
   
 shape=-1;  /* -1:no shape, 0:cyl, 1:box, 2:sphere  */
@@ -2234,9 +2236,11 @@ if (xwidth && yheight && zdepth)
 
   my_a_v = model_abs*2200*100; /* Is not yet divided by v. 100: Convert barns -> fm^2 */
   int j;
-  for(j=0;j<8;j++){
+  for(j=0;j<15;j++){
     modelpars[j]=model_pars[j];
   }
+
+
 %}
 
 TRACE

--- a/mcstas-comps/share/sas_adsorbed_layer.c
+++ b/mcstas-comps/share/sas_adsorbed_layer.c
@@ -1,0 +1,418 @@
+#define HAS_Iq
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/adsorbed_layer.c"
+
+#include <math.h>
+
+double Iq(
+    double q,
+    double second_moment,
+    double adsorbed_amount,
+    double density_shell,
+    double radius,
+    double volfraction,
+    double sld_shell,
+    double sld_solvent
+);
+
+#pragma acc routine seq
+double Iq(
+    double q,
+    double second_moment,
+    double adsorbed_amount,
+    double density_shell,
+    double radius,
+    double volfraction,
+    double sld_shell,
+    double sld_solvent
+) {
+    double aa = ((sld_shell - sld_solvent) / density_shell * adsorbed_amount) / q;
+    double bb = q * second_moment;
+    double inten = 6.0e-02 * PI * volfraction * pow(aa, 2) * exp(-pow(bb, 2)) / radius;
+    return inten;
+}
+
+

--- a/mcstas-comps/share/sas_barbell.c
+++ b/mcstas-comps/share/sas_barbell.c
@@ -1,644 +1,1063 @@
-// GENERATED CODE --- DO NOT EDIT ---
-// Code is produced by sasmodels.gen from sasmodels/models/MODEL.c
+#define HAS_Iqac
+#define HAS_FQ
+#define FORM_VOL
+#line 1 "../kernel_header.c"
 
 #ifdef __OPENCL_VERSION__
 # define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
 #endif
 
-#define USE_KAHAN_SUMMATION 0
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
 
 // If opencl is not available, then we are compiling a C function
 // Note: if using a C++ compiler, then define kernel as extern "C"
-#ifndef USE_OPENCL
-#  ifdef __cplusplus
-     #include <cstdio>
-     #include <cmath>
-     using namespace std;
-     #if defined(_MSC_VER)
-     #   define kernel extern "C" __declspec( dllexport )
-         inline float trunc(float x) { return x>=0?floor(x):-floor(-x); }
-	 inline float fmin(float x, float y) { return x>y ? y : x; }
-	 inline float fmax(float x, float y) { return x<y ? y : x; }
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
      #else
-     #   define kernel extern "C"
+         #define kernel extern "C"
+         #include <cstdint>
      #endif
-     inline void SINCOS(float angle, float &svar, float &cvar) { svar=sin(angle); cvar=cos(angle); }
-#  else
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
      #include <stdio.h>
-     #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
      // MSVC doesn't support C99, so no need for dllexport on C99 branch
      #define kernel
-     #define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
-#  define global
-#  define local
-#  define constant const
-// OpenCL powr(a,b) = C99 pow(a,b), b >= 0
-// OpenCL pown(a,b) = C99 pow(a,b), b integer
-#  define powr(a,b) pow(a,b)
-#  define pown(a,b) pow(a,b)
-#else
-#  ifdef USE_SINCOS
-#    define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
-#  else
-#    define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
 #endif
 
 // Standard mathematical constants:
 //   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
 //   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
-// OpenCL defines M_constant_F for float constants, and nothing if float
+// OpenCL defines M_constant_F for float constants, and nothing if double
 // is not enabled on the card, which is why these constants may be missing
 #ifndef M_PI
-#  define M_PI 3.141592653589793f
+#  define M_PI 3.141592653589793
 #endif
 #ifndef M_PI_2
-#  define M_PI_2 1.570796326794897f
+#  define M_PI_2 1.570796326794897
 #endif
 #ifndef M_PI_4
-#  define M_PI_4 0.7853981633974483f
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
 #endif
 
-// Non-standard pi/180, used for converting between degrees and radians
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
 #ifndef M_PI_180
-#  define M_PI_180 0.017453292519943295f
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
 #endif
 
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
 
-#define VOLUME_PARAMETERS bell_radius,radius,length
-#define VOLUME_WEIGHT_PRODUCT bell_radius_w*radius_w*length_w
-#define IQ_KERNEL_NAME barbell_Iq
-#define IQ_PARAMETERS sld, solvent_sld, bell_radius, radius, length
-#define IQ_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float sld, \
-    const float solvent_sld
-#define IQ_WEIGHT_PRODUCT bell_radius_w*radius_w*length_w
-#define IQ_DISPERSION_LENGTH_DECLARATIONS const int Nbell_radius, \
-    const int Nradius, \
-    const int Nlength
-#define IQ_DISPERSION_LENGTH_SUM Nbell_radius+Nradius+Nlength
-#define IQ_OPEN_LOOPS     for (int bell_radius_i=0; bell_radius_i < Nbell_radius; bell_radius_i++) { \
-      const float bell_radius = loops[2*(bell_radius_i)]; \
-      const float bell_radius_w = loops[2*(bell_radius_i)+1]; \
-      for (int radius_i=0; radius_i < Nradius; radius_i++) { \
-        const float radius = loops[2*(radius_i+Nbell_radius)]; \
-        const float radius_w = loops[2*(radius_i+Nbell_radius)+1]; \
-        for (int length_i=0; length_i < Nlength; length_i++) { \
-          const float length = loops[2*(length_i+Nbell_radius+Nradius)]; \
-          const float length_w = loops[2*(length_i+Nbell_radius+Nradius)+1];
-#define IQ_CLOSE_LOOPS         } \
-      } \
-    }
-#define IQXY_KERNEL_NAME barbell_Iqxy
-#define IQXY_PARAMETERS sld, solvent_sld, bell_radius, radius, length, theta, phi
-#define IQXY_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float sld, \
-    const float solvent_sld
-#define IQXY_WEIGHT_PRODUCT bell_radius_w*radius_w*length_w*theta_w*phi_w
-#define IQXY_DISPERSION_LENGTH_DECLARATIONS const int Nbell_radius, \
-    const int Nradius, \
-    const int Nlength, \
-    const int Ntheta, \
-    const int Nphi
-#define IQXY_DISPERSION_LENGTH_SUM Nbell_radius+Nradius+Nlength+Ntheta+Nphi
-#define IQXY_OPEN_LOOPS     for (int bell_radius_i=0; bell_radius_i < Nbell_radius; bell_radius_i++) { \
-      const float bell_radius = loops[2*(bell_radius_i)]; \
-      const float bell_radius_w = loops[2*(bell_radius_i)+1]; \
-      for (int radius_i=0; radius_i < Nradius; radius_i++) { \
-        const float radius = loops[2*(radius_i+Nbell_radius)]; \
-        const float radius_w = loops[2*(radius_i+Nbell_radius)+1]; \
-        for (int length_i=0; length_i < Nlength; length_i++) { \
-          const float length = loops[2*(length_i+Nbell_radius+Nradius)]; \
-          const float length_w = loops[2*(length_i+Nbell_radius+Nradius)+1]; \
-          for (int theta_i=0; theta_i < Ntheta; theta_i++) { \
-            const float theta = loops[2*(theta_i+Nbell_radius+Nradius+Nlength)]; \
-            const float theta_w = loops[2*(theta_i+Nbell_radius+Nradius+Nlength)+1]; \
-            for (int phi_i=0; phi_i < Nphi; phi_i++) { \
-              const float phi = loops[2*(phi_i+Nbell_radius+Nradius+Nlength+Ntheta)]; \
-              const float phi_w = loops[2*(phi_i+Nbell_radius+Nradius+Nlength+Ntheta)+1];
-#define IQXY_CLOSE_LOOPS             } \
-          } \
-        } \
-      } \
-    }
-#define IQXY_HAS_THETA 1
+//# Beginning of rotational operation definitions
 
-float J1(float x);
-float J1(float x)
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
 {
-  const float ax = fabs(x);
-  if (ax < 8.0f) {
-    const float y = x*x;
-    const float ans1 = x*(72362614232.0f
-              + y*(-7895059235.0f
-              + y*(242396853.1f
-              + y*(-2972611.439f
-              + y*(15704.48260f
-              + y*(-30.16036606f))))));
-    const float ans2 = 144725228442.0f
-              + y*(2300535178.0f
-              + y*(18583304.74f
-              + y*(99447.43394f
-              + y*(376.9991397f
-              + y))));
-    return ans1/ans2;
-  } else {
-    const float y = 64.0f/(ax*ax);
-    const float xx = ax - 2.356194491f;
-    const float ans1 = 1.0f
-              + y*(0.183105e-2f
-              + y*(-0.3516396496e-4f
-              + y*(0.2457520174e-5f
-              + y*-0.240337019e-6f)));
-    const float ans2 = 0.04687499995f
-              + y*(-0.2002690873e-3f
-              + y*(0.8449199096e-5f
-              + y*(-0.88228987e-6f
-              + y*0.105787412e-6f)));
-    float sn,cn;
-    SINCOS(xx, sn, cn);
-    const float ans = sqrt(0.636619772f/ax) * (cn*ans1 - (8.0f/ax)*sn*ans2);
-    return (x < 0.0f) ? -ans : ans;
-  }
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/polevl.c"
+
+/*							polevl.c
+ *							p1evl.c
+ *
+ *	Evaluate polynomial
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * int N;
+ * double x, y, coef[N+1], polevl[];
+ *
+ * y = polevl( x, coef, N );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Evaluates polynomial of degree N:
+ *
+ *                     2          N
+ * y  =  C  + C x + C x  +...+ C x
+ *        0    1     2          N
+ *
+ * Coefficients are stored in reverse order:
+ *
+ * coef[0] = C  , ..., coef[N] = C  .
+ *            N                   0
+ *
+ * The function p1evl() assumes that C_N = 1.0 and is
+ * omitted from the array.  Its calling arguments are
+ * otherwise the same as polevl().
+ *
+ *
+ * SPEED:
+ *
+ * In the interest of speed, there are no checks for out
+ * of bounds arithmetic.  This routine is used by most of
+ * the functions in the library.  Depending on available
+ * equipment features, the user may wish to rewrite the
+ * program in microcode or assembly language.
+ *
+ */
+
+
+/*
+Cephes Math Library Release 2.1:  December, 1988
+Copyright 1984, 1987, 1988 by Stephen L. Moshier
+Direct inquiries to 30 Frost Street, Cambridge, MA 02140
+*/
+#pragma acc routine seq
+static
+double polevl( double x, pconstant double *coef, int N )
+{
+
+    int i = 0;
+    double ans = coef[i];
+
+    while (i < N) {
+        i++;
+        ans = ans * x + coef[i];
+    }
+
+    return ans;
+}
+
+/*							p1evl()	*/
+/*                                          N
+ * Evaluate polynomial when coefficient of x  is 1.0.
+ * Otherwise same as polevl.
+ */
+#pragma acc routine seq
+static
+double p1evl( double x, pconstant double *coef, int N )
+{
+    int i=0;
+    double ans = x+coef[i];
+
+    while (i < N-1) {
+        i++;
+        ans = ans*x + coef[i];
+    }
+
+    return ans;
 }
 
 
-/*
- *  GaussWeights.c
- *  SANSAnalysis
+#line 1 ".././models/lib/sas_J1.c"
+
+/*							j1.c
  *
- *  Created by Andrew Jackson on 4/23/07.f
- *  Copyright 2007 __MyCompanyName__. All rights reserved.
+ *	Bessel function of order one
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * double x, y, j1();
+ *
+ * y = j1( x );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Returns Bessel function of order one of the argument.
+ *
+ * The domain is divided into the intervals [0, 8] and
+ * (8, infinity). In the first interval a 24 term Chebyshev
+ * expansion is used. In the second, the asymptotic
+ * trigonometric representation is employed using two
+ * rational functions of degree 5/5.
+ *
+ *
+ *
+ * ACCURACY:
+ *
+ *                      Absolute error:
+ * arithmetic   domain      # trials      peak         rms
+ *    DEC       0, 30       10000       4.0e-17     1.1e-17
+ *    IEEE      0, 30       30000       2.6e-16     1.1e-16
+ *
  *
  */
 
-// Gaussians
-constant float Gauss76Wt[]={
-	.00126779163408536f,		//0
-	.00294910295364247f,
-	.00462793522803742f,
-	.00629918049732845f,
-	.00795984747723973f,
-	.00960710541471375f,
-	.0112381685696677f,
-	.0128502838475101f,
-	.0144407317482767f,
-	.0160068299122486f,
-	.0175459372914742f,		//10
-	.0190554584671906f,
-	.020532847967908f,
-	.0219756145344162f,
-	.0233813253070112f,
-	.0247476099206597f,
-	.026072164497986f,
-	.0273527555318275f,
-	.028587223650054f,
-	.029773487255905f,
-	.0309095460374916f,		//20
-	.0319934843404216f,
-	.0330234743977917f,
-	.0339977794120564f,
-	.0349147564835508f,
-	.0357728593807139f,
-	.0365706411473296f,
-	.0373067565423816f,
-	.0379799643084053f,
-	.0385891292645067f,
-	.0391332242205184f,		//30
-	.0396113317090621f,
-	.0400226455325968f,
-	.040366472122844f,
-	.0406422317102947f,
-	.0408494593018285f,
-	.040987805464794f,
-	.0410570369162294f,
-	.0410570369162294f,
-	.040987805464794f,
-	.0408494593018285f,		//40
-	.0406422317102947f,
-	.040366472122844f,
-	.0400226455325968f,
-	.0396113317090621f,
-	.0391332242205184f,
-	.0385891292645067f,
-	.0379799643084053f,
-	.0373067565423816f,
-	.0365706411473296f,
-	.0357728593807139f,		//50
-	.0349147564835508f,
-	.0339977794120564f,
-	.0330234743977917f,
-	.0319934843404216f,
-	.0309095460374916f,
-	.029773487255905f,
-	.028587223650054f,
-	.0273527555318275f,
-	.026072164497986f,
-	.0247476099206597f,		//60
-	.0233813253070112f,
-	.0219756145344162f,
-	.020532847967908f,
-	.0190554584671906f,
-	.0175459372914742f,
-	.0160068299122486f,
-	.0144407317482767f,
-	.0128502838475101f,
-	.0112381685696677f,
-	.00960710541471375f,		//70
-	.00795984747723973f,
-	.00629918049732845f,
-	.00462793522803742f,
-	.00294910295364247f,
-	.00126779163408536f		//75 (indexed from 0)
-};
-
-#pragma acc declare create ( Gauss76Wt )
-
-constant float Gauss76Z[]={
-	-.999505948362153f,		//0
-	-.997397786355355f,
-	-.993608772723527f,
-	-.988144453359837f,
-	-.981013938975656f,
-	-.972229228520377f,
-	-.961805126758768f,
-	-.949759207710896f,
-	-.936111781934811f,
-	-.92088586125215f,
-	-.904107119545567f,		//10
-	-.885803849292083f,
-	-.866006913771982f,
-	-.844749694983342f,
-	-.822068037328975f,
-	-.7980001871612f,
-	-.77258672828181f,
-	-.74587051350361f,
-	-.717896592387704f,
-	-.688712135277641f,
-	-.658366353758143f,		//20
-	-.626910417672267f,
-	-.594397368836793f,
-	-.560882031601237f,
-	-.526420920401243f,
-	-.491072144462194f,
-	-.454895309813726f,
-	-.417951418780327f,
-	-.380302767117504f,
-	-.342012838966962f,
-	-.303146199807908f,		//30
-	-.263768387584994f,
-	-.223945802196474f,
-	-.183745593528914f,
-	-.143235548227268f,
-	-.102483975391227f,
-	-.0615595913906112f,
-	-.0205314039939986f,
-	.0205314039939986f,
-	.0615595913906112f,
-	.102483975391227f,			//40
-	.143235548227268f,
-	.183745593528914f,
-	.223945802196474f,
-	.263768387584994f,
-	.303146199807908f,
-	.342012838966962f,
-	.380302767117504f,
-	.417951418780327f,
-	.454895309813726f,
-	.491072144462194f,		//50
-	.526420920401243f,
-	.560882031601237f,
-	.594397368836793f,
-	.626910417672267f,
-	.658366353758143f,
-	.688712135277641f,
-	.717896592387704f,
-	.74587051350361f,
-	.77258672828181f,
-	.7980001871612f,	//60
-	.822068037328975f,
-	.844749694983342f,
-	.866006913771982f,
-	.885803849292083f,
-	.904107119545567f,
-	.92088586125215f,
-	.936111781934811f,
-	.949759207710896f,
-	.961805126758768f,
-	.972229228520377f,		//70
-	.981013938975656f,
-	.988144453359837f,
-	.993608772723527f,
-	.997397786355355f,
-	.999505948362153f		//75
-};
-
-#pragma acc declare create ( Gauss76Z )
-
-float form_volume(float bell_radius, float radius, float length);
-float Iq(float q, float sld, float solvent_sld,
-        float bell_radius, float radius, float length);
-float Iqxy(float qx, float qy, float sld, float solvent_sld,
-        float bell_radius, float radius, float length,
-        float theta, float phi);
-
-//barbell kernel - same as dumbell
-float _bell_kernel(float q, float h, float bell_radius,
-        float length, float sin_alpha, float cos_alpha);
-float _bell_kernel(float q, float h, float bell_radius,
-        float length, float sin_alpha, float cos_alpha)
-{
-    const float upper = 1.0f;
-    const float lower = -1.0f*h/bell_radius;
-
-    float total = 0.0f;
-    for (int i = 0; i < 76; i++){
-        const float t = 0.5f*(Gauss76Z[i]*(upper-lower)+upper+lower);
-        const float arg1 = q*cos_alpha*(bell_radius*t+h+length*0.5f);
-        const float arg2 = q*bell_radius*sin_alpha*sqrt(1.0f-t*t);
-        const float be = (arg2 == 0.0f ? 0.5f :J1(arg2)/arg2);
-        const float Fq = cos(arg1)*(1.0f-t*t)*be;
-        total += Gauss76Wt[i] * Fq;
-    }
-    const float integral = 0.5f*(upper-lower)*total;
-    return 4.0f*M_PI*bell_radius*bell_radius*bell_radius*integral;
-}
-
-float form_volume(float bell_radius,
-        float radius,
-        float length)
-{
-
-    // bell radius should never be less than radius when this is called
-    const float hdist = sqrt(bell_radius*bell_radius - radius*radius);
-    const float p1 = 2.0f*bell_radius*bell_radius*bell_radius/3.0f;
-    const float p2 = bell_radius*bell_radius*hdist;
-    const float p3 = hdist*hdist*hdist/3.0f;
-
-    return M_PI*radius*radius*length + 2.0f*M_PI*(p1+p2-p3);
-}
-
-float Iq(float q, float sld,
-        float solvent_sld,
-        float bell_radius,
-        float radius,
-        float length)
-{
-    float sn, cn; // slots to hold sincos function output
-
-    if (bell_radius < radius) return NAN;
-
-    const float lower = 0.0f;
-    const float upper = M_PI_2;
-    const float h = sqrt(bell_radius*bell_radius-radius*radius);
-    float total = 0.0f;
-    for (int i = 0; i < 76; i++){
-        const float alpha= 0.5f*(Gauss76Z[i]*(upper-lower) + upper + lower);
-        SINCOS(alpha, sn, cn);
-
-        const float bell_Fq = _bell_kernel(q, h, bell_radius, length, sn, cn);
-
-        const float arg1 = q*length*0.5f*cn;
-        const float arg2 = q*radius*sn;
-        // lim_{x->0} J1(x)/x = 1/2,   lim_{x->0} sin(x)/x = 1
-        const float be = (arg2 == 0.0f ? 0.5f :J1(arg2)/arg2);
-        const float si = (arg1 == 0.0f ? 1.0f :sin(arg1)/arg1);
-        const float cyl_Fq = M_PI*radius*radius*length*si*2.0f*be;
-
-        const float Aq = cyl_Fq + bell_Fq;
-        total += Gauss76Wt[i] * Aq * Aq * sn;
-    }
-
-    const float form = total*(upper-lower)*0.5f;
-
-    //Contrast and volume normalization
-    const float s = (sld - solvent_sld);
-    return form*1.0e-4f*s*s; //form_volume(bell_radius,radius,length);
-}
-
-
-
-float Iqxy(float qx, float qy,
-        float sld,
-        float solvent_sld,
-        float bell_radius,
-        float radius,
-        float length,
-        float theta,
-        float phi)
-{
-     float sn, cn; // slots to hold sincos function output
-
-    // Exclude invalid inputs.
-    if (bell_radius < radius) return NAN;
-
-    // Compute angle alpha between q and the cylinder axis
-    SINCOS(theta*M_PI_180, sn, cn);
-    // # The following correction factor exists in sasview, but it can't be
-    // # right, so we are leaving it out for now.
-    const float q = sqrt(qx*qx+qy*qy);
-    const float cos_val = cn*cos(phi*M_PI_180)*qx + sn*qy;
-    const float alpha = acos(cos_val); // rod angle relative to q
-    SINCOS(alpha, sn, cn);
-
-    const float h = sqrt(bell_radius*bell_radius - radius*radius); // negative h
-    const float bell_Fq = _bell_kernel(q, h, bell_radius, length, sn, cn)/sn;
-
-    const float besarg = q*radius*sn;
-    const float siarg = q*0.5f*length*cn;
-    // lim_{x->0} J1(x)/x = 1/2,   lim_{x->0} sin(x)/x = 1
-    const float bj = (besarg == 0.0f ? 0.5f : J1(besarg)/besarg);
-    const float si = (siarg == 0.0f ? 1.0f : sin(siarg)/siarg);
-    const float cyl_Fq = M_PI*radius*radius*length*2.0f*bj*si;
-
-    // Volume weighted average F(q)
-    const float Aq = cyl_Fq + bell_Fq;
-
-    // Multiply by contrast^2, normalize by cylinder volume and convert to cm-1
-    const float s = (sld - solvent_sld);
-    return 1.0e-4f * Aq * Aq * s * s; // form_volume(radius, cap_radius, length);
-}
-
-
 /*
-    ##########################################################
-    #                                                        #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #   !!                                              !!   #
-    #   !!  KEEP THIS CODE CONSISTENT WITH KERNELPY.PY  !!   #
-    #   !!                                              !!   #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #                                                        #
-    ##########################################################
+Cephes Math Library Release 2.8:  June, 2000
+Copyright 1984, 1987, 1989, 2000 by Stephen L. Moshier
 */
 
-#ifdef IQ_KERNEL_NAME
-kernel void IQ_KERNEL_NAME(
-    global const float *q,
-    global float *result,
-    const int Nq,
-#ifdef IQ_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQ_DISPERSION_LENGTH_DECLARATIONS,
-#endif
-    IQ_FIXED_PARAMETER_DECLARATIONS
-    )
+#if FLOAT_SIZE>4
+//Cephes double pression function
+
+constant double RPJ1[8] = {
+    -8.99971225705559398224E8,
+    4.52228297998194034323E11,
+    -7.27494245221818276015E13,
+    3.68295732863852883286E15,
+    0.0,
+    0.0,
+    0.0,
+    0.0 };
+
+constant double RQJ1[8] = {
+    6.20836478118054335476E2,
+    2.56987256757748830383E5,
+    8.35146791431949253037E7,
+    2.21511595479792499675E10,
+    4.74914122079991414898E12,
+    7.84369607876235854894E14,
+    8.95222336184627338078E16,
+    5.32278620332680085395E18
+    };
+
+constant double PPJ1[8] = {
+    7.62125616208173112003E-4,
+    7.31397056940917570436E-2,
+    1.12719608129684925192E0,
+    5.11207951146807644818E0,
+    8.42404590141772420927E0,
+    5.21451598682361504063E0,
+    1.00000000000000000254E0,
+    0.0} ;
+
+
+constant double PQJ1[8] = {
+    5.71323128072548699714E-4,
+    6.88455908754495404082E-2,
+    1.10514232634061696926E0,
+    5.07386386128601488557E0,
+    8.39985554327604159757E0,
+    5.20982848682361821619E0,
+    9.99999999999999997461E-1,
+    0.0 };
+
+constant double QPJ1[8] = {
+    5.10862594750176621635E-2,
+    4.98213872951233449420E0,
+    7.58238284132545283818E1,
+    3.66779609360150777800E2,
+    7.10856304998926107277E2,
+    5.97489612400613639965E2,
+    2.11688757100572135698E2,
+    2.52070205858023719784E1 };
+
+constant double QQJ1[8] = {
+    7.42373277035675149943E1,
+    1.05644886038262816351E3,
+    4.98641058337653607651E3,
+    9.56231892404756170795E3,
+    7.99704160447350683650E3,
+    2.82619278517639096600E3,
+    3.36093607810698293419E2,
+    0.0 };
+
+#pragma acc declare copyin( RPJ1[0:8], RQJ1[0:8], PPJ1[0:8], PQJ1[0:8], QPJ1[0:8], QQJ1[0:8])
+
+#pragma acc routine seq
+static
+double cephes_j1(double x)
 {
-#ifdef USE_OPENCL
-  #ifdef IQ_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQ_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
 
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qi = q[i];
-#ifdef IQ_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-  #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-  #endif
-    IQ_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
+    double w, z, p, q, abs_x, sign_x;
 
-    const float weight = IQ_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-      const float scattering = Iq(qi, IQ_PARAMETERS);
-      // allow kernels to exclude invalid regions by returning NaN
-      if (!isnan(scattering)) {
-        ret += weight*scattering;
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-        norm_vol += vol_weight;
-      #endif
-      }
-    //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
+    const double Z1 = 1.46819706421238932572E1;
+    const double Z2 = 4.92184563216946036703E1;
+
+    // 2017-05-18 PAK - mathematica and mpmath use J1(-x) = -J1(x)
+    if (x < 0) {
+        abs_x = -x;
+        sign_x = -1.0;
+    } else {
+        abs_x = x;
+        sign_x = 1.0;
     }
-    IQ_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
+
+    if( abs_x <= 5.0 ) {
+        z = abs_x * abs_x;
+        w = polevl( z, RPJ1, 3 ) / p1evl( z, RQJ1, 8 );
+        w = w * abs_x * (z - Z1) * (z - Z2);
+        return( sign_x * w );
     }
-  #endif
-    result[i] = scale*ret/norm+background;
+
+    w = 5.0/abs_x;
+    z = w * w;
+    p = polevl( z, PPJ1, 6)/polevl( z, PQJ1, 6 );
+    q = polevl( z, QPJ1, 7)/p1evl( z, QQJ1, 7 );
+
+    // 2017-05-19 PAK improve accuracy using trig identies
+    // original:
+    //    const double THPIO4 =  2.35619449019234492885;
+    //    const double SQ2OPI = 0.79788456080286535588;
+    //    double sin_xn, cos_xn;
+    //    SINCOS(abs_x - THPIO4, sin_xn, cos_xn);
+    //    p = p * cos_xn - w * q * sin_xn;
+    //    return( sign_x * p * SQ2OPI / sqrt(abs_x) );
+    // expanding p*cos(a - 3 pi/4) - wq sin(a - 3 pi/4)
+    //    [ p(sin(a) - cos(a)) + wq(sin(a) + cos(a)) / sqrt(2)
+    // note that sqrt(1/2) * sqrt(2/pi) = sqrt(1/pi)
+    const double SQRT1_PI = 0.56418958354775628;
+    double sin_x, cos_x;
+    SINCOS(abs_x, sin_x, cos_x);
+    p = p*(sin_x - cos_x) + w*q*(sin_x + cos_x);
+    return( sign_x * p * SQRT1_PI / sqrt(abs_x) );
+}
+
 #else
-    result[i] = scale*Iq(qi, IQ_PARAMETERS) + background;
-#endif
-  }
+//Single precission version of cephes
+
+constant float JPJ1[8] = {
+    -4.878788132172128E-009,
+    6.009061827883699E-007,
+    -4.541343896997497E-005,
+    1.937383947804541E-003,
+    -3.405537384615824E-002,
+    0.0,
+    0.0,
+    0.0
+    };
+
+constant float MO1J1[8] = {
+    6.913942741265801E-002,
+    -2.284801500053359E-001,
+    3.138238455499697E-001,
+    -2.102302420403875E-001,
+    5.435364690523026E-003,
+    1.493389585089498E-001,
+    4.976029650847191E-006,
+    7.978845453073848E-001
+    };
+
+constant float PH1J1[8] = {
+    -4.497014141919556E+001,
+    5.073465654089319E+001,
+    -2.485774108720340E+001,
+    7.222973196770240E+000,
+    -1.544842782180211E+000,
+    3.503787691653334E-001,
+    -1.637986776941202E-001,
+    3.749989509080821E-001
+    };
+
+#pragma acc declare copyin( JPJ1[0:8], MO1J1[0:8], PH1J1[0:8])
+
+#pragma acc routine seq
+static
+float cephes_j1f(float xx)
+{
+
+    float x, w, z, p, q, xn;
+
+    const float Z1 = 1.46819706421238932572E1;
+
+
+    // 2017-05-18 PAK - mathematica and mpmath use J1(-x) = -J1(x)
+    x = xx;
+    if( x < 0 )
+        x = -xx;
+
+    if( x <= 2.0 ) {
+        z = x * x;
+        p = (z-Z1) * x * polevl( z, JPJ1, 4 );
+        return( xx < 0. ? -p : p );
+    }
+
+    q = 1.0/x;
+    w = sqrt(q);
+
+    p = w * polevl( q, MO1J1, 7);
+    w = q*q;
+    // 2017-05-19 PAK improve accuracy using trig identies
+    // original:
+    //    const float THPIO4F =  2.35619449019234492885;    /* 3*pi/4 */
+    //    xn = q * polevl( w, PH1J1, 7) - THPIO4F;
+    //    p = p * cos(xn + x);
+    //    return( xx < 0. ? -p : p );
+    // expanding cos(a + b - 3 pi/4) is
+    //    [sin(a)sin(b) + sin(a)cos(b) + cos(a)sin(b)-cos(a)cos(b)] / sqrt(2)
+    xn = q * polevl( w, PH1J1, 7);
+    float cos_xn, sin_xn;
+    float cos_x, sin_x;
+    SINCOS(xn, sin_xn, cos_xn);  // about xn and 1
+    SINCOS(x, sin_x, cos_x);
+    p *= M_SQRT1_2*(sin_xn*(sin_x+cos_x) + cos_xn*(sin_x-cos_x));
+
+    return( xx < 0. ? -p : p );
 }
 #endif
 
-
-#ifdef IQXY_KERNEL_NAME
-kernel void IQXY_KERNEL_NAME(
-    global const float *qx,
-    global const float *qy,
-    global float *result,
-    const int Nq,
-#ifdef IQXY_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQXY_DISPERSION_LENGTH_DECLARATIONS,
+#if FLOAT_SIZE>4
+#define sas_J1 cephes_j1
+#else
+#define sas_J1 cephes_j1f
 #endif
-    IQXY_FIXED_PARAMETER_DECLARATIONS
-    )
+
+//Finally J1c function that equals 2*J1(x)/x
+    
+#pragma acc routine seq
+static
+double sas_2J1x_x(double x)
 {
-#ifdef USE_OPENCL
-  #ifdef IQXY_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQXY_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
-
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qxi = qx[i];
-    const float qyi = qy[i];
-    #if USE_KAHAN_SUMMATION
-    float accumulated_error = 0.0f;
-    #endif
-#ifdef IQXY_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-    #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-    #endif
-    IQXY_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
-
-    const float weight = IQXY_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-
-      const float scattering = Iqxy(qxi, qyi, IQXY_PARAMETERS);
-      if (!isnan(scattering)) { // if scattering is bad, exclude it from sum
-      //if (scattering >= 0.0f) { // scattering cannot be negative
-        // TODO: use correct angle for spherical correction
-        // Definition of theta and phi are probably reversed relative to the
-        // equation which gave rise to this correction, leading to an
-        // attenuation of the pattern as theta moves through pi/2.f  Either
-        // reverse the meanings of phi and theta in the forms, or use phi
-        // rather than theta in this correction.  Current code uses cos(theta)
-        // so that values match those of sasview.
-      #if defined(IQXY_HAS_THETA) // && 0
-        const float spherical_correction
-          = (Ntheta>1 ? fabs(cos(M_PI_180*theta))*M_PI_2:1.0f);
-        const float next = spherical_correction * weight * scattering;
-      #else
-        const float next = weight * scattering;
-      #endif
-      #if USE_KAHAN_SUMMATION
-        const float y = next - accumulated_error;
-        const float t = ret + y;
-        accumulated_error = (t - ret) - y;
-        ret = t;
-      #else
-        ret += next;
-      #endif
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-      #endif
-        norm_vol += vol_weight;
-      }
-      //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
-    }
-    IQXY_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iqxy(qxi, qyi, IQXY_PARAMETERS) + background;
-#endif
-  }
+    return (x != 0.0 ) ? 2.0*sas_J1(x)/x : 1.0;
 }
-#endif
+
+
+#line 1 ".././models/lib/gauss76.c"
+
+// Created by Andrew Jackson on 4/23/07
+
+ #ifdef GAUSS_N
+ # undef GAUSS_N
+ # undef GAUSS_Z
+ # undef GAUSS_W
+ #endif
+ #define GAUSS_N 76
+ #define GAUSS_Z Gauss76Z
+ #define GAUSS_W Gauss76Wt
+
+// Gaussians
+constant double Gauss76Wt[76] = {
+	.00126779163408536,		//0
+	.00294910295364247,
+	.00462793522803742,
+	.00629918049732845,
+	.00795984747723973,
+	.00960710541471375,
+	.0112381685696677,
+	.0128502838475101,
+	.0144407317482767,
+	.0160068299122486,
+	.0175459372914742,		//10
+	.0190554584671906,
+	.020532847967908,
+	.0219756145344162,
+	.0233813253070112,
+	.0247476099206597,
+	.026072164497986,
+	.0273527555318275,
+	.028587223650054,
+	.029773487255905,
+	.0309095460374916,		//20
+	.0319934843404216,
+	.0330234743977917,
+	.0339977794120564,
+	.0349147564835508,
+	.0357728593807139,
+	.0365706411473296,
+	.0373067565423816,
+	.0379799643084053,
+	.0385891292645067,
+	.0391332242205184,		//30
+	.0396113317090621,
+	.0400226455325968,
+	.040366472122844,
+	.0406422317102947,
+	.0408494593018285,
+	.040987805464794,
+	.0410570369162294,
+	.0410570369162294,
+	.040987805464794,
+	.0408494593018285,		//40
+	.0406422317102947,
+	.040366472122844,
+	.0400226455325968,
+	.0396113317090621,
+	.0391332242205184,
+	.0385891292645067,
+	.0379799643084053,
+	.0373067565423816,
+	.0365706411473296,
+	.0357728593807139,		//50
+	.0349147564835508,
+	.0339977794120564,
+	.0330234743977917,
+	.0319934843404216,
+	.0309095460374916,
+	.029773487255905,
+	.028587223650054,
+	.0273527555318275,
+	.026072164497986,
+	.0247476099206597,		//60
+	.0233813253070112,
+	.0219756145344162,
+	.020532847967908,
+	.0190554584671906,
+	.0175459372914742,
+	.0160068299122486,
+	.0144407317482767,
+	.0128502838475101,
+	.0112381685696677,
+	.00960710541471375,		//70
+	.00795984747723973,
+	.00629918049732845,
+	.00462793522803742,
+	.00294910295364247,
+	.00126779163408536		//75 (indexed from 0)
+};
+
+constant double Gauss76Z[76] = {
+	-.999505948362153,		//0
+	-.997397786355355,
+	-.993608772723527,
+	-.988144453359837,
+	-.981013938975656,
+	-.972229228520377,
+	-.961805126758768,
+	-.949759207710896,
+	-.936111781934811,
+	-.92088586125215,
+	-.904107119545567,		//10
+	-.885803849292083,
+	-.866006913771982,
+	-.844749694983342,
+	-.822068037328975,
+	-.7980001871612,
+	-.77258672828181,
+	-.74587051350361,
+	-.717896592387704,
+	-.688712135277641,
+	-.658366353758143,		//20
+	-.626910417672267,
+	-.594397368836793,
+	-.560882031601237,
+	-.526420920401243,
+	-.491072144462194,
+	-.454895309813726,
+	-.417951418780327,
+	-.380302767117504,
+	-.342012838966962,
+	-.303146199807908,		//30
+	-.263768387584994,
+	-.223945802196474,
+	-.183745593528914,
+	-.143235548227268,
+	-.102483975391227,
+	-.0615595913906112,
+	-.0205314039939986,
+	.0205314039939986,
+	.0615595913906112,
+	.102483975391227,			//40
+	.143235548227268,
+	.183745593528914,
+	.223945802196474,
+	.263768387584994,
+	.303146199807908,
+	.342012838966962,
+	.380302767117504,
+	.417951418780327,
+	.454895309813726,
+	.491072144462194,		//50
+	.526420920401243,
+	.560882031601237,
+	.594397368836793,
+	.626910417672267,
+	.658366353758143,
+	.688712135277641,
+	.717896592387704,
+	.74587051350361,
+	.77258672828181,
+	.7980001871612,	//60
+	.822068037328975,
+	.844749694983342,
+	.866006913771982,
+	.885803849292083,
+	.904107119545567,
+	.92088586125215,
+	.936111781934811,
+	.949759207710896,
+	.961805126758768,
+	.972229228520377,		//70
+	.981013938975656,
+	.988144453359837,
+	.993608772723527,
+	.997397786355355,
+	.999505948362153		//75
+};
+
+
+#pragma acc declare copyin(Gauss76Wt[0:76], Gauss76Z[0:76])
+
+#line 1 ".././models/barbell.c"
+
+//barbell kernel - same as dumbbell
+static double
+_bell_kernel(double qab, double qc, double h, double radius_bell,
+             double half_length)
+{
+    // translate a point in [-1,1] to a point in [lower,upper]
+    const double upper = 1.0;
+    const double lower = -h/radius_bell;
+    const double zm = 0.5*(upper-lower);
+    const double zb = 0.5*(upper+lower);
+
+    // cos term in integral is:
+    //    cos (q (R t - h + L/2) cos(alpha))
+    // so turn it into:
+    //    cos (m t + b)
+    // where:
+    //    m = q R cos(alpha)
+    //    b = q(L/2-h) cos(alpha)
+    const double m = radius_bell*qc; // cos argument slope
+    const double b = (half_length+h)*qc; // cos argument intercept
+    const double qab_r = radius_bell*qab; // Q*R*sin(theta)
+    double total = 0.0;
+    for (int i = 0; i < GAUSS_N; i++){
+        const double t = GAUSS_Z[i]*zm + zb;
+        const double radical = 1.0 - t*t;
+        const double bj = sas_2J1x_x(qab_r*sqrt(radical));
+        const double Fq = cos(m*t + b) * radical * bj;
+        total += GAUSS_W[i] * Fq;
+    }
+    // translate dx in [-1,1] to dx in [lower,upper]
+    const double integral = total*zm;
+    const double bell_fq = 2.0*M_PI*cube(radius_bell)*integral;
+    return bell_fq;
+}
+
+static double
+_fq(double qab, double qc, double h,
+    double radius_bell, double radius, double half_length)
+{
+    const double bell_fq = _bell_kernel(qab, qc, h, radius_bell, half_length);
+    const double bj = sas_2J1x_x(radius*qab);
+    const double si = sas_sinx_x(half_length*qc);
+    const double cyl_fq = 2.0*M_PI*radius*radius*half_length*bj*si;
+    const double Aq = bell_fq + cyl_fq;
+    return Aq;
+}
+
+static double
+form_volume(double radius_bell,
+    double radius,
+    double length)
+{
+    // bell radius should never be less than radius when this is called
+    const double h = sqrt(square(radius_bell) - square(radius));
+    const double slice = M_PI*(square(radius_bell)*h - cube(h)/3.0);
+    const double hemisphere = 2.0*M_PI/3.0*cube(radius_bell);
+    const double rod = M_PI*square(radius)*length;
+    // h > 0 so slice is added to hemisphere
+    return rod + 2.0*(hemisphere + slice);
+}
+
+static double
+radius_from_excluded_volume(double radius_bell, double radius, double length)
+{
+    const double h = sqrt(square(radius_bell) - square(radius));
+    const double length_tot = length + 2.0*(radius + h);
+    // Use cylinder excluded volume with length' = length + caps and
+    // radius' = bell radius since the bell is bigger than the cylinder.
+    return 0.5*cbrt(0.75*radius_bell*(2.0*radius_bell*length_tot
+           + (radius_bell + length_tot)*(M_PI*radius_bell + length_tot)));
+}
+
+static double
+radius_from_volume(double radius_bell, double radius, double length)
+{
+    const double vol_barbell = form_volume(radius_bell,radius,length);
+    return cbrt(vol_barbell/M_4PI_3);
+}
+
+static double
+radius_from_totallength(double radius_bell, double radius, double length)
+{
+    const double h = sqrt(square(radius_bell) - square(radius));
+    const double half_length = 0.5*length;
+    return half_length + radius_bell + h;
+}
+
+static double
+radius_effective(int mode, double radius_bell, double radius, double length)
+{
+    switch (mode) {
+    default:
+    case 1: // equivalent cylinder excluded volume
+        return radius_from_excluded_volume(radius_bell, radius , length);
+    case 2: // equivalent volume sphere
+        return radius_from_volume(radius_bell, radius , length);
+    case 3: // radius
+        return radius;
+    case 4: // half length
+        return 0.5*length;
+    case 5: // half total length
+        return radius_from_totallength(radius_bell,radius,length);
+    }
+}
+
+static void
+Fq(double q,double *F1, double *F2, double sld, double solvent_sld,
+    double radius_bell, double radius, double length)
+{
+    const double h = sqrt(square(radius_bell) - square(radius));
+    const double half_length = 0.5*length;
+
+    // translate a point in [-1,1] to a point in [0, pi/2]
+    const double zm = M_PI_4;
+    const double zb = M_PI_4;
+    double total_F1 = 0.0;
+    double total_F2 = 0.0;
+    for (int i = 0; i < GAUSS_N; i++){
+        const double theta = GAUSS_Z[i]*zm + zb;
+        double sin_theta, cos_theta; // slots to hold sincos function output
+        SINCOS(theta, sin_theta, cos_theta);
+        const double qab = q*sin_theta;
+        const double qc = q*cos_theta;
+        const double Aq = _fq(qab, qc, h, radius_bell, radius, half_length);
+        // scale by sin_theta for spherical coord integration
+        total_F1 += GAUSS_W[i] * Aq * sin_theta;
+        total_F2 += GAUSS_W[i] * Aq * Aq * sin_theta;
+    }
+    // translate dx in [-1,1] to dx in [lower,upper]
+    const double form_avg = total_F1 * zm;
+    const double form_squared_avg = total_F2 * zm;
+
+    //Contrast
+    const double s = (sld - solvent_sld);
+    *F1 = 1.0e-2 * s * form_avg;
+    *F2 = 1.0e-4 * s * s * form_squared_avg;
+}
+
+static double
+Iqac(double qab, double qc,
+    double sld, double solvent_sld,
+    double radius_bell, double radius, double length)
+{
+    const double h = sqrt(square(radius_bell) - square(radius));
+    const double Aq = _fq(qab, qc, h, radius_bell, radius, 0.5*length);
+
+    // Multiply by contrast^2 and convert to cm-1
+    const double s = (sld - solvent_sld);
+    return 1.0e-4 * square(s * Aq);
+}
+
+

--- a/mcstas-comps/share/sas_bcc_paracrystal.c
+++ b/mcstas-comps/share/sas_bcc_paracrystal.c
@@ -1,836 +1,925 @@
-// GENERATED CODE --- DO NOT EDIT ---
-// Code is produced by sasmodels.gen from sasmodels/models/MODEL.c
+#define HAS_Iqabc
+#define HAS_Iq
+#define FORM_VOL
+#line 1 "../kernel_header.c"
 
 #ifdef __OPENCL_VERSION__
 # define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
 #endif
 
-#define USE_KAHAN_SUMMATION 0
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
 
 // If opencl is not available, then we are compiling a C function
 // Note: if using a C++ compiler, then define kernel as extern "C"
-#ifndef USE_OPENCL
-#  ifdef __cplusplus
-     #include <cstdio>
-     #include <cmath>
-     using namespace std;
-     #if defined(_MSC_VER)
-     #   define kernel extern "C" __declspec( dllexport )
-         inline float trunc(float x) { return x>=0?floor(x):-floor(-x); }
-	 inline float fmin(float x, float y) { return x>y ? y : x; }
-	 inline float fmax(float x, float y) { return x<y ? y : x; }
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
      #else
-     #   define kernel extern "C"
+         #define kernel extern "C"
+         #include <cstdint>
      #endif
-     inline void SINCOS(float angle, float &svar, float &cvar) { svar=sin(angle); cvar=cos(angle); }
-#  else
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
      #include <stdio.h>
-     #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
      // MSVC doesn't support C99, so no need for dllexport on C99 branch
      #define kernel
-     #define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
-#  define global
-#  define local
-#  define constant const
-// OpenCL powr(a,b) = C99 pow(a,b), b >= 0
-// OpenCL pown(a,b) = C99 pow(a,b), b integer
-#  define powr(a,b) pow(a,b)
-#  define pown(a,b) pow(a,b)
-#else
-#  ifdef USE_SINCOS
-#    define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
-#  else
-#    define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
 #endif
 
 // Standard mathematical constants:
 //   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
 //   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
-// OpenCL defines M_constant_F for float constants, and nothing if float
+// OpenCL defines M_constant_F for float constants, and nothing if double
 // is not enabled on the card, which is why these constants may be missing
 #ifndef M_PI
-#  define M_PI 3.141592653589793f
+#  define M_PI 3.141592653589793
 #endif
 #ifndef M_PI_2
-#  define M_PI_2 1.570796326794897f
+#  define M_PI_2 1.570796326794897
 #endif
 #ifndef M_PI_4
-#  define M_PI_4 0.7853981633974483f
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
 #endif
 
-// Non-standard pi/180, used for converting between degrees and radians
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
 #ifndef M_PI_180
-#  define M_PI_180 0.017453292519943295f
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
 #endif
 
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
 
-#define VOLUME_PARAMETERS radius
-#define VOLUME_WEIGHT_PRODUCT radius_w
-#define IQ_KERNEL_NAME bcc_paracrystal_Iq
-#define IQ_PARAMETERS dnn, d_factor, radius, sld, solvent_sld
-#define IQ_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float dnn, \
-    const float d_factor, \
-    const float sld, \
-    const float solvent_sld
-#define IQ_WEIGHT_PRODUCT radius_w
-#define IQ_DISPERSION_LENGTH_DECLARATIONS const int Nradius
-#define IQ_DISPERSION_LENGTH_SUM Nradius
-#define IQ_OPEN_LOOPS     for (int radius_i=0; radius_i < Nradius; radius_i++) { \
-      const float radius = loops[2*(radius_i)]; \
-      const float radius_w = loops[2*(radius_i)+1];
-#define IQ_CLOSE_LOOPS     }
-#define IQXY_KERNEL_NAME bcc_paracrystal_Iqxy
-#define IQXY_PARAMETERS dnn, d_factor, radius, sld, solvent_sld, theta, phi, psi
-#define IQXY_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float dnn, \
-    const float d_factor, \
-    const float sld, \
-    const float solvent_sld
-#define IQXY_WEIGHT_PRODUCT radius_w*theta_w*phi_w*psi_w
-#define IQXY_DISPERSION_LENGTH_DECLARATIONS const int Nradius, \
-    const int Ntheta, \
-    const int Nphi, \
-    const int Npsi
-#define IQXY_DISPERSION_LENGTH_SUM Nradius+Ntheta+Nphi+Npsi
-#define IQXY_OPEN_LOOPS     for (int radius_i=0; radius_i < Nradius; radius_i++) { \
-      const float radius = loops[2*(radius_i)]; \
-      const float radius_w = loops[2*(radius_i)+1]; \
-      for (int theta_i=0; theta_i < Ntheta; theta_i++) { \
-        const float theta = loops[2*(theta_i+Nradius)]; \
-        const float theta_w = loops[2*(theta_i+Nradius)+1]; \
-        for (int phi_i=0; phi_i < Nphi; phi_i++) { \
-          const float phi = loops[2*(phi_i+Nradius+Ntheta)]; \
-          const float phi_w = loops[2*(phi_i+Nradius+Ntheta)+1]; \
-          for (int psi_i=0; psi_i < Npsi; psi_i++) { \
-            const float psi = loops[2*(psi_i+Nradius+Ntheta+Nphi)]; \
-            const float psi_w = loops[2*(psi_i+Nradius+Ntheta+Nphi)+1];
-#define IQXY_CLOSE_LOOPS           } \
-        } \
-      } \
-    }
-#define IQXY_HAS_THETA 1
+//# Beginning of rotational operation definitions
 
-float J1(float x);
-float J1(float x)
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
 {
-  const float ax = fabs(x);
-  if (ax < 8.0f) {
-    const float y = x*x;
-    const float ans1 = x*(72362614232.0f
-              + y*(-7895059235.0f
-              + y*(242396853.1f
-              + y*(-2972611.439f
-              + y*(15704.48260f
-              + y*(-30.16036606f))))));
-    const float ans2 = 144725228442.0f
-              + y*(2300535178.0f
-              + y*(18583304.74f
-              + y*(99447.43394f
-              + y*(376.9991397f
-              + y))));
-    return ans1/ans2;
-  } else {
-    const float y = 64.0f/(ax*ax);
-    const float xx = ax - 2.356194491f;
-    const float ans1 = 1.0f
-              + y*(0.183105e-2f
-              + y*(-0.3516396496e-4f
-              + y*(0.2457520174e-5f
-              + y*-0.240337019e-6f)));
-    const float ans2 = 0.04687499995f
-              + y*(-0.2002690873e-3f
-              + y*(0.8449199096e-5f
-              + y*(-0.88228987e-6f
-              + y*0.105787412e-6f)));
-    float sn,cn;
-    SINCOS(xx, sn, cn);
-    const float ans = sqrt(0.636619772f/ax) * (cn*ans1 - (8.0f/ax)*sn*ans2);
-    return (x < 0.0f) ? -ans : ans;
-  }
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
 }
 
-
-/*
- *  GaussWeights.c
- *  SANSAnalysis
- *
- *  Created by Andrew Jackson on 4/23/07.f
- *  Copyright 2007 __MyCompanyName__. All rights reserved.
- *
- */
-
-// Gaussians
-constant float Gauss150Z[]={
-  	-0.9998723404457334f,
-  	-0.9993274305065947f,
-  	-0.9983473449340834f,
-  	-0.9969322929775997f,
-  	-0.9950828645255290f,
-  	-0.9927998590434373f,
-  	-0.9900842691660192f,
-  	-0.9869372772712794f,
-  	-0.9833602541697529f,
-  	-0.9793547582425894f,
-  	-0.9749225346595943f,
-  	-0.9700655145738374f,
-  	-0.9647858142586956f,
-  	-0.9590857341746905f,
-  	-0.9529677579610971f,
-  	-0.9464345513503147f,
-  	-0.9394889610042837f,
-  	-0.9321340132728527f,
-  	-0.9243729128743136f,
-  	-0.9162090414984952f,
-  	-0.9076459563329236f,
-  	-0.8986873885126239f,
-  	-0.8893372414942055f,
-  	-0.8795995893549102f,
-  	-0.8694786750173527f,
-  	-0.8589789084007133f,
-  	-0.8481048644991847f,
-  	-0.8368612813885015f,
-  	-0.8252530581614230f,
-  	-0.8132852527930605f,
-  	-0.8009630799369827f,
-  	-0.7882919086530552f,
-  	-0.7752772600680049f,
-  	-0.7619248049697269f,
-  	-0.7482403613363824f,
-  	-0.7342298918013638f,
-  	-0.7198995010552305f,
-  	-0.7052554331857488f,
-  	-0.6903040689571928f,
-  	-0.6750519230300931f,
-  	-0.6595056411226444f,
-  	-0.6436719971150083f,
-  	-0.6275578900977726f,
-  	-0.6111703413658551f,
-  	-0.5945164913591590f,
-  	-0.5776035965513142f,
-  	-0.5604390262878617f,
-  	-0.5430302595752546f,
-  	-0.5253848818220803f,
-  	-0.5075105815339176f,
-  	-0.4894151469632753f,
-  	-0.4711064627160663f,
-  	-0.4525925063160997f,
-  	-0.4338813447290861f,
-  	-0.4149811308476706f,
-  	-0.3959000999390257f,
-  	-0.3766465660565522f,
-  	-0.3572289184172501f,
-  	-0.3376556177463400f,
-  	-0.3179351925907259f,
-  	-0.2980762356029071f,
-  	-0.2780873997969574f,
-  	-0.2579773947782034f,
-  	-0.2377549829482451f,
-  	-0.2174289756869712f,
-  	-0.1970082295132342f,
-  	-0.1765016422258567f,
-  	-0.1559181490266516f,
-  	-0.1352667186271445f,
-  	-0.1145563493406956f,
-  	-0.0937960651617229f,
-  	-0.0729949118337358f,
-  	-0.0521619529078925f,
-  	-0.0313062657937972f,
-  	-0.0104369378042598f,
-  	0.0104369378042598f,
-  	0.0313062657937972f,
-  	0.0521619529078925f,
-  	0.0729949118337358f,
-  	0.0937960651617229f,
-  	0.1145563493406956f,
-  	0.1352667186271445f,
-  	0.1559181490266516f,
-  	0.1765016422258567f,
-  	0.1970082295132342f,
-  	0.2174289756869712f,
-  	0.2377549829482451f,
-  	0.2579773947782034f,
-  	0.2780873997969574f,
-  	0.2980762356029071f,
-  	0.3179351925907259f,
-  	0.3376556177463400f,
-  	0.3572289184172501f,
-  	0.3766465660565522f,
-  	0.3959000999390257f,
-  	0.4149811308476706f,
-  	0.4338813447290861f,
-  	0.4525925063160997f,
-  	0.4711064627160663f,
-  	0.4894151469632753f,
-  	0.5075105815339176f,
-  	0.5253848818220803f,
-  	0.5430302595752546f,
-  	0.5604390262878617f,
-  	0.5776035965513142f,
-  	0.5945164913591590f,
-  	0.6111703413658551f,
-  	0.6275578900977726f,
-  	0.6436719971150083f,
-  	0.6595056411226444f,
-  	0.6750519230300931f,
-  	0.6903040689571928f,
-  	0.7052554331857488f,
-  	0.7198995010552305f,
-  	0.7342298918013638f,
-  	0.7482403613363824f,
-  	0.7619248049697269f,
-  	0.7752772600680049f,
-  	0.7882919086530552f,
-  	0.8009630799369827f,
-  	0.8132852527930605f,
-  	0.8252530581614230f,
-  	0.8368612813885015f,
-  	0.8481048644991847f,
-  	0.8589789084007133f,
-  	0.8694786750173527f,
-  	0.8795995893549102f,
-  	0.8893372414942055f,
-  	0.8986873885126239f,
-  	0.9076459563329236f,
-  	0.9162090414984952f,
-  	0.9243729128743136f,
-  	0.9321340132728527f,
-  	0.9394889610042837f,
-  	0.9464345513503147f,
-  	0.9529677579610971f,
-  	0.9590857341746905f,
-  	0.9647858142586956f,
-  	0.9700655145738374f,
-  	0.9749225346595943f,
-  	0.9793547582425894f,
-  	0.9833602541697529f,
-  	0.9869372772712794f,
-  	0.9900842691660192f,
-  	0.9927998590434373f,
-  	0.9950828645255290f,
-  	0.9969322929775997f,
-  	0.9983473449340834f,
-  	0.9993274305065947f,
-  	0.9998723404457334f
-};
-
-#pragma acc declare create ( Gauss150Z )
-
-constant float Gauss150Wt[]={
-  	0.0003276086705538f,
-  	0.0007624720924706f,
-  	0.0011976474864367f,
-  	0.0016323569986067f,
-  	0.0020663664924131f,
-  	0.0024994789888943f,
-  	0.0029315036836558f,
-  	0.0033622516236779f,
-  	0.0037915348363451f,
-  	0.0042191661429919f,
-  	0.0046449591497966f,
-  	0.0050687282939456f,
-  	0.0054902889094487f,
-  	0.0059094573005900f,
-  	0.0063260508184704f,
-  	0.0067398879387430f,
-  	0.0071507883396855f,
-  	0.0075585729801782f,
-  	0.0079630641773633f,
-  	0.0083640856838475f,
-  	0.0087614627643580f,
-  	0.0091550222717888f,
-  	0.0095445927225849f,
-  	0.0099300043714212f,
-  	0.0103110892851360f,
-  	0.0106876814158841f,
-  	0.0110596166734735f,
-  	0.0114267329968529f,
-  	0.0117888704247183f,
-  	0.0121458711652067f,
-  	0.0124975796646449f,
-  	0.0128438426753249f,
-  	0.0131845093222756f,
-  	0.0135194311690004f,
-  	0.0138484622795371f,
-  	0.0141714592928592f,
-  	0.0144882814685445f,
-  	0.0147987907597169f,
-  	0.0151028518701744f,
-  	0.0154003323133401f,
-  	0.0156911024699895f,
-  	0.0159750356447283f,
-  	0.0162520081211971f,
-  	0.0165218992159766f,
-  	0.0167845913311726f,
-  	0.0170399700056559f,
-  	0.0172879239649355f,
-  	0.0175283451696437f,
-  	0.0177611288626114f,
-  	0.0179861736145128f,
-  	0.0182033813680609f,
-  	0.0184126574807331f,
-  	0.0186139107660094f,
-  	0.0188070535331042f,
-  	0.0189920016251754f,
-  	0.0191686744559934f,
-  	0.0193369950450545f,
-  	0.0194968900511231f,
-  	0.0196482898041878f,
-  	0.0197911283358190f,
-  	0.0199253434079123f,
-  	0.0200508765398072f,
-  	0.0201676730337687f,
-  	0.0202756819988200f,
-  	0.0203748563729175f,
-  	0.0204651529434560f,
-  	0.0205465323660984f,
-  	0.0206189591819181f,
-  	0.0206824018328499f,
-  	0.0207368326754401f,
-  	0.0207822279928917f,
-  	0.0208185680053983f,
-  	0.0208458368787627f,
-  	0.0208640227312962f,
-  	0.0208731176389954f,
-  	0.0208731176389954f,
-  	0.0208640227312962f,
-  	0.0208458368787627f,
-  	0.0208185680053983f,
-  	0.0207822279928917f,
-  	0.0207368326754401f,
-  	0.0206824018328499f,
-  	0.0206189591819181f,
-  	0.0205465323660984f,
-  	0.0204651529434560f,
-  	0.0203748563729175f,
-  	0.0202756819988200f,
-  	0.0201676730337687f,
-  	0.0200508765398072f,
-  	0.0199253434079123f,
-  	0.0197911283358190f,
-  	0.0196482898041878f,
-  	0.0194968900511231f,
-  	0.0193369950450545f,
-  	0.0191686744559934f,
-  	0.0189920016251754f,
-  	0.0188070535331042f,
-  	0.0186139107660094f,
-  	0.0184126574807331f,
-  	0.0182033813680609f,
-  	0.0179861736145128f,
-  	0.0177611288626114f,
-  	0.0175283451696437f,
-  	0.0172879239649355f,
-  	0.0170399700056559f,
-  	0.0167845913311726f,
-  	0.0165218992159766f,
-  	0.0162520081211971f,
-  	0.0159750356447283f,
-  	0.0156911024699895f,
-  	0.0154003323133401f,
-  	0.0151028518701744f,
-  	0.0147987907597169f,
-  	0.0144882814685445f,
-  	0.0141714592928592f,
-  	0.0138484622795371f,
-  	0.0135194311690004f,
-  	0.0131845093222756f,
-  	0.0128438426753249f,
-  	0.0124975796646449f,
-  	0.0121458711652067f,
-  	0.0117888704247183f,
-  	0.0114267329968529f,
-  	0.0110596166734735f,
-  	0.0106876814158841f,
-  	0.0103110892851360f,
-  	0.0099300043714212f,
-  	0.0095445927225849f,
-  	0.0091550222717888f,
-  	0.0087614627643580f,
-  	0.0083640856838475f,
-  	0.0079630641773633f,
-  	0.0075585729801782f,
-  	0.0071507883396855f,
-  	0.0067398879387430f,
-  	0.0063260508184704f,
-  	0.0059094573005900f,
-  	0.0054902889094487f,
-  	0.0050687282939456f,
-  	0.0046449591497966f,
-  	0.0042191661429919f,
-  	0.0037915348363451f,
-  	0.0033622516236779f,
-  	0.0029315036836558f,
-  	0.0024994789888943f,
-  	0.0020663664924131f,
-  	0.0016323569986067f,
-  	0.0011976474864367f,
-  	0.0007624720924706f,
-  	0.0003276086705538f
-};
-
-#pragma acc declare create ( Gauss150Wt )
-
-float form_volume(float radius);
-float Iq(float q,float dnn,float d_factor, float radius,float sld, float solvent_sld);
-float Iqxy(float qx, float qy, float dnn,
-    float d_factor, float radius,float sld, float solvent_sld,
-    float theta, float phi, float psi);
-
-float _BCC_Integrand(float q, float dnn, float d_factor, float theta, float phi);
-float _BCCeval(float Theta, float Phi, float temp1, float temp3);
-float _sphereform(float q, float radius, float sld, float solvent_sld);
-
-
-float _BCC_Integrand(float q, float dnn, float d_factor, float theta, float phi) {
-
-	const float Da = d_factor*dnn;
-	const float temp1 = q*q*Da*Da;
-	const float temp3 = q*dnn;
-
-	float retVal = _BCCeval(theta,phi,temp1,temp3)/(4.0f*M_PI);
-	return(retVal);
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
 }
 
-float _BCCeval(float Theta, float Phi, float temp1, float temp3) {
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
 
-	float result;
-	float sin_theta,cos_theta,sin_phi,cos_phi;
-	SINCOS(Theta, sin_theta, cos_theta);
-	SINCOS(Phi, sin_phi, cos_phi);
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
 
-	const float temp6 =  sin_theta;
-	const float temp7 =  sin_theta*cos_phi + sin_theta*sin_phi + cos_theta;
-	const float temp8 = -sin_theta*cos_phi - sin_theta*sin_phi + cos_theta;
-	const float temp9 = -sin_theta*cos_phi + sin_theta*sin_phi - cos_theta;
-	const float temp10 = exp((-1.0f/8.0f)*temp1*(temp7*temp7 + temp8*temp8 + temp9*temp9));
-	result = pow(1.0f-(temp10*temp10),3)*temp6
-	    / ( (1.0f - 2.0f*temp10*cos(0.5f*temp3*temp7) + temp10*temp10)
-	      * (1.0f - 2.0f*temp10*cos(0.5f*temp3*temp8) + temp10*temp10)
-	      * (1.0f - 2.0f*temp10*cos(0.5f*temp3*temp9) + temp10*temp10));
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
 
-	return (result);
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
 }
 
-float _sphereform(float q, float radius, float sld, float solvent_sld){
-    const float qr = q*radius;
-    float sn, cn;
-    SINCOS(qr, sn, cn);
-    const float bes = (qr == 0.0f ? 1.0f : 3.0f*(sn-qr*cn)/(qr*qr*qr));
-    const float fq = bes * (sld - solvent_sld)*form_volume(radius);
-    return 1.0e-4f*fq*fq;
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
 }
 
-float form_volume(float radius){
-    return 1.333333333333333f*M_PI*radius*radius*radius;
-}
+// ##### End of rotation operation definitions ######
 
+#line 1 ".././models/lib/sas_3j1x_x.c"
 
-float Iq(float q, float dnn,
-  float d_factor, float radius,
-  float sld, float solvent_sld){
-
-	//Volume fraction calculated from lattice symmetry and sphere radius
-	const float s1 = dnn/sqrt(0.75f);
-	const float latticescale = 2.0f*(4.0f/3.0f)*M_PI*(radius*radius*radius)/(s1*s1*s1);
-
-    const float va = 0.0f;
-    const float vb = 2.0f*M_PI;
-    const float vaj = 0.0f;
-    const float vbj = M_PI;
-
-    float summ = 0.0f;
-    float answer = 0.0f;
-	for(int i=0; i<150; i++) {
-		//setup inner integral over the ellipsoidal cross-section
-		float summj=0.0f;
-		const float zphi = ( Gauss150Z[i]*(vb-va) + va + vb )/2.0f;		//the outer dummy is phi
-		for(int j=0;j<150;j++) {
-			//20 gauss points for the inner integral
-			float ztheta = ( Gauss150Z[j]*(vbj-vaj) + vaj + vbj )/2.0f;		//the inner dummy is theta
-			float yyy = Gauss150Wt[j] * _BCC_Integrand(q,dnn,d_factor,ztheta,zphi);
-			summj += yyy;
-		}
-		//now calculate the value of the inner integral
-		float answer = (vbj-vaj)/2.0f*summj;
-
-		//now calculate outer integral
-		summ = summ+(Gauss150Wt[i] * answer);
-	}		//final scaling is done at the end of the function, after the NT_FP64 case
-
-	answer = (vb-va)/2.0f*summ;
-	answer = answer*_sphereform(q,radius,sld,solvent_sld)*latticescale;
-
-    return answer;
-
-
-}
-
-
-float Iqxy(float qx, float qy, float dnn,
-    float d_factor, float radius,float sld, float solvent_sld,
-    float theta, float phi, float psi){
-
-  float b3_x, b3_y, b1_x, b1_y, b2_x, b2_y; //b3_z,
-  //float q_z;
-  float cos_val_b3, cos_val_b2, cos_val_b1;
-  float a1_dot_q, a2_dot_q,a3_dot_q;
-  float answer;
-  float Zq, Fkq, Fkq_2;
-
-  //convert to q and make scaled values
-  float q = sqrt(qx*qx+qy*qy);
-  float q_x = qx/q;
-  float q_y = qy/q;
-
-  //convert angle degree to radian
-  theta = theta * M_PI_180;
-  phi = phi * M_PI_180;
-  psi = psi * M_PI_180;
-
-  const float Da = d_factor*dnn;
-  const float s1 = dnn/sqrt(0.75f);
-
-
-  //the occupied volume of the lattice
-  const float latticescale = 2.0f*(4.0f/3.0f)*M_PI*(radius*radius*radius)/(s1*s1*s1);
-  // q vector
-  //q_z = 0.0f; // for SANS; assuming qz is negligible
-  /// Angles here are respect to detector coordinate
-  ///  instead of against q coordinate(PRB 36(46), 3(6), 1754(3854))
-    // b3 axis orientation
-    b3_x = cos(theta) * cos(phi);
-    b3_y = sin(theta);
-    //b3_z = -cos(theta) * sin(phi);
-    cos_val_b3 =  b3_x*q_x + b3_y*q_y;// + b3_z*q_z;
-
-    //alpha = acos(cos_val_b3);
-    // b1 axis orientation
-    b1_x = -cos(phi)*sin(psi) * sin(theta)+sin(phi)*cos(psi);
-    b1_y = sin(psi)*cos(theta);
-    cos_val_b1 = b1_x*q_x + b1_y*q_y;
-    // b2 axis orientation
-    b2_x = -sin(theta)*cos(psi)*cos(phi)-sin(psi)*sin(phi);
-  	b2_y = cos(theta)*cos(psi);
-    cos_val_b2 = b2_x*q_x + b2_y*q_y;
-
-    // The following test should always pass
-    if (fabs(cos_val_b3)>1.0f) {
-      //printf("bcc_ana_2D: Unexpected error: cos()>1\n");
-      cos_val_b3 = 1.0f;
-    }
-    if (fabs(cos_val_b2)>1.0f) {
-      //printf("bcc_ana_2D: Unexpected error: cos()>1\n");
-      cos_val_b2 = 1.0f;
-    }
-    if (fabs(cos_val_b1)>1.0f) {
-      //printf("bcc_ana_2D: Unexpected error: cos()>1\n");
-      cos_val_b1 = 1.0f;
-    }
-    // Compute the angle btw vector q and the a3 axis
-    a3_dot_q = 0.5f*dnn*q*(cos_val_b2+cos_val_b1-cos_val_b3);
-
-    // a1 axis
-    a1_dot_q = 0.5f*dnn*q*(cos_val_b3+cos_val_b2-cos_val_b1);
-
-    // a2 axis
-    a2_dot_q = 0.5f*dnn*q*(cos_val_b3+cos_val_b1-cos_val_b2);
-
-
-    // Get Fkq and Fkq_2
-    Fkq = exp(-0.5f*pow(Da/dnn,2.0f)*(a1_dot_q*a1_dot_q+a2_dot_q*a2_dot_q+a3_dot_q*a3_dot_q));
-    Fkq_2 = Fkq*Fkq;
-    // Call Zq=Z1*Z2*Z3
-    Zq = (1.0f-Fkq_2)/(1.0f-2.0f*Fkq*cos(a1_dot_q)+Fkq_2);
-    Zq *= (1.0f-Fkq_2)/(1.0f-2.0f*Fkq*cos(a2_dot_q)+Fkq_2);
-    Zq *= (1.0f-Fkq_2)/(1.0f-2.0f*Fkq*cos(a3_dot_q)+Fkq_2);
-
-  // Use SphereForm directly from libigor
-  answer = _sphereform(q,radius,sld,solvent_sld)*Zq*latticescale;
-
-  return answer;
- }
-
-/*
-    ##########################################################
-    #                                                        #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #   !!                                              !!   #
-    #   !!  KEEP THIS CODE CONSISTENT WITH KERNELPY.PY  !!   #
-    #   !!                                              !!   #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #                                                        #
-    ##########################################################
+/**
+* Spherical Bessel function 3*j1(x)/x
+*
+* Used for low q to avoid cancellation error.
+* Note that the values differ from sasview ~ 5e-12 rather than 5e-14, but
+* in this case it is likely cancellation errors in the original expression
+* using double precision that are the source.
 */
+double sas_3j1x_x(double q);
 
-#ifdef IQ_KERNEL_NAME
-kernel void IQ_KERNEL_NAME(
-    global const float *q,
-    global float *result,
-    const int Nq,
-#ifdef IQ_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQ_DISPERSION_LENGTH_DECLARATIONS,
+// The choice of the number of terms in the series and the cutoff value for
+// switching between series and direct calculation depends on the numeric
+// precision.
+//
+// Point where direct calculation reaches machine precision:
+//
+//   single machine precision eps 3e-8 at qr=1.1 **
+//   double machine precision eps 4e-16 at qr=1.1
+//
+// Point where Taylor series reaches machine precision (eps), where taylor
+// series matches direct calculation (cross) and the error at that point:
+//
+//   prec   n eps  cross  error
+//   single 3 0.28  0.4   6.2e-7
+//   single 4 0.68  0.7   2.3e-7
+//   single 5 1.18  1.2   7.5e-8
+//   double 3 0.01  0.03  2.3e-13
+//   double 4 0.06  0.1   3.1e-14
+//   double 5 0.16  0.2   5.0e-15
+//
+// ** Note: relative error on single precision starts increase on the direct
+// method at qr=1.1, rising from 3e-8 to 5e-5 by qr=1e3.  This should be
+// safe for the sans range, with objects of 100 nm supported to a q of 0.1
+// while maintaining 5 digits of precision.  For usans/sesans, the objects
+// are larger but the q is smaller, so again it should be fine.
+//
+// See explore/sph_j1c.py for code to explore these ranges.
+
+// Use 4th order series
+#if FLOAT_SIZE>4
+#define SPH_J1C_CUTOFF 0.1
+#else
+#define SPH_J1C_CUTOFF 0.7
 #endif
-    IQ_FIXED_PARAMETER_DECLARATIONS
-    )
+#pragma acc routine seq
+double sas_3j1x_x(double q)
 {
-#ifdef USE_OPENCL
-  #ifdef IQ_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQ_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
-
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qi = q[i];
-#ifdef IQ_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-  #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-  #endif
-    IQ_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
-
-    const float weight = IQ_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-      const float scattering = Iq(qi, IQ_PARAMETERS);
-      // allow kernels to exclude invalid regions by returning NaN
-      if (!isnan(scattering)) {
-        ret += weight*scattering;
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-        norm_vol += vol_weight;
-      #endif
-      }
-    //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
+    // 2017-05-18 PAK - support negative q
+    if (fabs(q) < SPH_J1C_CUTOFF) {
+        const double q2 = q*q;
+        return (1.0 + q2*(-3./30. + q2*(3./840. + q2*(-3./45360.))));// + q2*(3./3991680.)))));
+    } else {
+        double sin_q, cos_q;
+        SINCOS(q, sin_q, cos_q);
+        return 3.0*(sin_q/q - cos_q)/(q*q);
     }
-    IQ_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iq(qi, IQ_PARAMETERS) + background;
-#endif
-  }
 }
-#endif
 
 
-#ifdef IQXY_KERNEL_NAME
-kernel void IQXY_KERNEL_NAME(
-    global const float *qx,
-    global const float *qy,
-    global float *result,
-    const int Nq,
-#ifdef IQXY_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQXY_DISPERSION_LENGTH_DECLARATIONS,
-#endif
-    IQXY_FIXED_PARAMETER_DECLARATIONS
-    )
+#line 1 ".././models/lib/gauss150.c"
+
+// Created by Andrew Jackson on 4/23/07
+
+ #ifdef GAUSS_N
+ # undef GAUSS_N
+ # undef GAUSS_Z
+ # undef GAUSS_W
+ #endif
+ #define GAUSS_N 150
+ #define GAUSS_Z Gauss150Z
+ #define GAUSS_W Gauss150Wt
+
+
+// Note: using array size 152 rather than 150 so that it is a multiple of 4.
+// Some OpenCL devices prefer that vectors start and end on nice boundaries.
+constant double Gauss150Z[152]={
+  	-0.9998723404457334,
+  	-0.9993274305065947,
+  	-0.9983473449340834,
+  	-0.9969322929775997,
+  	-0.9950828645255290,
+  	-0.9927998590434373,
+  	-0.9900842691660192,
+  	-0.9869372772712794,
+  	-0.9833602541697529,
+  	-0.9793547582425894,
+  	-0.9749225346595943,
+  	-0.9700655145738374,
+  	-0.9647858142586956,
+  	-0.9590857341746905,
+  	-0.9529677579610971,
+  	-0.9464345513503147,
+  	-0.9394889610042837,
+  	-0.9321340132728527,
+  	-0.9243729128743136,
+  	-0.9162090414984952,
+  	-0.9076459563329236,
+  	-0.8986873885126239,
+  	-0.8893372414942055,
+  	-0.8795995893549102,
+  	-0.8694786750173527,
+  	-0.8589789084007133,
+  	-0.8481048644991847,
+  	-0.8368612813885015,
+  	-0.8252530581614230,
+  	-0.8132852527930605,
+  	-0.8009630799369827,
+  	-0.7882919086530552,
+  	-0.7752772600680049,
+  	-0.7619248049697269,
+  	-0.7482403613363824,
+  	-0.7342298918013638,
+  	-0.7198995010552305,
+  	-0.7052554331857488,
+  	-0.6903040689571928,
+  	-0.6750519230300931,
+  	-0.6595056411226444,
+  	-0.6436719971150083,
+  	-0.6275578900977726,
+  	-0.6111703413658551,
+  	-0.5945164913591590,
+  	-0.5776035965513142,
+  	-0.5604390262878617,
+  	-0.5430302595752546,
+  	-0.5253848818220803,
+  	-0.5075105815339176,
+  	-0.4894151469632753,
+  	-0.4711064627160663,
+  	-0.4525925063160997,
+  	-0.4338813447290861,
+  	-0.4149811308476706,
+  	-0.3959000999390257,
+  	-0.3766465660565522,
+  	-0.3572289184172501,
+  	-0.3376556177463400,
+  	-0.3179351925907259,
+  	-0.2980762356029071,
+  	-0.2780873997969574,
+  	-0.2579773947782034,
+  	-0.2377549829482451,
+  	-0.2174289756869712,
+  	-0.1970082295132342,
+  	-0.1765016422258567,
+  	-0.1559181490266516,
+  	-0.1352667186271445,
+  	-0.1145563493406956,
+  	-0.0937960651617229,
+  	-0.0729949118337358,
+  	-0.0521619529078925,
+  	-0.0313062657937972,
+  	-0.0104369378042598,
+  	0.0104369378042598,
+  	0.0313062657937972,
+  	0.0521619529078925,
+  	0.0729949118337358,
+  	0.0937960651617229,
+  	0.1145563493406956,
+  	0.1352667186271445,
+  	0.1559181490266516,
+  	0.1765016422258567,
+  	0.1970082295132342,
+  	0.2174289756869712,
+  	0.2377549829482451,
+  	0.2579773947782034,
+  	0.2780873997969574,
+  	0.2980762356029071,
+  	0.3179351925907259,
+  	0.3376556177463400,
+  	0.3572289184172501,
+  	0.3766465660565522,
+  	0.3959000999390257,
+  	0.4149811308476706,
+  	0.4338813447290861,
+  	0.4525925063160997,
+  	0.4711064627160663,
+  	0.4894151469632753,
+  	0.5075105815339176,
+  	0.5253848818220803,
+  	0.5430302595752546,
+  	0.5604390262878617,
+  	0.5776035965513142,
+  	0.5945164913591590,
+  	0.6111703413658551,
+  	0.6275578900977726,
+  	0.6436719971150083,
+  	0.6595056411226444,
+  	0.6750519230300931,
+  	0.6903040689571928,
+  	0.7052554331857488,
+  	0.7198995010552305,
+  	0.7342298918013638,
+  	0.7482403613363824,
+  	0.7619248049697269,
+  	0.7752772600680049,
+  	0.7882919086530552,
+  	0.8009630799369827,
+  	0.8132852527930605,
+  	0.8252530581614230,
+  	0.8368612813885015,
+  	0.8481048644991847,
+  	0.8589789084007133,
+  	0.8694786750173527,
+  	0.8795995893549102,
+  	0.8893372414942055,
+  	0.8986873885126239,
+  	0.9076459563329236,
+  	0.9162090414984952,
+  	0.9243729128743136,
+  	0.9321340132728527,
+  	0.9394889610042837,
+  	0.9464345513503147,
+  	0.9529677579610971,
+  	0.9590857341746905,
+  	0.9647858142586956,
+  	0.9700655145738374,
+  	0.9749225346595943,
+  	0.9793547582425894,
+  	0.9833602541697529,
+  	0.9869372772712794,
+  	0.9900842691660192,
+  	0.9927998590434373,
+  	0.9950828645255290,
+  	0.9969322929775997,
+  	0.9983473449340834,
+  	0.9993274305065947,
+  	0.9998723404457334,
+  	0., // zero padding is ignored
+  	0.  // zero padding is ignored
+};
+
+constant double Gauss150Wt[152]={
+  	0.0003276086705538,
+  	0.0007624720924706,
+  	0.0011976474864367,
+  	0.0016323569986067,
+  	0.0020663664924131,
+  	0.0024994789888943,
+  	0.0029315036836558,
+  	0.0033622516236779,
+  	0.0037915348363451,
+  	0.0042191661429919,
+  	0.0046449591497966,
+  	0.0050687282939456,
+  	0.0054902889094487,
+  	0.0059094573005900,
+  	0.0063260508184704,
+  	0.0067398879387430,
+  	0.0071507883396855,
+  	0.0075585729801782,
+  	0.0079630641773633,
+  	0.0083640856838475,
+  	0.0087614627643580,
+  	0.0091550222717888,
+  	0.0095445927225849,
+  	0.0099300043714212,
+  	0.0103110892851360,
+  	0.0106876814158841,
+  	0.0110596166734735,
+  	0.0114267329968529,
+  	0.0117888704247183,
+  	0.0121458711652067,
+  	0.0124975796646449,
+  	0.0128438426753249,
+  	0.0131845093222756,
+  	0.0135194311690004,
+  	0.0138484622795371,
+  	0.0141714592928592,
+  	0.0144882814685445,
+  	0.0147987907597169,
+  	0.0151028518701744,
+  	0.0154003323133401,
+  	0.0156911024699895,
+  	0.0159750356447283,
+  	0.0162520081211971,
+  	0.0165218992159766,
+  	0.0167845913311726,
+  	0.0170399700056559,
+  	0.0172879239649355,
+  	0.0175283451696437,
+  	0.0177611288626114,
+  	0.0179861736145128,
+  	0.0182033813680609,
+  	0.0184126574807331,
+  	0.0186139107660094,
+  	0.0188070535331042,
+  	0.0189920016251754,
+  	0.0191686744559934,
+  	0.0193369950450545,
+  	0.0194968900511231,
+  	0.0196482898041878,
+  	0.0197911283358190,
+  	0.0199253434079123,
+  	0.0200508765398072,
+  	0.0201676730337687,
+  	0.0202756819988200,
+  	0.0203748563729175,
+  	0.0204651529434560,
+  	0.0205465323660984,
+  	0.0206189591819181,
+  	0.0206824018328499,
+  	0.0207368326754401,
+  	0.0207822279928917,
+  	0.0208185680053983,
+  	0.0208458368787627,
+  	0.0208640227312962,
+  	0.0208731176389954,
+  	0.0208731176389954,
+  	0.0208640227312962,
+  	0.0208458368787627,
+  	0.0208185680053983,
+  	0.0207822279928917,
+  	0.0207368326754401,
+  	0.0206824018328499,
+  	0.0206189591819181,
+  	0.0205465323660984,
+  	0.0204651529434560,
+  	0.0203748563729175,
+  	0.0202756819988200,
+  	0.0201676730337687,
+  	0.0200508765398072,
+  	0.0199253434079123,
+  	0.0197911283358190,
+  	0.0196482898041878,
+  	0.0194968900511231,
+  	0.0193369950450545,
+  	0.0191686744559934,
+  	0.0189920016251754,
+  	0.0188070535331042,
+  	0.0186139107660094,
+  	0.0184126574807331,
+  	0.0182033813680609,
+  	0.0179861736145128,
+  	0.0177611288626114,
+  	0.0175283451696437,
+  	0.0172879239649355,
+  	0.0170399700056559,
+  	0.0167845913311726,
+  	0.0165218992159766,
+  	0.0162520081211971,
+  	0.0159750356447283,
+  	0.0156911024699895,
+  	0.0154003323133401,
+  	0.0151028518701744,
+  	0.0147987907597169,
+  	0.0144882814685445,
+  	0.0141714592928592,
+  	0.0138484622795371,
+  	0.0135194311690004,
+  	0.0131845093222756,
+  	0.0128438426753249,
+  	0.0124975796646449,
+  	0.0121458711652067,
+  	0.0117888704247183,
+  	0.0114267329968529,
+  	0.0110596166734735,
+  	0.0106876814158841,
+  	0.0103110892851360,
+  	0.0099300043714212,
+  	0.0095445927225849,
+  	0.0091550222717888,
+  	0.0087614627643580,
+  	0.0083640856838475,
+  	0.0079630641773633,
+  	0.0075585729801782,
+  	0.0071507883396855,
+  	0.0067398879387430,
+  	0.0063260508184704,
+  	0.0059094573005900,
+  	0.0054902889094487,
+  	0.0050687282939456,
+  	0.0046449591497966,
+  	0.0042191661429919,
+  	0.0037915348363451,
+  	0.0033622516236779,
+  	0.0029315036836558,
+  	0.0024994789888943,
+  	0.0020663664924131,
+  	0.0016323569986067,
+  	0.0011976474864367,
+  	0.0007624720924706,
+  	0.0003276086705538,
+  	0., // zero padding is ignored
+  	0.  // zero padding is ignored
+};
+
+#pragma acc declare copyin( Gauss150Wt[0:150], Gauss150Z[0:150] )
+
+#line 1 ".././models/lib/sphere_form.c"
+
+double sphere_volume(double radius);
+double sphere_form(double q, double radius, double sld, double solvent_sld);
+
+    
+#pragma acc routine seq
+double sphere_volume(double radius)
 {
-#ifdef USE_OPENCL
-  #ifdef IQXY_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQXY_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
-
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qxi = qx[i];
-    const float qyi = qy[i];
-    #if USE_KAHAN_SUMMATION
-    float accumulated_error = 0.0f;
-    #endif
-#ifdef IQXY_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-    #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-    #endif
-    IQXY_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
-
-    const float weight = IQXY_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-
-      const float scattering = Iqxy(qxi, qyi, IQXY_PARAMETERS);
-      if (!isnan(scattering)) { // if scattering is bad, exclude it from sum
-      //if (scattering >= 0.0f) { // scattering cannot be negative
-        // TODO: use correct angle for spherical correction
-        // Definition of theta and phi are probably reversed relative to the
-        // equation which gave rise to this correction, leading to an
-        // attenuation of the pattern as theta moves through pi/2.f  Either
-        // reverse the meanings of phi and theta in the forms, or use phi
-        // rather than theta in this correction.  Current code uses cos(theta)
-        // so that values match those of sasview.
-      #if defined(IQXY_HAS_THETA) // && 0
-        const float spherical_correction
-          = (Ntheta>1 ? fabs(cos(M_PI_180*theta))*M_PI_2:1.0f);
-        const float next = spherical_correction * weight * scattering;
-      #else
-        const float next = weight * scattering;
-      #endif
-      #if USE_KAHAN_SUMMATION
-        const float y = next - accumulated_error;
-        const float t = ret + y;
-        accumulated_error = (t - ret) - y;
-        ret = t;
-      #else
-        ret += next;
-      #endif
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-      #endif
-        norm_vol += vol_weight;
-      }
-      //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
-    }
-    IQXY_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iqxy(qxi, qyi, IQXY_PARAMETERS) + background;
-#endif
-  }
+    return M_4PI_3*cube(radius);
 }
+    
+#pragma acc routine seq
+double sphere_form(double q, double radius, double sld, double solvent_sld)
+{
+    const double fq = sphere_volume(radius) * sas_3j1x_x(q*radius);
+    const double contrast = (sld - solvent_sld);
+    return 1.0e-4*square(contrast * fq);
+}
+
+
+
+#line 1 ".././models/bcc_paracrystal.c"
+
+static double
+bcc_Zq(double qa, double qb, double qc, double dnn, double d_factor)
+{
+    // Equations from Matsuoka 26-27-28, multiplied by |q|
+    const double a1 = (-qa + qb + qc)/2.0;
+    const double a2 = (+qa - qb + qc)/2.0;
+    const double a3 = (+qa + qb - qc)/2.0;
+    const double d_a = dnn/sqrt(0.75);
+
+#if 1
+    // Matsuoka 29-30-31
+    //     Z_k numerator: 1 - exp(a)^2
+    //     Z_k denominator: 1 - 2 cos(d a_k) exp(a) + exp(2a)
+    // Rewriting numerator
+    //         => -(exp(2a) - 1)
+    //         => -expm1(2a)
+    // Rewriting denominator
+    //         => exp(a)^2 - 2 cos(d ak) exp(a) + 1)
+    //         => (exp(a) - 2 cos(d ak)) * exp(a) + 1
+    const double arg = -0.5*square(dnn*d_factor)*(a1*a1 + a2*a2 + a3*a3);
+    const double exp_arg = exp(arg);
+    const double Zq = -cube(expm1(2.0*arg))
+        / ( ((exp_arg - 2.0*cos(d_a*a1))*exp_arg + 1.0)
+          * ((exp_arg - 2.0*cos(d_a*a2))*exp_arg + 1.0)
+          * ((exp_arg - 2.0*cos(d_a*a3))*exp_arg + 1.0));
+
+#elif 0
+    // ** Alternate form, which perhaps is more approachable
+    //     Z_k numerator   => -[(exp(2a) - 1) / 2.exp(a)] 2.exp(a)
+    //                     => -[sinh(a)] exp(a)
+    //     Z_k denominator => [(exp(2a) + 1) / 2.exp(a) - cos(d a_k)] 2.exp(a)
+    //                     => [cosh(a) - cos(d a_k)] 2.exp(a)
+    //     => Z_k = -sinh(a) / [cosh(a) - cos(d a_k)]
+    //            = sinh(-a) / [cosh(-a) - cos(d a_k)]
+    //
+    // One more step leads to the form in sasview 3.x for 2d models
+    //            = tanh(-a) / [1 - cos(d a_k)/cosh(-a)]
+    //
+    const double arg = 0.5*square(dnn*d_factor)*(a1*a1 + a2*a2 + a3*a3);
+    const double sinh_qd = sinh(arg);
+    const double cosh_qd = cosh(arg);
+    const double Zq = sinh_qd/(cosh_qd - cos(d_a*a1))
+                    * sinh_qd/(cosh_qd - cos(d_a*a2))
+                    * sinh_qd/(cosh_qd - cos(d_a*a3));
+#else
+    const double arg = 0.5*square(dnn*d_factor)*(a1*a1 + a2*a2 + a3*a3);
+    const double tanh_qd = tanh(arg);
+    const double cosh_qd = cosh(arg);
+    const double Zq = tanh_qd/(1.0 - cos(d_a*a1)/cosh_qd)
+                    * tanh_qd/(1.0 - cos(d_a*a2)/cosh_qd)
+                    * tanh_qd/(1.0 - cos(d_a*a3)/cosh_qd);
 #endif
+
+    return Zq;
+}
+
+
+// occupied volume fraction calculated from lattice symmetry and sphere radius
+static double
+bcc_volume_fraction(double radius, double dnn)
+{
+    return 2.0*sphere_volume(sqrt(0.75)*radius/dnn);
+    // note that sqrt(0.75) = root3/2 and sqrt(0.75)/dnn=1/d_a
+    //Thus this is correct
+}
+
+static double
+form_volume(double radius)
+{
+    return sphere_volume(radius);
+}
+
+
+static double Iq(double q, double dnn,
+    double d_factor, double radius,
+    double sld, double solvent_sld)
+{
+    // translate a point in [-1,1] to a point in [0, 2 pi]
+    const double phi_m = M_PI;
+    const double phi_b = M_PI;
+    // translate a point in [-1,1] to a point in [0, pi]
+    const double theta_m = M_PI_2;
+    const double theta_b = M_PI_2;
+
+    double outer_sum = 0.0;
+    for(int i=0; i<GAUSS_N; i++) {
+        double inner_sum = 0.0;
+        const double theta = GAUSS_Z[i]*theta_m + theta_b;
+        double sin_theta, cos_theta;
+        SINCOS(theta, sin_theta, cos_theta);
+        const double qc = q*cos_theta;
+        const double qab = q*sin_theta;
+        for(int j=0;j<GAUSS_N;j++) {
+            const double phi = GAUSS_Z[j]*phi_m + phi_b;
+            double sin_phi, cos_phi;
+            SINCOS(phi, sin_phi, cos_phi);
+            const double qa = qab*cos_phi;
+            const double qb = qab*sin_phi;
+            const double form = bcc_Zq(qa, qb, qc, dnn, d_factor);
+            inner_sum += GAUSS_W[j] * form;
+        }
+        inner_sum *= phi_m;  // sum(f(x)dx) = sum(f(x)) dx
+        outer_sum += GAUSS_W[i] * inner_sum * sin_theta;
+    }
+    outer_sum *= theta_m;
+    const double Zq = outer_sum/(4.0*M_PI);
+    const double Pq = sphere_form(q, radius, sld, solvent_sld);
+    return bcc_volume_fraction(radius, dnn) * Pq * Zq;
+    // note that until we can return non fitable values to the GUI this
+    // can only be queried by a script. Otherwise we can drop the
+    // bcc_volume_fraction as it is effectively included in "scale."
+}
+
+
+static double Iqabc(double qa, double qb, double qc,
+    double dnn, double d_factor, double radius,
+    double sld, double solvent_sld)
+{
+    const double q = sqrt(qa*qa + qb*qb + qc*qc);
+    const double Zq = bcc_Zq(qa, qb, qc, dnn, d_factor);
+    const double Pq = sphere_form(q, radius, sld, solvent_sld);
+    return bcc_volume_fraction(radius, dnn) * Pq * Zq;
+}
+
+

--- a/mcstas-comps/share/sas_binary_hard_sphere.c
+++ b/mcstas-comps/share/sas_binary_hard_sphere.c
@@ -1,0 +1,611 @@
+#define HAS_Iq
+#define FORM_VOL
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/sas_3j1x_x.c"
+
+/**
+* Spherical Bessel function 3*j1(x)/x
+*
+* Used for low q to avoid cancellation error.
+* Note that the values differ from sasview ~ 5e-12 rather than 5e-14, but
+* in this case it is likely cancellation errors in the original expression
+* using double precision that are the source.
+*/
+double sas_3j1x_x(double q);
+
+// The choice of the number of terms in the series and the cutoff value for
+// switching between series and direct calculation depends on the numeric
+// precision.
+//
+// Point where direct calculation reaches machine precision:
+//
+//   single machine precision eps 3e-8 at qr=1.1 **
+//   double machine precision eps 4e-16 at qr=1.1
+//
+// Point where Taylor series reaches machine precision (eps), where taylor
+// series matches direct calculation (cross) and the error at that point:
+//
+//   prec   n eps  cross  error
+//   single 3 0.28  0.4   6.2e-7
+//   single 4 0.68  0.7   2.3e-7
+//   single 5 1.18  1.2   7.5e-8
+//   double 3 0.01  0.03  2.3e-13
+//   double 4 0.06  0.1   3.1e-14
+//   double 5 0.16  0.2   5.0e-15
+//
+// ** Note: relative error on single precision starts increase on the direct
+// method at qr=1.1, rising from 3e-8 to 5e-5 by qr=1e3.  This should be
+// safe for the sans range, with objects of 100 nm supported to a q of 0.1
+// while maintaining 5 digits of precision.  For usans/sesans, the objects
+// are larger but the q is smaller, so again it should be fine.
+//
+// See explore/sph_j1c.py for code to explore these ranges.
+
+// Use 4th order series
+#if FLOAT_SIZE>4
+#define SPH_J1C_CUTOFF 0.1
+#else
+#define SPH_J1C_CUTOFF 0.7
+#endif
+#pragma acc routine seq
+double sas_3j1x_x(double q)
+{
+    // 2017-05-18 PAK - support negative q
+    if (fabs(q) < SPH_J1C_CUTOFF) {
+        const double q2 = q*q;
+        return (1.0 + q2*(-3./30. + q2*(3./840. + q2*(-3./45360.))));// + q2*(3./3991680.)))));
+    } else {
+        double sin_q, cos_q;
+        SINCOS(q, sin_q, cos_q);
+        return 3.0*(sin_q/q - cos_q)/(q*q);
+    }
+}
+
+
+#line 1 ".././models/binary_hard_sphere.c"
+
+double form_volume(void);
+
+double Iq(double q,
+    double lg_radius, double sm_radius,
+    double lg_vol_frac, double sm_vol_frac,
+    double lg_sld, double sm_sld, double solvent_sld
+    );
+
+void calculate_psfs(double qval,
+    double r2, double nf2,
+    double aa, double phi,
+    double *s11, double *s22, double *s12
+    );
+
+double form_volume(void)
+{
+    return 1.0;
+}
+
+double Iq(double q,
+    double lg_radius, double sm_radius,
+    double lg_vol_frac, double sm_vol_frac,
+    double lg_sld, double sm_sld, double solvent_sld)
+{
+    double r2,r1,nf2,phi,aa,rho2,rho1,rhos,inten;       //my local names
+    double psf11,psf12,psf22;
+    double phi1,phi2,phr,a3;
+    double v1,v2,n1,n2,qr1,qr2,b1,b2,sc1,sc2;
+
+    r2 = lg_radius;
+    r1 = sm_radius;
+    phi2 = lg_vol_frac;
+    phi1 = sm_vol_frac;
+    rho2 = lg_sld;
+    rho1 = sm_sld;
+    rhos = solvent_sld;
+
+
+    phi = phi1 + phi2;
+    aa = r1/r2;
+    //calculate the number fraction of larger spheres (eqn 2 in reference)
+    a3=aa*aa*aa;
+    phr=phi2/phi;
+    nf2 = phr*a3/(1.0-phr+phr*a3);
+    // calculate the PSF's here
+    calculate_psfs(q,r2,nf2,aa,phi,&psf11,&psf22,&psf12);
+
+    // /* do form factor calculations  */
+
+    v1 = M_4PI_3*r1*r1*r1;
+    v2 = M_4PI_3*r2*r2*r2;
+
+    n1 = phi1/v1;
+    n2 = phi2/v2;
+
+    qr1 = r1*q;
+    qr2 = r2*q;
+
+    sc1 = sas_3j1x_x(qr1);
+    sc2 = sas_3j1x_x(qr2);
+    b1 = r1*r1*r1*(rho1-rhos)*M_4PI_3*sc1;
+    b2 = r2*r2*r2*(rho2-rhos)*M_4PI_3*sc2;
+    inten = n1*b1*b1*psf11;
+    inten += sqrt(n1*n2)*2.0*b1*b2*psf12;
+    inten += n2*b2*b2*psf22;
+    ///* convert I(1/A) to (1/cm)  */
+    inten *= 1.0e8;
+    ///*convert rho^2 in 10^-6A to A*/
+    inten *= 1.0e-12;
+    return(inten);
+}
+
+
+void calculate_psfs(double qval,
+    double r2, double nf2,
+    double aa, double phi,
+    double *s11, double *s22, double *s12)
+{
+    //  variable qval,r2,nf2,aa,phi,&s11,&s22,&s12
+
+    //   calculate constant terms
+    double s2,v,a3,v1,v2,g11,g12,g22,wmv,wmv3,wmv4;
+    double a1,a2i,a2,b1,b2,b12,gm1,gm12;
+    double yy,ay,ay2,ay3,t1,t2,t3,f11,y2,y3,tt1,tt2,tt3;
+    double c11,c22,c12,f12,f22,ttt1,ttt2,ttt3,ttt4,yl,y13;
+    double t21,t22,t23,t31,t32,t33,t41,t42,yl3,wma3,y1;
+
+    s2 = 2.0*r2;
+//    s1 = aa*s2;  why is this never used?  check original paper?
+    v = phi;
+    a3 = aa*aa*aa;
+    v1=((1.-nf2)*a3/(nf2+(1.-nf2)*a3))*v;
+    v2=(nf2/(nf2+(1.-nf2)*a3))*v;
+    g11=((1.+.5*v)+1.5*v2*(aa-1.))/(1.-v)/(1.-v);
+    g22=((1.+.5*v)+1.5*v1*(1./aa-1.))/(1.-v)/(1.-v);
+    g12=((1.+.5*v)+1.5*(1.-aa)*(v1-v2)/(1.+aa))/(1.-v)/(1.-v);
+    wmv = 1/(1.-v);
+    wmv3 = wmv*wmv*wmv;
+    wmv4 = wmv*wmv3;
+    a1=3.*wmv4*((v1+a3*v2)*(1.+v+v*v)-3.*v1*v2*(1.-aa)*(1.-aa)*(1.+v1+aa*(1.+v2))) + ((v1+a3*v2)*(1.+2.*v)+(1.+v+v*v)-3.*v1*v2*(1.-aa)*(1.-aa)-3.*v2*(1.-aa)*(1.-aa)*(1.+v1+aa*(1.+v2)))*wmv3;
+    a2i=((v1+a3*v2)*(1.+v+v*v)-3.*v1*v2*(1.-aa)*(1.-aa)*(1.+v1+aa*(1.+v2)))*3*wmv4 + ((v1+a3*v2)*(1.+2.*v)+a3*(1.+v+v*v)-3.*v1*v2*(1.-aa)*(1.-aa)*aa-3.*v1*(1.-aa)*(1.-aa)*(1.+v1+aa*(1.+v2)))*wmv3;
+    a2=a2i/a3;
+    b1=-6.*(v1*g11*g11+.25*v2*(1.+aa)*(1.+aa)*aa*g12*g12);
+    b2=-6.*(v2*g22*g22+.25*v1/a3*(1.+aa)*(1.+aa)*g12*g12);
+    b12=-3.*aa*(1.+aa)*(v1*g11/aa/aa+v2*g22)*g12;
+    gm1=(v1*a1+a3*v2*a2)*.5;
+    gm12=2.*gm1*(1.-aa)/aa;
+    //c
+    //c   calculate the direct correlation functions and print results
+    //c
+    //  do 20 j=1,npts
+
+    yy=qval*s2;
+    //c   calculate direct correlation functions
+    //c   ----c11
+    ay=aa*yy;
+    ay2 = ay*ay;
+    ay3 = ay*ay*ay;
+    t1=a1*(sin(ay)-ay*cos(ay));
+    t2=b1*(2.*ay*sin(ay)-(ay2-2.)*cos(ay)-2.)/ay;
+    t3=gm1*((4.*ay*ay2-24.*ay)*sin(ay)-(ay2*ay2-12.*ay2+24.)*cos(ay)+24.)/ay3;
+    f11=24.*v1*(t1+t2+t3)/ay3;
+
+    //c ------c22
+    y2=yy*yy;
+    y3=yy*y2;
+    tt1=a2*(sin(yy)-yy*cos(yy));
+    tt2=b2*(2.*yy*sin(yy)-(y2-2.)*cos(yy)-2.)/yy;
+    tt3=gm1*((4.*y3-24.*yy)*sin(yy)-(y2*y2-12.*y2+24.)*cos(yy)+24.)/ay3;
+    f22=24.*v2*(tt1+tt2+tt3)/y3;
+
+    //c   -----c12
+    yl=.5*yy*(1.-aa);
+    yl3=yl*yl*yl;
+    wma3 = (1.-aa)*(1.-aa)*(1.-aa);
+    y1=aa*yy;
+    y13 = y1*y1*y1;
+    ttt1=3.*wma3*v*sqrt(nf2)*sqrt(1.-nf2)*a1*(sin(yl)-yl*cos(yl))/((nf2+(1.-nf2)*a3)*yl3);
+    t21=b12*(2.*y1*cos(y1)+(y1*y1-2.)*sin(y1));
+    t22=gm12*((3.*y1*y1-6.)*cos(y1)+(y1*y1*y1-6.*y1)*sin(y1)+6.)/y1;
+    t23=gm1*((4.*y13-24.*y1)*cos(y1)+(y13*y1-12.*y1*y1+24.)*sin(y1))/(y1*y1);
+    t31=b12*(2.*y1*sin(y1)-(y1*y1-2.)*cos(y1)-2.);
+    t32=gm12*((3.*y1*y1-6.)*sin(y1)-(y1*y1*y1-6.*y1)*cos(y1))/y1;
+    t33=gm1*((4.*y13-24.*y1)*sin(y1)-(y13*y1-12.*y1*y1+24.)*cos(y1)+24.)/(y1*y1);
+    t41=cos(yl)*((sin(y1)-y1*cos(y1))/(y1*y1) + (1.-aa)/(2.*aa)*(1.-cos(y1))/y1);
+    t42=sin(yl)*((cos(y1)+y1*sin(y1)-1.)/(y1*y1) + (1.-aa)/(2.*aa)*sin(y1)/y1);
+    ttt2=sin(yl)*(t21+t22+t23)/(y13*y1);
+    ttt3=cos(yl)*(t31+t32+t33)/(y13*y1);
+    ttt4=a1*(t41+t42)/y1;
+    f12=ttt1+24.*v*sqrt(nf2)*sqrt(1.-nf2)*a3*(ttt2+ttt3+ttt4)/(nf2+(1.-nf2)*a3);
+
+    c11=f11;
+    c22=f22;
+    c12=f12;
+    *s11=1./(1.+c11-(c12)*c12/(1.+c22));
+    *s22=1./(1.+c22-(c12)*c12/(1.+c11));
+    *s12=-c12/((1.+c11)*(1.+c22)-(c12)*(c12));
+
+    return;
+}
+
+

--- a/mcstas-comps/share/sas_broad_peak.c
+++ b/mcstas-comps/share/sas_broad_peak.c
@@ -1,0 +1,405 @@
+#define HAS_Iq
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/broad_peak.c"
+
+#include <math.h>
+
+double Iq(double q, double porod_scale, double porod_exp, double peak_scale,
+          double correlation_length, double peak_pos, double width_exp,
+          double shape_exp);
+
+#pragma acc routine seq
+double Iq(double q, double porod_scale, double porod_exp, double peak_scale,
+          double correlation_length, double peak_pos, double width_exp,
+          double shape_exp) {
+    double z = fabs(q - peak_pos) * correlation_length;
+    double inten = pow((porod_scale / pow(q, porod_exp)) + (peak_scale / (1.0 + pow(z, width_exp))), shape_exp);
+    return inten;
+}
+
+
+
+

--- a/mcstas-comps/share/sas_capped_cylinder.c
+++ b/mcstas-comps/share/sas_capped_cylinder.c
@@ -1,688 +1,1068 @@
-// GENERATED CODE --- DO NOT EDIT ---
-// Code is produced by sasmodels.gen from sasmodels/models/MODEL.c
+#define HAS_Iqac
+#define HAS_FQ
+#define FORM_VOL
+#line 1 "../kernel_header.c"
 
 #ifdef __OPENCL_VERSION__
 # define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
 #endif
 
-#define USE_KAHAN_SUMMATION 0
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
 
 // If opencl is not available, then we are compiling a C function
 // Note: if using a C++ compiler, then define kernel as extern "C"
-#ifndef USE_OPENCL
-#  ifdef __cplusplus
-     #include <cstdio>
-     #include <cmath>
-     using namespace std;
-     #if defined(_MSC_VER)
-     #   define kernel extern "C" __declspec( dllexport )
-         inline float trunc(float x) { return x>=0?floor(x):-floor(-x); }
-	 inline float fmin(float x, float y) { return x>y ? y : x; }
-	 inline float fmax(float x, float y) { return x<y ? y : x; }
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
      #else
-     #   define kernel extern "C"
+         #define kernel extern "C"
+         #include <cstdint>
      #endif
-     inline void SINCOS(float angle, float &svar, float &cvar) { svar=sin(angle); cvar=cos(angle); }
-#  else
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
      #include <stdio.h>
-     #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
      // MSVC doesn't support C99, so no need for dllexport on C99 branch
      #define kernel
-     #define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
-#  define global
-#  define local
-#  define constant const
-// OpenCL powr(a,b) = C99 pow(a,b), b >= 0
-// OpenCL pown(a,b) = C99 pow(a,b), b integer
-#  define powr(a,b) pow(a,b)
-#  define pown(a,b) pow(a,b)
-#else
-#  ifdef USE_SINCOS
-#    define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
-#  else
-#    define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
 #endif
 
 // Standard mathematical constants:
 //   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
 //   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
-// OpenCL defines M_constant_F for float constants, and nothing if float
+// OpenCL defines M_constant_F for float constants, and nothing if double
 // is not enabled on the card, which is why these constants may be missing
 #ifndef M_PI
-#  define M_PI 3.141592653589793f
+#  define M_PI 3.141592653589793
 #endif
 #ifndef M_PI_2
-#  define M_PI_2 1.570796326794897f
+#  define M_PI_2 1.570796326794897
 #endif
 #ifndef M_PI_4
-#  define M_PI_4 0.7853981633974483f
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
 #endif
 
-// Non-standard pi/180, used for converting between degrees and radians
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
 #ifndef M_PI_180
-#  define M_PI_180 0.017453292519943295f
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
 #endif
 
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
 
-#define VOLUME_PARAMETERS radius,cap_radius,length
-#define VOLUME_WEIGHT_PRODUCT radius_w*cap_radius_w*length_w
-#define IQ_KERNEL_NAME capped_cylinder_Iq
-#define IQ_PARAMETERS sld, solvent_sld, radius, cap_radius, length
-#define IQ_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float sld, \
-    const float solvent_sld
-#define IQ_WEIGHT_PRODUCT radius_w*cap_radius_w*length_w
-#define IQ_DISPERSION_LENGTH_DECLARATIONS const int Nradius, \
-    const int Ncap_radius, \
-    const int Nlength
-#define IQ_DISPERSION_LENGTH_SUM Nradius+Ncap_radius+Nlength
-#define IQ_OPEN_LOOPS     for (int radius_i=0; radius_i < Nradius; radius_i++) { \
-      const float radius = loops[2*(radius_i)]; \
-      const float radius_w = loops[2*(radius_i)+1]; \
-      for (int cap_radius_i=0; cap_radius_i < Ncap_radius; cap_radius_i++) { \
-        const float cap_radius = loops[2*(cap_radius_i+Nradius)]; \
-        const float cap_radius_w = loops[2*(cap_radius_i+Nradius)+1]; \
-        for (int length_i=0; length_i < Nlength; length_i++) { \
-          const float length = loops[2*(length_i+Nradius+Ncap_radius)]; \
-          const float length_w = loops[2*(length_i+Nradius+Ncap_radius)+1];
-#define IQ_CLOSE_LOOPS         } \
-      } \
-    }
-#define IQXY_KERNEL_NAME capped_cylinder_Iqxy
-#define IQXY_PARAMETERS sld, solvent_sld, radius, cap_radius, length, theta, phi
-#define IQXY_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float sld, \
-    const float solvent_sld
-#define IQXY_WEIGHT_PRODUCT radius_w*cap_radius_w*length_w*theta_w*phi_w
-#define IQXY_DISPERSION_LENGTH_DECLARATIONS const int Nradius, \
-    const int Ncap_radius, \
-    const int Nlength, \
-    const int Ntheta, \
-    const int Nphi
-#define IQXY_DISPERSION_LENGTH_SUM Nradius+Ncap_radius+Nlength+Ntheta+Nphi
-#define IQXY_OPEN_LOOPS     for (int radius_i=0; radius_i < Nradius; radius_i++) { \
-      const float radius = loops[2*(radius_i)]; \
-      const float radius_w = loops[2*(radius_i)+1]; \
-      for (int cap_radius_i=0; cap_radius_i < Ncap_radius; cap_radius_i++) { \
-        const float cap_radius = loops[2*(cap_radius_i+Nradius)]; \
-        const float cap_radius_w = loops[2*(cap_radius_i+Nradius)+1]; \
-        for (int length_i=0; length_i < Nlength; length_i++) { \
-          const float length = loops[2*(length_i+Nradius+Ncap_radius)]; \
-          const float length_w = loops[2*(length_i+Nradius+Ncap_radius)+1]; \
-          for (int theta_i=0; theta_i < Ntheta; theta_i++) { \
-            const float theta = loops[2*(theta_i+Nradius+Ncap_radius+Nlength)]; \
-            const float theta_w = loops[2*(theta_i+Nradius+Ncap_radius+Nlength)+1]; \
-            for (int phi_i=0; phi_i < Nphi; phi_i++) { \
-              const float phi = loops[2*(phi_i+Nradius+Ncap_radius+Nlength+Ntheta)]; \
-              const float phi_w = loops[2*(phi_i+Nradius+Ncap_radius+Nlength+Ntheta)+1];
-#define IQXY_CLOSE_LOOPS             } \
-          } \
-        } \
-      } \
-    }
-#define IQXY_HAS_THETA 1
+//# Beginning of rotational operation definitions
 
-float J1(float x);
-float J1(float x)
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
 {
-  const float ax = fabs(x);
-  if (ax < 8.0f) {
-    const float y = x*x;
-    const float ans1 = x*(72362614232.0f
-              + y*(-7895059235.0f
-              + y*(242396853.1f
-              + y*(-2972611.439f
-              + y*(15704.48260f
-              + y*(-30.16036606f))))));
-    const float ans2 = 144725228442.0f
-              + y*(2300535178.0f
-              + y*(18583304.74f
-              + y*(99447.43394f
-              + y*(376.9991397f
-              + y))));
-    return ans1/ans2;
-  } else {
-    const float y = 64.0f/(ax*ax);
-    const float xx = ax - 2.356194491f;
-    const float ans1 = 1.0f
-              + y*(0.183105e-2f
-              + y*(-0.3516396496e-4f
-              + y*(0.2457520174e-5f
-              + y*-0.240337019e-6f)));
-    const float ans2 = 0.04687499995f
-              + y*(-0.2002690873e-3f
-              + y*(0.8449199096e-5f
-              + y*(-0.88228987e-6f
-              + y*0.105787412e-6f)));
-    float sn,cn;
-    SINCOS(xx, sn, cn);
-    const float ans = sqrt(0.636619772f/ax) * (cn*ans1 - (8.0f/ax)*sn*ans2);
-    return (x < 0.0f) ? -ans : ans;
-  }
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/polevl.c"
+
+/*							polevl.c
+ *							p1evl.c
+ *
+ *	Evaluate polynomial
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * int N;
+ * double x, y, coef[N+1], polevl[];
+ *
+ * y = polevl( x, coef, N );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Evaluates polynomial of degree N:
+ *
+ *                     2          N
+ * y  =  C  + C x + C x  +...+ C x
+ *        0    1     2          N
+ *
+ * Coefficients are stored in reverse order:
+ *
+ * coef[0] = C  , ..., coef[N] = C  .
+ *            N                   0
+ *
+ * The function p1evl() assumes that C_N = 1.0 and is
+ * omitted from the array.  Its calling arguments are
+ * otherwise the same as polevl().
+ *
+ *
+ * SPEED:
+ *
+ * In the interest of speed, there are no checks for out
+ * of bounds arithmetic.  This routine is used by most of
+ * the functions in the library.  Depending on available
+ * equipment features, the user may wish to rewrite the
+ * program in microcode or assembly language.
+ *
+ */
+
+
+/*
+Cephes Math Library Release 2.1:  December, 1988
+Copyright 1984, 1987, 1988 by Stephen L. Moshier
+Direct inquiries to 30 Frost Street, Cambridge, MA 02140
+*/
+#pragma acc routine seq
+static
+double polevl( double x, pconstant double *coef, int N )
+{
+
+    int i = 0;
+    double ans = coef[i];
+
+    while (i < N) {
+        i++;
+        ans = ans * x + coef[i];
+    }
+
+    return ans;
+}
+
+/*							p1evl()	*/
+/*                                          N
+ * Evaluate polynomial when coefficient of x  is 1.0.
+ * Otherwise same as polevl.
+ */
+#pragma acc routine seq
+static
+double p1evl( double x, pconstant double *coef, int N )
+{
+    int i=0;
+    double ans = x+coef[i];
+
+    while (i < N-1) {
+        i++;
+        ans = ans*x + coef[i];
+    }
+
+    return ans;
 }
 
 
-/*
- *  GaussWeights.c
- *  SANSAnalysis
+#line 1 ".././models/lib/sas_J1.c"
+
+/*							j1.c
  *
- *  Created by Andrew Jackson on 4/23/07.f
- *  Copyright 2007 __MyCompanyName__. All rights reserved.
+ *	Bessel function of order one
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * double x, y, j1();
+ *
+ * y = j1( x );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Returns Bessel function of order one of the argument.
+ *
+ * The domain is divided into the intervals [0, 8] and
+ * (8, infinity). In the first interval a 24 term Chebyshev
+ * expansion is used. In the second, the asymptotic
+ * trigonometric representation is employed using two
+ * rational functions of degree 5/5.
+ *
+ *
+ *
+ * ACCURACY:
+ *
+ *                      Absolute error:
+ * arithmetic   domain      # trials      peak         rms
+ *    DEC       0, 30       10000       4.0e-17     1.1e-17
+ *    IEEE      0, 30       30000       2.6e-16     1.1e-16
+ *
  *
  */
 
+/*
+Cephes Math Library Release 2.8:  June, 2000
+Copyright 1984, 1987, 1989, 2000 by Stephen L. Moshier
+*/
+
+#if FLOAT_SIZE>4
+//Cephes double pression function
+
+constant double RPJ1[8] = {
+    -8.99971225705559398224E8,
+    4.52228297998194034323E11,
+    -7.27494245221818276015E13,
+    3.68295732863852883286E15,
+    0.0,
+    0.0,
+    0.0,
+    0.0 };
+
+constant double RQJ1[8] = {
+    6.20836478118054335476E2,
+    2.56987256757748830383E5,
+    8.35146791431949253037E7,
+    2.21511595479792499675E10,
+    4.74914122079991414898E12,
+    7.84369607876235854894E14,
+    8.95222336184627338078E16,
+    5.32278620332680085395E18
+    };
+
+constant double PPJ1[8] = {
+    7.62125616208173112003E-4,
+    7.31397056940917570436E-2,
+    1.12719608129684925192E0,
+    5.11207951146807644818E0,
+    8.42404590141772420927E0,
+    5.21451598682361504063E0,
+    1.00000000000000000254E0,
+    0.0} ;
+
+
+constant double PQJ1[8] = {
+    5.71323128072548699714E-4,
+    6.88455908754495404082E-2,
+    1.10514232634061696926E0,
+    5.07386386128601488557E0,
+    8.39985554327604159757E0,
+    5.20982848682361821619E0,
+    9.99999999999999997461E-1,
+    0.0 };
+
+constant double QPJ1[8] = {
+    5.10862594750176621635E-2,
+    4.98213872951233449420E0,
+    7.58238284132545283818E1,
+    3.66779609360150777800E2,
+    7.10856304998926107277E2,
+    5.97489612400613639965E2,
+    2.11688757100572135698E2,
+    2.52070205858023719784E1 };
+
+constant double QQJ1[8] = {
+    7.42373277035675149943E1,
+    1.05644886038262816351E3,
+    4.98641058337653607651E3,
+    9.56231892404756170795E3,
+    7.99704160447350683650E3,
+    2.82619278517639096600E3,
+    3.36093607810698293419E2,
+    0.0 };
+
+#pragma acc declare copyin( RPJ1[0:8], RQJ1[0:8], PPJ1[0:8], PQJ1[0:8], QPJ1[0:8], QQJ1[0:8])
+
+#pragma acc routine seq
+static
+double cephes_j1(double x)
+{
+
+    double w, z, p, q, abs_x, sign_x;
+
+    const double Z1 = 1.46819706421238932572E1;
+    const double Z2 = 4.92184563216946036703E1;
+
+    // 2017-05-18 PAK - mathematica and mpmath use J1(-x) = -J1(x)
+    if (x < 0) {
+        abs_x = -x;
+        sign_x = -1.0;
+    } else {
+        abs_x = x;
+        sign_x = 1.0;
+    }
+
+    if( abs_x <= 5.0 ) {
+        z = abs_x * abs_x;
+        w = polevl( z, RPJ1, 3 ) / p1evl( z, RQJ1, 8 );
+        w = w * abs_x * (z - Z1) * (z - Z2);
+        return( sign_x * w );
+    }
+
+    w = 5.0/abs_x;
+    z = w * w;
+    p = polevl( z, PPJ1, 6)/polevl( z, PQJ1, 6 );
+    q = polevl( z, QPJ1, 7)/p1evl( z, QQJ1, 7 );
+
+    // 2017-05-19 PAK improve accuracy using trig identies
+    // original:
+    //    const double THPIO4 =  2.35619449019234492885;
+    //    const double SQ2OPI = 0.79788456080286535588;
+    //    double sin_xn, cos_xn;
+    //    SINCOS(abs_x - THPIO4, sin_xn, cos_xn);
+    //    p = p * cos_xn - w * q * sin_xn;
+    //    return( sign_x * p * SQ2OPI / sqrt(abs_x) );
+    // expanding p*cos(a - 3 pi/4) - wq sin(a - 3 pi/4)
+    //    [ p(sin(a) - cos(a)) + wq(sin(a) + cos(a)) / sqrt(2)
+    // note that sqrt(1/2) * sqrt(2/pi) = sqrt(1/pi)
+    const double SQRT1_PI = 0.56418958354775628;
+    double sin_x, cos_x;
+    SINCOS(abs_x, sin_x, cos_x);
+    p = p*(sin_x - cos_x) + w*q*(sin_x + cos_x);
+    return( sign_x * p * SQRT1_PI / sqrt(abs_x) );
+}
+
+#else
+//Single precission version of cephes
+
+constant float JPJ1[8] = {
+    -4.878788132172128E-009,
+    6.009061827883699E-007,
+    -4.541343896997497E-005,
+    1.937383947804541E-003,
+    -3.405537384615824E-002,
+    0.0,
+    0.0,
+    0.0
+    };
+
+constant float MO1J1[8] = {
+    6.913942741265801E-002,
+    -2.284801500053359E-001,
+    3.138238455499697E-001,
+    -2.102302420403875E-001,
+    5.435364690523026E-003,
+    1.493389585089498E-001,
+    4.976029650847191E-006,
+    7.978845453073848E-001
+    };
+
+constant float PH1J1[8] = {
+    -4.497014141919556E+001,
+    5.073465654089319E+001,
+    -2.485774108720340E+001,
+    7.222973196770240E+000,
+    -1.544842782180211E+000,
+    3.503787691653334E-001,
+    -1.637986776941202E-001,
+    3.749989509080821E-001
+    };
+
+#pragma acc declare copyin( JPJ1[0:8], MO1J1[0:8], PH1J1[0:8])
+
+#pragma acc routine seq
+static
+float cephes_j1f(float xx)
+{
+
+    float x, w, z, p, q, xn;
+
+    const float Z1 = 1.46819706421238932572E1;
+
+
+    // 2017-05-18 PAK - mathematica and mpmath use J1(-x) = -J1(x)
+    x = xx;
+    if( x < 0 )
+        x = -xx;
+
+    if( x <= 2.0 ) {
+        z = x * x;
+        p = (z-Z1) * x * polevl( z, JPJ1, 4 );
+        return( xx < 0. ? -p : p );
+    }
+
+    q = 1.0/x;
+    w = sqrt(q);
+
+    p = w * polevl( q, MO1J1, 7);
+    w = q*q;
+    // 2017-05-19 PAK improve accuracy using trig identies
+    // original:
+    //    const float THPIO4F =  2.35619449019234492885;    /* 3*pi/4 */
+    //    xn = q * polevl( w, PH1J1, 7) - THPIO4F;
+    //    p = p * cos(xn + x);
+    //    return( xx < 0. ? -p : p );
+    // expanding cos(a + b - 3 pi/4) is
+    //    [sin(a)sin(b) + sin(a)cos(b) + cos(a)sin(b)-cos(a)cos(b)] / sqrt(2)
+    xn = q * polevl( w, PH1J1, 7);
+    float cos_xn, sin_xn;
+    float cos_x, sin_x;
+    SINCOS(xn, sin_xn, cos_xn);  // about xn and 1
+    SINCOS(x, sin_x, cos_x);
+    p *= M_SQRT1_2*(sin_xn*(sin_x+cos_x) + cos_xn*(sin_x-cos_x));
+
+    return( xx < 0. ? -p : p );
+}
+#endif
+
+#if FLOAT_SIZE>4
+#define sas_J1 cephes_j1
+#else
+#define sas_J1 cephes_j1f
+#endif
+
+//Finally J1c function that equals 2*J1(x)/x
+    
+#pragma acc routine seq
+static
+double sas_2J1x_x(double x)
+{
+    return (x != 0.0 ) ? 2.0*sas_J1(x)/x : 1.0;
+}
+
+
+#line 1 ".././models/lib/gauss76.c"
+
+// Created by Andrew Jackson on 4/23/07
+
+ #ifdef GAUSS_N
+ # undef GAUSS_N
+ # undef GAUSS_Z
+ # undef GAUSS_W
+ #endif
+ #define GAUSS_N 76
+ #define GAUSS_Z Gauss76Z
+ #define GAUSS_W Gauss76Wt
+
 // Gaussians
-constant float Gauss76Wt[]={
-	.00126779163408536f,		//0
-	.00294910295364247f,
-	.00462793522803742f,
-	.00629918049732845f,
-	.00795984747723973f,
-	.00960710541471375f,
-	.0112381685696677f,
-	.0128502838475101f,
-	.0144407317482767f,
-	.0160068299122486f,
-	.0175459372914742f,		//10
-	.0190554584671906f,
-	.020532847967908f,
-	.0219756145344162f,
-	.0233813253070112f,
-	.0247476099206597f,
-	.026072164497986f,
-	.0273527555318275f,
-	.028587223650054f,
-	.029773487255905f,
-	.0309095460374916f,		//20
-	.0319934843404216f,
-	.0330234743977917f,
-	.0339977794120564f,
-	.0349147564835508f,
-	.0357728593807139f,
-	.0365706411473296f,
-	.0373067565423816f,
-	.0379799643084053f,
-	.0385891292645067f,
-	.0391332242205184f,		//30
-	.0396113317090621f,
-	.0400226455325968f,
-	.040366472122844f,
-	.0406422317102947f,
-	.0408494593018285f,
-	.040987805464794f,
-	.0410570369162294f,
-	.0410570369162294f,
-	.040987805464794f,
-	.0408494593018285f,		//40
-	.0406422317102947f,
-	.040366472122844f,
-	.0400226455325968f,
-	.0396113317090621f,
-	.0391332242205184f,
-	.0385891292645067f,
-	.0379799643084053f,
-	.0373067565423816f,
-	.0365706411473296f,
-	.0357728593807139f,		//50
-	.0349147564835508f,
-	.0339977794120564f,
-	.0330234743977917f,
-	.0319934843404216f,
-	.0309095460374916f,
-	.029773487255905f,
-	.028587223650054f,
-	.0273527555318275f,
-	.026072164497986f,
-	.0247476099206597f,		//60
-	.0233813253070112f,
-	.0219756145344162f,
-	.020532847967908f,
-	.0190554584671906f,
-	.0175459372914742f,
-	.0160068299122486f,
-	.0144407317482767f,
-	.0128502838475101f,
-	.0112381685696677f,
-	.00960710541471375f,		//70
-	.00795984747723973f,
-	.00629918049732845f,
-	.00462793522803742f,
-	.00294910295364247f,
-	.00126779163408536f		//75 (indexed from 0)
+constant double Gauss76Wt[76] = {
+	.00126779163408536,		//0
+	.00294910295364247,
+	.00462793522803742,
+	.00629918049732845,
+	.00795984747723973,
+	.00960710541471375,
+	.0112381685696677,
+	.0128502838475101,
+	.0144407317482767,
+	.0160068299122486,
+	.0175459372914742,		//10
+	.0190554584671906,
+	.020532847967908,
+	.0219756145344162,
+	.0233813253070112,
+	.0247476099206597,
+	.026072164497986,
+	.0273527555318275,
+	.028587223650054,
+	.029773487255905,
+	.0309095460374916,		//20
+	.0319934843404216,
+	.0330234743977917,
+	.0339977794120564,
+	.0349147564835508,
+	.0357728593807139,
+	.0365706411473296,
+	.0373067565423816,
+	.0379799643084053,
+	.0385891292645067,
+	.0391332242205184,		//30
+	.0396113317090621,
+	.0400226455325968,
+	.040366472122844,
+	.0406422317102947,
+	.0408494593018285,
+	.040987805464794,
+	.0410570369162294,
+	.0410570369162294,
+	.040987805464794,
+	.0408494593018285,		//40
+	.0406422317102947,
+	.040366472122844,
+	.0400226455325968,
+	.0396113317090621,
+	.0391332242205184,
+	.0385891292645067,
+	.0379799643084053,
+	.0373067565423816,
+	.0365706411473296,
+	.0357728593807139,		//50
+	.0349147564835508,
+	.0339977794120564,
+	.0330234743977917,
+	.0319934843404216,
+	.0309095460374916,
+	.029773487255905,
+	.028587223650054,
+	.0273527555318275,
+	.026072164497986,
+	.0247476099206597,		//60
+	.0233813253070112,
+	.0219756145344162,
+	.020532847967908,
+	.0190554584671906,
+	.0175459372914742,
+	.0160068299122486,
+	.0144407317482767,
+	.0128502838475101,
+	.0112381685696677,
+	.00960710541471375,		//70
+	.00795984747723973,
+	.00629918049732845,
+	.00462793522803742,
+	.00294910295364247,
+	.00126779163408536		//75 (indexed from 0)
 };
 
-#pragma acc declare create ( Gauss76Wt )
-
-constant float Gauss76Z[]={
-	-.999505948362153f,		//0
-	-.997397786355355f,
-	-.993608772723527f,
-	-.988144453359837f,
-	-.981013938975656f,
-	-.972229228520377f,
-	-.961805126758768f,
-	-.949759207710896f,
-	-.936111781934811f,
-	-.92088586125215f,
-	-.904107119545567f,		//10
-	-.885803849292083f,
-	-.866006913771982f,
-	-.844749694983342f,
-	-.822068037328975f,
-	-.7980001871612f,
-	-.77258672828181f,
-	-.74587051350361f,
-	-.717896592387704f,
-	-.688712135277641f,
-	-.658366353758143f,		//20
-	-.626910417672267f,
-	-.594397368836793f,
-	-.560882031601237f,
-	-.526420920401243f,
-	-.491072144462194f,
-	-.454895309813726f,
-	-.417951418780327f,
-	-.380302767117504f,
-	-.342012838966962f,
-	-.303146199807908f,		//30
-	-.263768387584994f,
-	-.223945802196474f,
-	-.183745593528914f,
-	-.143235548227268f,
-	-.102483975391227f,
-	-.0615595913906112f,
-	-.0205314039939986f,
-	.0205314039939986f,
-	.0615595913906112f,
-	.102483975391227f,			//40
-	.143235548227268f,
-	.183745593528914f,
-	.223945802196474f,
-	.263768387584994f,
-	.303146199807908f,
-	.342012838966962f,
-	.380302767117504f,
-	.417951418780327f,
-	.454895309813726f,
-	.491072144462194f,		//50
-	.526420920401243f,
-	.560882031601237f,
-	.594397368836793f,
-	.626910417672267f,
-	.658366353758143f,
-	.688712135277641f,
-	.717896592387704f,
-	.74587051350361f,
-	.77258672828181f,
-	.7980001871612f,	//60
-	.822068037328975f,
-	.844749694983342f,
-	.866006913771982f,
-	.885803849292083f,
-	.904107119545567f,
-	.92088586125215f,
-	.936111781934811f,
-	.949759207710896f,
-	.961805126758768f,
-	.972229228520377f,		//70
-	.981013938975656f,
-	.988144453359837f,
-	.993608772723527f,
-	.997397786355355f,
-	.999505948362153f		//75
+constant double Gauss76Z[76] = {
+	-.999505948362153,		//0
+	-.997397786355355,
+	-.993608772723527,
+	-.988144453359837,
+	-.981013938975656,
+	-.972229228520377,
+	-.961805126758768,
+	-.949759207710896,
+	-.936111781934811,
+	-.92088586125215,
+	-.904107119545567,		//10
+	-.885803849292083,
+	-.866006913771982,
+	-.844749694983342,
+	-.822068037328975,
+	-.7980001871612,
+	-.77258672828181,
+	-.74587051350361,
+	-.717896592387704,
+	-.688712135277641,
+	-.658366353758143,		//20
+	-.626910417672267,
+	-.594397368836793,
+	-.560882031601237,
+	-.526420920401243,
+	-.491072144462194,
+	-.454895309813726,
+	-.417951418780327,
+	-.380302767117504,
+	-.342012838966962,
+	-.303146199807908,		//30
+	-.263768387584994,
+	-.223945802196474,
+	-.183745593528914,
+	-.143235548227268,
+	-.102483975391227,
+	-.0615595913906112,
+	-.0205314039939986,
+	.0205314039939986,
+	.0615595913906112,
+	.102483975391227,			//40
+	.143235548227268,
+	.183745593528914,
+	.223945802196474,
+	.263768387584994,
+	.303146199807908,
+	.342012838966962,
+	.380302767117504,
+	.417951418780327,
+	.454895309813726,
+	.491072144462194,		//50
+	.526420920401243,
+	.560882031601237,
+	.594397368836793,
+	.626910417672267,
+	.658366353758143,
+	.688712135277641,
+	.717896592387704,
+	.74587051350361,
+	.77258672828181,
+	.7980001871612,	//60
+	.822068037328975,
+	.844749694983342,
+	.866006913771982,
+	.885803849292083,
+	.904107119545567,
+	.92088586125215,
+	.936111781934811,
+	.949759207710896,
+	.961805126758768,
+	.972229228520377,		//70
+	.981013938975656,
+	.988144453359837,
+	.993608772723527,
+	.997397786355355,
+	.999505948362153		//75
 };
 
-#pragma acc declare create ( Gauss76Z )
 
-float form_volume(float radius, float cap_radius, float length);
-float Iq(float q, float sld, float solvent_sld,
-    float radius, float cap_radius, float length);
-float Iqxy(float qx, float qy, float sld, float solvent_sld,
-    float radius, float cap_radius, float length, float theta, float phi);
+#pragma acc declare copyin(Gauss76Wt[0:76], Gauss76Z[0:76])
+
+#line 1 ".././models/capped_cylinder.c"
 
 // Integral over a convex lens kernel for t in [h/R,1].  See the docs for
 // the definition of the function being integrated.
 //   q is the magnitude of the q vector.
 //   h is the length of the lens "inside" the cylinder.  This negative wrt the
 //       definition of h in the docs.
-//   cap_radius is the radius of the lens
+//   radius_cap is the radius of the lens
 //   length is the cylinder length, or the separation between the lens halves
-//   alpha is the angle of the cylinder wrt q.
-float _cap_kernel(float q, float h, float cap_radius, float length,
-                 float sin_alpha, float cos_alpha);
-float _cap_kernel(float q, float h, float cap_radius, float length,
-                 float sin_alpha, float cos_alpha)
+//   theta is the angle of the cylinder wrt q.
+static double
+_cap_kernel(double qab, double qc, double h, double radius_cap,
+    double half_length)
 {
-    // For speed, we are pre-calculating terms which are constant over the
-    // kernel.
-    const float upper = 1.0f;
-    const float lower = h/cap_radius; // integral lower bound
+    // translate a point in [-1,1] to a point in [lower,upper]
+    const double upper = 1.0;
+    const double lower = -h/radius_cap; // integral lower bound
+    const double zm = 0.5*(upper-lower);
+    const double zb = 0.5*(upper+lower);
+
     // cos term in integral is:
-    //    cos (q (R t - h + L/2) cos(alpha))
+    //    cos (q (R t - h + L/2) cos(theta))
     // so turn it into:
     //    cos (m t + b)
     // where:
-    //    m = q R cos(alpha)
-    //    b = q(L/2-h) cos(alpha)
-    const float m = q*cap_radius*cos_alpha; // cos argument slope
-    const float b = q*(0.5f*length-h)*cos_alpha; // cos argument intercept
-    const float qrst = q*cap_radius*sin_alpha; // Q*R*sin(theta)
-    float total = 0.0f;
-    for (int i=0; i<76 ;i++) {
-        // translate a point in [-1,1] to a point in [lower,upper]
-        //const float t = ( Gauss76Z[i]*(upper-lower) + upper + lower )/2.0f;
-        const float t = 0.5f*(Gauss76Z[i]*(upper-lower)+upper+lower);
-        const float radical = 1.0f - t*t;
-        const float arg = qrst*sqrt(radical); // cap bessel function arg
-        const float be = (arg == 0.0f ? 0.5f : J1(arg)/arg);
-        const float Fq = cos(m*t + b) * radical * be;
-        total += Gauss76Wt[i] * Fq;
+    //    m = q R cos(theta)
+    //    b = q(L/2-h) cos(theta)
+    const double m = radius_cap*qc; // cos argument slope
+    const double b = (half_length+h)*qc; // cos argument intercept
+    const double qab_r = radius_cap*qab; // Q*R*sin(theta)
+    double total = 0.0;
+    for (int i=0; i<GAUSS_N; i++) {
+        const double t = GAUSS_Z[i]*zm + zb;
+        const double radical = 1.0 - t*t;
+        const double bj = sas_2J1x_x(qab_r*sqrt(radical));
+        const double Fq = cos(m*t + b) * radical * bj;
+        total += GAUSS_W[i] * Fq;
     }
     // translate dx in [-1,1] to dx in [lower,upper]
-    //const float form = (upper-lower)/2.0f*total;
-    const float integral = 0.5f*(upper-lower)*total;
-    return 4.0f*M_PI*cap_radius*cap_radius*cap_radius*integral;
+    const double integral = total*zm;
+    const double cap_Fq = 2.0*M_PI*cube(radius_cap)*integral;
+    return cap_Fq;
 }
 
-float form_volume(float radius, float cap_radius, float length)
+static double
+_fq(double qab, double qc, double h, double radius_cap, double radius, double half_length)
+{
+    const double cap_Fq = _cap_kernel(qab, qc, h, radius_cap, half_length);
+    const double bj = sas_2J1x_x(radius*qab);
+    const double si = sas_sinx_x(half_length*qc);
+    const double cyl_Fq = 2.0*M_PI*radius*radius*half_length*bj*si;
+    const double Aq = cap_Fq + cyl_Fq;
+    return Aq;
+}
+
+static double
+form_volume(double radius, double radius_cap, double length)
 {
     // cap radius should never be less than radius when this is called
-
-    // Note: volume V = 2*V_cap + V_cyl
-    //
-    // V_cyl = pi r_cyl^2 L
-    // V_cap = 1/6 pi h_c (3 r_cyl^2 + h_c^2) = 1/3 pi h_c^2 (3 r_cap - h_c)
-    //
-    // The docs for capped cylinder give the volume as:
-    //    V = pi r^2 L + 2/3 pi (R-h)^2 (2R + h)
-    // where r_cap=R and h = R - h_c.
-    //
-    // The first part is clearly V_cyl.  The second part requires some work:
-    //    (R-h)^2 => h_c^2
-    //    (2R+h) => 2R+ h_c-h_c + h => 2R + (R-h)-hc + h => 3R-h_c
-    // And so:
-    //    2/3 pi (R-h)^2 (2R + h) => 2/3 pi h_c^2 (3 r_cap - h_c)
-    // which is 2 V_cap, using the second form above.
-    //
-    // In this function we are going to use the first form of V_cap
-    //
-    //      V = V_cyl + 2 V_cap
-    //        = pi r^2 L + pi hc (r^2 + hc^2/3)
-    //        = pi (r^2 (L+hc) + hc^3/3)
-    const float hc = cap_radius - sqrt(cap_radius*cap_radius - radius*radius);
-    return M_PI*(radius*radius*(length+hc) + 0.333333333333333f*hc*hc*hc);
+    const double h = -sqrt(square(radius_cap) - square(radius));
+    const double slice = M_PI*(square(radius_cap)*h - cube(h)/3.0);
+    const double hemisphere = 2.0*M_PI/3.0*cube(radius_cap);
+    const double rod = M_PI*square(radius)*length;
+    // h < 0 so slice is subtracted from hemisphere
+    return rod + 2.0*(hemisphere + slice);
 }
 
-float Iq(float q,
-    float sld,
-    float solvent_sld,
-    float radius,
-    float cap_radius,
-    float length)
+static double
+radius_from_excluded_volume(double radius, double radius_cap, double length)
 {
-    float sn, cn; // slots to hold sincos function output
+    const double h = -sqrt(square(radius_cap) - square(radius));
+    const double length_tot = length + 2.0*(radius_cap + h);
+    // Use cylinder excluded volume with length' = length + caps and
+    // radius' = cylinder radius since the lens is smaller than the cylinder.
+    return 0.5*cbrt(0.75*radius*(2.0*radius*length_tot
+           + (radius + length_tot)*(M_PI*radius + length_tot)));
+}
 
-    // Exclude invalid inputs.
-    if (cap_radius < radius) return NAN;
+static double
+radius_from_volume(double radius, double radius_cap, double length)
+{
+    const double vol_cappedcyl = form_volume(radius,radius_cap,length);
+    return cbrt(vol_cappedcyl/M_4PI_3);
+}
 
-    const float lower = 0.0f;
-    const float upper = M_PI_2;
-    const float h = sqrt(cap_radius*cap_radius - radius*radius); // negative h
-    float total = 0.0f;
-    for (int i=0; i<76 ;i++) {
-        // translate a point in [-1,1] to a point in [lower,upper]
-        const float alpha= 0.5f*(Gauss76Z[i]*(upper-lower) + upper + lower);
-        SINCOS(alpha, sn, cn);
+static double
+radius_from_totallength(double radius, double radius_cap, double length)
+{
+    const double h = -sqrt(square(radius_cap) - square(radius));
+    const double half_length = 0.5*length;
+    return half_length + radius_cap - h;
+}
 
-        const float cap_Fq = _cap_kernel(q, h, cap_radius, length, sn, cn);
+static double
+radius_effective(int mode, double radius, double radius_cap, double length)
+{
+    switch (mode) {
+    default:
+    case 1: // equivalent cylinder excluded volume
+        return radius_from_excluded_volume(radius, radius_cap, length);
+    case 2: // equivalent volume sphere
+        return radius_from_volume(radius, radius_cap, length);
+    case 3: // radius
+        return radius;
+    case 4: // half length
+        return 0.5*length;
+    case 5: // half total length
+        return radius_from_totallength(radius, radius_cap,length);
+    }
+}
 
-        // The following is CylKernel() / sin(alpha), but we are doing it in place
-        // to avoid sin(alpha)/sin(alpha) for alpha = 0.f  It is also a teensy bit
-        // faster since we don't multiply and divide sin(alpha).
-        const float besarg = q*radius*sn;
-        const float siarg = q*0.5f*length*cn;
-        // lim_{x->0} J1(x)/x = 1/2,   lim_{x->0} sin(x)/x = 1
-        const float bj = (besarg == 0.0f ? 0.5f : J1(besarg)/besarg);
-        const float si = (siarg == 0.0f ? 1.0f : sin(siarg)/siarg);
-        const float cyl_Fq = M_PI*radius*radius*length*2.0f*bj*si;
+static void
+Fq(double q,double *F1, double *F2, double sld, double solvent_sld,
+    double radius, double radius_cap, double length)
+{
+    const double h = -sqrt(square(radius_cap) - square(radius));
+    const double half_length = 0.5*length;
 
-        // Volume weighted average F(q)
-        const float Aq = cyl_Fq + cap_Fq;
-        total += Gauss76Wt[i] * Aq * Aq * sn; // sn for spherical coord integration
+    // translate a point in [-1,1] to a point in [0, pi/2]
+    const double zm = M_PI_4;
+    const double zb = M_PI_4;
+    double total_F1 = 0.0;
+    double total_F2 = 0.0;
+    for (int i=0; i<GAUSS_N ;i++) {
+        const double theta = GAUSS_Z[i]*zm + zb;
+        double sin_theta, cos_theta; // slots to hold sincos function output
+        SINCOS(theta, sin_theta, cos_theta);
+        const double qab = q*sin_theta;
+        const double qc = q*cos_theta;
+        const double Aq = _fq(qab, qc, h, radius_cap, radius, half_length);
+        // scale by sin_theta for spherical coord integration
+        total_F1 += GAUSS_W[i] * Aq * sin_theta;
+        total_F2 += GAUSS_W[i] * Aq * Aq * sin_theta;
     }
     // translate dx in [-1,1] to dx in [lower,upper]
-    const float form = total * 0.5f*(upper-lower);
+    const double form_avg = total_F1 * zm;
+    const double form_squared_avg = total_F2 * zm;
 
-    // Multiply by contrast^2, normalize by cylinder volume and convert to cm-1
-    // NOTE that for this (Fournet) definition of the integral, one must MULTIPLY by Vcyl
-    // The additional volume factor is for polydisperse volume normalization.
-    const float s = (sld - solvent_sld);
-    return 1.0e-4f * form * s * s; // form_volume(radius, cap_radius, length);
+    // Contrast
+    const double s = (sld - solvent_sld);
+    *F1 = 1.0e-2 * s * form_avg;
+    *F2 = 1.0e-4 * s * s * form_squared_avg;
 }
 
 
-float Iqxy(float qx, float qy,
-    float sld,
-    float solvent_sld,
-    float radius,
-    float cap_radius,
-    float length,
-    float theta,
-    float phi)
+static double
+Iqac(double qab, double qc,
+    double sld, double solvent_sld, double radius,
+    double radius_cap, double length)
 {
-    float sn, cn; // slots to hold sincos function output
+    const double h = -sqrt(square(radius_cap) - square(radius));
+    const double Aq = _fq(qab, qc, h, radius_cap, radius, 0.5*length);
 
-    // Exclude invalid inputs.
-    if (cap_radius < radius) return NAN;
-
-    // Compute angle alpha between q and the cylinder axis
-    SINCOS(theta*M_PI_180, sn, cn);
-    // # The following correction factor exists in sasview, but it can't be
-    // # right, so we are leaving it out for now.
-    const float q = sqrt(qx*qx+qy*qy);
-    const float cos_val = cn*cos(phi*M_PI_180)*(qx/q) + sn*(qy/q);
-    const float alpha = acos(cos_val); // rod angle relative to q
-    SINCOS(alpha, sn, cn);
-
-    const float h = sqrt(cap_radius*cap_radius - radius*radius); // negative h
-    const float cap_Fq = _cap_kernel(q, h, cap_radius, length, sn, cn);
-
-    const float besarg = q*radius*sn;
-    const float siarg = q*0.5f*length*cn;
-    // lim_{x->0} J1(x)/x = 1/2,   lim_{x->0} sin(x)/x = 1
-    const float bj = (besarg == 0.0f ? 0.5f : J1(besarg)/besarg);
-    const float si = (siarg == 0.0f ? 1.0f : sin(siarg)/siarg);
-    const float cyl_Fq = M_PI*radius*radius*length*2.0f*bj*si;
-
-    // Volume weighted average F(q)
-    const float Aq = cyl_Fq + cap_Fq;
-
-    // Multiply by contrast^2, normalize by cylinder volume and convert to cm-1
-    const float s = (sld - solvent_sld);
-    return 1.0e-4f * Aq * Aq * s * s; // form_volume(radius, cap_radius, length);
+    // Multiply by contrast^2 and convert to cm-1
+    const double s = (sld - solvent_sld);
+    return 1.0e-4 * square(s * Aq);
 }
 
 
-/*
-    ##########################################################
-    #                                                        #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #   !!                                              !!   #
-    #   !!  KEEP THIS CODE CONSISTENT WITH KERNELPY.PY  !!   #
-    #   !!                                              !!   #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #                                                        #
-    ##########################################################
-*/
-
-#ifdef IQ_KERNEL_NAME
-kernel void IQ_KERNEL_NAME(
-    global const float *q,
-    global float *result,
-    const int Nq,
-#ifdef IQ_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQ_DISPERSION_LENGTH_DECLARATIONS,
-#endif
-    IQ_FIXED_PARAMETER_DECLARATIONS
-    )
-{
-#ifdef USE_OPENCL
-  #ifdef IQ_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQ_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
-
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qi = q[i];
-#ifdef IQ_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-  #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-  #endif
-    IQ_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
-
-    const float weight = IQ_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-      const float scattering = Iq(qi, IQ_PARAMETERS);
-      // allow kernels to exclude invalid regions by returning NaN
-      if (!isnan(scattering)) {
-        ret += weight*scattering;
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-        norm_vol += vol_weight;
-      #endif
-      }
-    //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
-    }
-    IQ_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iq(qi, IQ_PARAMETERS) + background;
-#endif
-  }
-}
-#endif
-
-
-#ifdef IQXY_KERNEL_NAME
-kernel void IQXY_KERNEL_NAME(
-    global const float *qx,
-    global const float *qy,
-    global float *result,
-    const int Nq,
-#ifdef IQXY_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQXY_DISPERSION_LENGTH_DECLARATIONS,
-#endif
-    IQXY_FIXED_PARAMETER_DECLARATIONS
-    )
-{
-#ifdef USE_OPENCL
-  #ifdef IQXY_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQXY_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
-
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qxi = qx[i];
-    const float qyi = qy[i];
-    #if USE_KAHAN_SUMMATION
-    float accumulated_error = 0.0f;
-    #endif
-#ifdef IQXY_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-    #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-    #endif
-    IQXY_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
-
-    const float weight = IQXY_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-
-      const float scattering = Iqxy(qxi, qyi, IQXY_PARAMETERS);
-      if (!isnan(scattering)) { // if scattering is bad, exclude it from sum
-      //if (scattering >= 0.0f) { // scattering cannot be negative
-        // TODO: use correct angle for spherical correction
-        // Definition of theta and phi are probably reversed relative to the
-        // equation which gave rise to this correction, leading to an
-        // attenuation of the pattern as theta moves through pi/2.f  Either
-        // reverse the meanings of phi and theta in the forms, or use phi
-        // rather than theta in this correction.  Current code uses cos(theta)
-        // so that values match those of sasview.
-      #if defined(IQXY_HAS_THETA) // && 0
-        const float spherical_correction
-          = (Ntheta>1 ? fabs(cos(M_PI_180*theta))*M_PI_2:1.0f);
-        const float next = spherical_correction * weight * scattering;
-      #else
-        const float next = weight * scattering;
-      #endif
-      #if USE_KAHAN_SUMMATION
-        const float y = next - accumulated_error;
-        const float t = ret + y;
-        accumulated_error = (t - ret) - y;
-        ret = t;
-      #else
-        ret += next;
-      #endif
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-      #endif
-        norm_vol += vol_weight;
-      }
-      //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
-    }
-    IQXY_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iqxy(qxi, qyi, IQXY_PARAMETERS) + background;
-#endif
-  }
-}
-#endif

--- a/mcstas-comps/share/sas_core_multi_shell.c
+++ b/mcstas-comps/share/sas_core_multi_shell.c
@@ -1,0 +1,507 @@
+#define HAS_FQ
+#define FORM_VOL
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/sas_3j1x_x.c"
+
+/**
+* Spherical Bessel function 3*j1(x)/x
+*
+* Used for low q to avoid cancellation error.
+* Note that the values differ from sasview ~ 5e-12 rather than 5e-14, but
+* in this case it is likely cancellation errors in the original expression
+* using double precision that are the source.
+*/
+double sas_3j1x_x(double q);
+
+// The choice of the number of terms in the series and the cutoff value for
+// switching between series and direct calculation depends on the numeric
+// precision.
+//
+// Point where direct calculation reaches machine precision:
+//
+//   single machine precision eps 3e-8 at qr=1.1 **
+//   double machine precision eps 4e-16 at qr=1.1
+//
+// Point where Taylor series reaches machine precision (eps), where taylor
+// series matches direct calculation (cross) and the error at that point:
+//
+//   prec   n eps  cross  error
+//   single 3 0.28  0.4   6.2e-7
+//   single 4 0.68  0.7   2.3e-7
+//   single 5 1.18  1.2   7.5e-8
+//   double 3 0.01  0.03  2.3e-13
+//   double 4 0.06  0.1   3.1e-14
+//   double 5 0.16  0.2   5.0e-15
+//
+// ** Note: relative error on single precision starts increase on the direct
+// method at qr=1.1, rising from 3e-8 to 5e-5 by qr=1e3.  This should be
+// safe for the sans range, with objects of 100 nm supported to a q of 0.1
+// while maintaining 5 digits of precision.  For usans/sesans, the objects
+// are larger but the q is smaller, so again it should be fine.
+//
+// See explore/sph_j1c.py for code to explore these ranges.
+
+// Use 4th order series
+#if FLOAT_SIZE>4
+#define SPH_J1C_CUTOFF 0.1
+#else
+#define SPH_J1C_CUTOFF 0.7
+#endif
+#pragma acc routine seq
+double sas_3j1x_x(double q)
+{
+    // 2017-05-18 PAK - support negative q
+    if (fabs(q) < SPH_J1C_CUTOFF) {
+        const double q2 = q*q;
+        return (1.0 + q2*(-3./30. + q2*(3./840. + q2*(-3./45360.))));// + q2*(3./3991680.)))));
+    } else {
+        double sin_q, cos_q;
+        SINCOS(q, sin_q, cos_q);
+        return 3.0*(sin_q/q - cos_q)/(q*q);
+    }
+}
+
+
+#line 1 ".././models/core_multi_shell.c"
+
+
+static double
+f_constant(double q, double r, double sld)
+{
+  const double bes = sas_3j1x_x(q * r);
+  const double vol = M_4PI_3 * cube(r);
+  return sld * vol * bes;
+}
+
+static double
+outer_radius(double core_radius, double fp_n, double thickness[])
+{
+  double r = core_radius;
+  int n = (int)(fp_n+0.5);
+  for (int i=0; i < n; i++) {
+    r += thickness[i];
+  }
+  return r;
+}
+
+static double
+form_volume(double core_radius, double fp_n, double thickness[])
+{
+  return M_4PI_3 * cube(outer_radius(core_radius, fp_n, thickness));
+}
+
+static double
+radius_effective(int mode, double core_radius, double fp_n, double thickness[])
+{
+  switch (mode) {
+  default:
+  case 1: // outer radius
+    return outer_radius(core_radius, fp_n, thickness);
+  case 2: // core radius
+    return core_radius;
+  }
+}
+
+static void
+Fq(double q, double *F1, double *F2, double core_sld, double core_radius,
+   double solvent_sld, double fp_n, double sld[], double thickness[])
+{
+  const int n = (int)(fp_n+0.5);
+  double f, r, last_sld;
+  r = core_radius;
+  last_sld = core_sld;
+  f = 0.;
+  for (int i=0; i<n; i++) {
+    f += M_4PI_3 * cube(r) * (sld[i] - last_sld) * sas_3j1x_x(q*r);
+    last_sld = sld[i];
+    r += thickness[i];
+  }
+  f += M_4PI_3 * cube(r) * (solvent_sld - last_sld) * sas_3j1x_x(q*r);
+  *F1 = 1e-2 * f;
+  *F2 = 1e-4 * f * f;
+}
+
+

--- a/mcstas-comps/share/sas_core_shell_bicelle.c
+++ b/mcstas-comps/share/sas_core_shell_bicelle.c
@@ -1,0 +1,1074 @@
+#define HAS_Iqac
+#define HAS_FQ
+#define FORM_VOL
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/sas_Si.c"
+
+// integral of sin(x)/x Taylor series approximated to w/i 0.1%
+double sas_Si(double x);
+
+    
+#pragma acc routine seq
+double sas_Si(double x)
+{
+    if (x >= M_PI*6.2/4.0) {
+        const double xxinv = 1./(x*x);
+        // Explicitly writing factorial values triples the speed of the calculation
+        const double out_cos = (((-720.*xxinv + 24.)*xxinv - 2.)*xxinv + 1.)/x;
+        const double out_sin = (((-5040.*xxinv + 120.)*xxinv - 6.)*xxinv + 1)*xxinv;
+
+        double sin_x, cos_x;
+        SINCOS(x, sin_x, cos_x);
+        return M_PI_2 - cos_x*out_cos - sin_x*out_sin;
+    } else {
+        const double xx = x*x;
+        // Explicitly writing factorial values triples the speed of the calculation
+        return (((((-1./439084800.*xx
+            + 1./3265920.)*xx
+            - 1./35280.)*xx
+            + 1./600.)*xx
+            - 1./18.)*xx
+            + 1.)*x;
+    }
+}
+
+
+#line 1 ".././models/lib/polevl.c"
+
+/*							polevl.c
+ *							p1evl.c
+ *
+ *	Evaluate polynomial
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * int N;
+ * double x, y, coef[N+1], polevl[];
+ *
+ * y = polevl( x, coef, N );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Evaluates polynomial of degree N:
+ *
+ *                     2          N
+ * y  =  C  + C x + C x  +...+ C x
+ *        0    1     2          N
+ *
+ * Coefficients are stored in reverse order:
+ *
+ * coef[0] = C  , ..., coef[N] = C  .
+ *            N                   0
+ *
+ * The function p1evl() assumes that C_N = 1.0 and is
+ * omitted from the array.  Its calling arguments are
+ * otherwise the same as polevl().
+ *
+ *
+ * SPEED:
+ *
+ * In the interest of speed, there are no checks for out
+ * of bounds arithmetic.  This routine is used by most of
+ * the functions in the library.  Depending on available
+ * equipment features, the user may wish to rewrite the
+ * program in microcode or assembly language.
+ *
+ */
+
+
+/*
+Cephes Math Library Release 2.1:  December, 1988
+Copyright 1984, 1987, 1988 by Stephen L. Moshier
+Direct inquiries to 30 Frost Street, Cambridge, MA 02140
+*/
+#pragma acc routine seq
+static
+double polevl( double x, pconstant double *coef, int N )
+{
+
+    int i = 0;
+    double ans = coef[i];
+
+    while (i < N) {
+        i++;
+        ans = ans * x + coef[i];
+    }
+
+    return ans;
+}
+
+/*							p1evl()	*/
+/*                                          N
+ * Evaluate polynomial when coefficient of x  is 1.0.
+ * Otherwise same as polevl.
+ */
+#pragma acc routine seq
+static
+double p1evl( double x, pconstant double *coef, int N )
+{
+    int i=0;
+    double ans = x+coef[i];
+
+    while (i < N-1) {
+        i++;
+        ans = ans*x + coef[i];
+    }
+
+    return ans;
+}
+
+
+#line 1 ".././models/lib/sas_J1.c"
+
+/*							j1.c
+ *
+ *	Bessel function of order one
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * double x, y, j1();
+ *
+ * y = j1( x );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Returns Bessel function of order one of the argument.
+ *
+ * The domain is divided into the intervals [0, 8] and
+ * (8, infinity). In the first interval a 24 term Chebyshev
+ * expansion is used. In the second, the asymptotic
+ * trigonometric representation is employed using two
+ * rational functions of degree 5/5.
+ *
+ *
+ *
+ * ACCURACY:
+ *
+ *                      Absolute error:
+ * arithmetic   domain      # trials      peak         rms
+ *    DEC       0, 30       10000       4.0e-17     1.1e-17
+ *    IEEE      0, 30       30000       2.6e-16     1.1e-16
+ *
+ *
+ */
+
+/*
+Cephes Math Library Release 2.8:  June, 2000
+Copyright 1984, 1987, 1989, 2000 by Stephen L. Moshier
+*/
+
+#if FLOAT_SIZE>4
+//Cephes double pression function
+
+constant double RPJ1[8] = {
+    -8.99971225705559398224E8,
+    4.52228297998194034323E11,
+    -7.27494245221818276015E13,
+    3.68295732863852883286E15,
+    0.0,
+    0.0,
+    0.0,
+    0.0 };
+
+constant double RQJ1[8] = {
+    6.20836478118054335476E2,
+    2.56987256757748830383E5,
+    8.35146791431949253037E7,
+    2.21511595479792499675E10,
+    4.74914122079991414898E12,
+    7.84369607876235854894E14,
+    8.95222336184627338078E16,
+    5.32278620332680085395E18
+    };
+
+constant double PPJ1[8] = {
+    7.62125616208173112003E-4,
+    7.31397056940917570436E-2,
+    1.12719608129684925192E0,
+    5.11207951146807644818E0,
+    8.42404590141772420927E0,
+    5.21451598682361504063E0,
+    1.00000000000000000254E0,
+    0.0} ;
+
+
+constant double PQJ1[8] = {
+    5.71323128072548699714E-4,
+    6.88455908754495404082E-2,
+    1.10514232634061696926E0,
+    5.07386386128601488557E0,
+    8.39985554327604159757E0,
+    5.20982848682361821619E0,
+    9.99999999999999997461E-1,
+    0.0 };
+
+constant double QPJ1[8] = {
+    5.10862594750176621635E-2,
+    4.98213872951233449420E0,
+    7.58238284132545283818E1,
+    3.66779609360150777800E2,
+    7.10856304998926107277E2,
+    5.97489612400613639965E2,
+    2.11688757100572135698E2,
+    2.52070205858023719784E1 };
+
+constant double QQJ1[8] = {
+    7.42373277035675149943E1,
+    1.05644886038262816351E3,
+    4.98641058337653607651E3,
+    9.56231892404756170795E3,
+    7.99704160447350683650E3,
+    2.82619278517639096600E3,
+    3.36093607810698293419E2,
+    0.0 };
+
+#pragma acc declare copyin( RPJ1[0:8], RQJ1[0:8], PPJ1[0:8], PQJ1[0:8], QPJ1[0:8], QQJ1[0:8])
+
+#pragma acc routine seq
+static
+double cephes_j1(double x)
+{
+
+    double w, z, p, q, abs_x, sign_x;
+
+    const double Z1 = 1.46819706421238932572E1;
+    const double Z2 = 4.92184563216946036703E1;
+
+    // 2017-05-18 PAK - mathematica and mpmath use J1(-x) = -J1(x)
+    if (x < 0) {
+        abs_x = -x;
+        sign_x = -1.0;
+    } else {
+        abs_x = x;
+        sign_x = 1.0;
+    }
+
+    if( abs_x <= 5.0 ) {
+        z = abs_x * abs_x;
+        w = polevl( z, RPJ1, 3 ) / p1evl( z, RQJ1, 8 );
+        w = w * abs_x * (z - Z1) * (z - Z2);
+        return( sign_x * w );
+    }
+
+    w = 5.0/abs_x;
+    z = w * w;
+    p = polevl( z, PPJ1, 6)/polevl( z, PQJ1, 6 );
+    q = polevl( z, QPJ1, 7)/p1evl( z, QQJ1, 7 );
+
+    // 2017-05-19 PAK improve accuracy using trig identies
+    // original:
+    //    const double THPIO4 =  2.35619449019234492885;
+    //    const double SQ2OPI = 0.79788456080286535588;
+    //    double sin_xn, cos_xn;
+    //    SINCOS(abs_x - THPIO4, sin_xn, cos_xn);
+    //    p = p * cos_xn - w * q * sin_xn;
+    //    return( sign_x * p * SQ2OPI / sqrt(abs_x) );
+    // expanding p*cos(a - 3 pi/4) - wq sin(a - 3 pi/4)
+    //    [ p(sin(a) - cos(a)) + wq(sin(a) + cos(a)) / sqrt(2)
+    // note that sqrt(1/2) * sqrt(2/pi) = sqrt(1/pi)
+    const double SQRT1_PI = 0.56418958354775628;
+    double sin_x, cos_x;
+    SINCOS(abs_x, sin_x, cos_x);
+    p = p*(sin_x - cos_x) + w*q*(sin_x + cos_x);
+    return( sign_x * p * SQRT1_PI / sqrt(abs_x) );
+}
+
+#else
+//Single precission version of cephes
+
+constant float JPJ1[8] = {
+    -4.878788132172128E-009,
+    6.009061827883699E-007,
+    -4.541343896997497E-005,
+    1.937383947804541E-003,
+    -3.405537384615824E-002,
+    0.0,
+    0.0,
+    0.0
+    };
+
+constant float MO1J1[8] = {
+    6.913942741265801E-002,
+    -2.284801500053359E-001,
+    3.138238455499697E-001,
+    -2.102302420403875E-001,
+    5.435364690523026E-003,
+    1.493389585089498E-001,
+    4.976029650847191E-006,
+    7.978845453073848E-001
+    };
+
+constant float PH1J1[8] = {
+    -4.497014141919556E+001,
+    5.073465654089319E+001,
+    -2.485774108720340E+001,
+    7.222973196770240E+000,
+    -1.544842782180211E+000,
+    3.503787691653334E-001,
+    -1.637986776941202E-001,
+    3.749989509080821E-001
+    };
+
+#pragma acc declare copyin( JPJ1[0:8], MO1J1[0:8], PH1J1[0:8])
+
+#pragma acc routine seq
+static
+float cephes_j1f(float xx)
+{
+
+    float x, w, z, p, q, xn;
+
+    const float Z1 = 1.46819706421238932572E1;
+
+
+    // 2017-05-18 PAK - mathematica and mpmath use J1(-x) = -J1(x)
+    x = xx;
+    if( x < 0 )
+        x = -xx;
+
+    if( x <= 2.0 ) {
+        z = x * x;
+        p = (z-Z1) * x * polevl( z, JPJ1, 4 );
+        return( xx < 0. ? -p : p );
+    }
+
+    q = 1.0/x;
+    w = sqrt(q);
+
+    p = w * polevl( q, MO1J1, 7);
+    w = q*q;
+    // 2017-05-19 PAK improve accuracy using trig identies
+    // original:
+    //    const float THPIO4F =  2.35619449019234492885;    /* 3*pi/4 */
+    //    xn = q * polevl( w, PH1J1, 7) - THPIO4F;
+    //    p = p * cos(xn + x);
+    //    return( xx < 0. ? -p : p );
+    // expanding cos(a + b - 3 pi/4) is
+    //    [sin(a)sin(b) + sin(a)cos(b) + cos(a)sin(b)-cos(a)cos(b)] / sqrt(2)
+    xn = q * polevl( w, PH1J1, 7);
+    float cos_xn, sin_xn;
+    float cos_x, sin_x;
+    SINCOS(xn, sin_xn, cos_xn);  // about xn and 1
+    SINCOS(x, sin_x, cos_x);
+    p *= M_SQRT1_2*(sin_xn*(sin_x+cos_x) + cos_xn*(sin_x-cos_x));
+
+    return( xx < 0. ? -p : p );
+}
+#endif
+
+#if FLOAT_SIZE>4
+#define sas_J1 cephes_j1
+#else
+#define sas_J1 cephes_j1f
+#endif
+
+//Finally J1c function that equals 2*J1(x)/x
+    
+#pragma acc routine seq
+static
+double sas_2J1x_x(double x)
+{
+    return (x != 0.0 ) ? 2.0*sas_J1(x)/x : 1.0;
+}
+
+
+#line 1 ".././models/lib/gauss76.c"
+
+// Created by Andrew Jackson on 4/23/07
+
+ #ifdef GAUSS_N
+ # undef GAUSS_N
+ # undef GAUSS_Z
+ # undef GAUSS_W
+ #endif
+ #define GAUSS_N 76
+ #define GAUSS_Z Gauss76Z
+ #define GAUSS_W Gauss76Wt
+
+// Gaussians
+constant double Gauss76Wt[76] = {
+	.00126779163408536,		//0
+	.00294910295364247,
+	.00462793522803742,
+	.00629918049732845,
+	.00795984747723973,
+	.00960710541471375,
+	.0112381685696677,
+	.0128502838475101,
+	.0144407317482767,
+	.0160068299122486,
+	.0175459372914742,		//10
+	.0190554584671906,
+	.020532847967908,
+	.0219756145344162,
+	.0233813253070112,
+	.0247476099206597,
+	.026072164497986,
+	.0273527555318275,
+	.028587223650054,
+	.029773487255905,
+	.0309095460374916,		//20
+	.0319934843404216,
+	.0330234743977917,
+	.0339977794120564,
+	.0349147564835508,
+	.0357728593807139,
+	.0365706411473296,
+	.0373067565423816,
+	.0379799643084053,
+	.0385891292645067,
+	.0391332242205184,		//30
+	.0396113317090621,
+	.0400226455325968,
+	.040366472122844,
+	.0406422317102947,
+	.0408494593018285,
+	.040987805464794,
+	.0410570369162294,
+	.0410570369162294,
+	.040987805464794,
+	.0408494593018285,		//40
+	.0406422317102947,
+	.040366472122844,
+	.0400226455325968,
+	.0396113317090621,
+	.0391332242205184,
+	.0385891292645067,
+	.0379799643084053,
+	.0373067565423816,
+	.0365706411473296,
+	.0357728593807139,		//50
+	.0349147564835508,
+	.0339977794120564,
+	.0330234743977917,
+	.0319934843404216,
+	.0309095460374916,
+	.029773487255905,
+	.028587223650054,
+	.0273527555318275,
+	.026072164497986,
+	.0247476099206597,		//60
+	.0233813253070112,
+	.0219756145344162,
+	.020532847967908,
+	.0190554584671906,
+	.0175459372914742,
+	.0160068299122486,
+	.0144407317482767,
+	.0128502838475101,
+	.0112381685696677,
+	.00960710541471375,		//70
+	.00795984747723973,
+	.00629918049732845,
+	.00462793522803742,
+	.00294910295364247,
+	.00126779163408536		//75 (indexed from 0)
+};
+
+constant double Gauss76Z[76] = {
+	-.999505948362153,		//0
+	-.997397786355355,
+	-.993608772723527,
+	-.988144453359837,
+	-.981013938975656,
+	-.972229228520377,
+	-.961805126758768,
+	-.949759207710896,
+	-.936111781934811,
+	-.92088586125215,
+	-.904107119545567,		//10
+	-.885803849292083,
+	-.866006913771982,
+	-.844749694983342,
+	-.822068037328975,
+	-.7980001871612,
+	-.77258672828181,
+	-.74587051350361,
+	-.717896592387704,
+	-.688712135277641,
+	-.658366353758143,		//20
+	-.626910417672267,
+	-.594397368836793,
+	-.560882031601237,
+	-.526420920401243,
+	-.491072144462194,
+	-.454895309813726,
+	-.417951418780327,
+	-.380302767117504,
+	-.342012838966962,
+	-.303146199807908,		//30
+	-.263768387584994,
+	-.223945802196474,
+	-.183745593528914,
+	-.143235548227268,
+	-.102483975391227,
+	-.0615595913906112,
+	-.0205314039939986,
+	.0205314039939986,
+	.0615595913906112,
+	.102483975391227,			//40
+	.143235548227268,
+	.183745593528914,
+	.223945802196474,
+	.263768387584994,
+	.303146199807908,
+	.342012838966962,
+	.380302767117504,
+	.417951418780327,
+	.454895309813726,
+	.491072144462194,		//50
+	.526420920401243,
+	.560882031601237,
+	.594397368836793,
+	.626910417672267,
+	.658366353758143,
+	.688712135277641,
+	.717896592387704,
+	.74587051350361,
+	.77258672828181,
+	.7980001871612,	//60
+	.822068037328975,
+	.844749694983342,
+	.866006913771982,
+	.885803849292083,
+	.904107119545567,
+	.92088586125215,
+	.936111781934811,
+	.949759207710896,
+	.961805126758768,
+	.972229228520377,		//70
+	.981013938975656,
+	.988144453359837,
+	.993608772723527,
+	.997397786355355,
+	.999505948362153		//75
+};
+
+
+#pragma acc declare copyin(Gauss76Wt[0:76], Gauss76Z[0:76])
+
+#line 1 ".././models/core_shell_bicelle.c"
+
+static double
+form_volume(double radius, double thick_rim, double thick_face, double length)
+{
+    return M_PI*square(radius+thick_rim)*(length+2.0*thick_face);
+}
+
+static double
+bicelle_kernel(double qab,
+    double qc,
+    double radius,
+    double thick_radius,
+    double thick_face,
+    double halflength,
+    double sld_core,
+    double sld_face,
+    double sld_rim,
+    double sld_solvent)
+{
+    const double dr1 = sld_core-sld_face;
+    const double dr2 = sld_rim-sld_solvent;
+    const double dr3 = sld_face-sld_rim;
+    const double vol1 = M_PI*square(radius)*2.0*(halflength);
+    const double vol2 = M_PI*square(radius+thick_radius)*2.0*(halflength+thick_face);
+    const double vol3 = M_PI*square(radius)*2.0*(halflength+thick_face);
+
+    const double be1 = sas_2J1x_x((radius)*qab);
+    const double be2 = sas_2J1x_x((radius+thick_radius)*qab);
+    const double si1 = sas_sinx_x((halflength)*qc);
+    const double si2 = sas_sinx_x((halflength+thick_face)*qc);
+
+    const double t = vol1*dr1*si1*be1 +
+                     vol2*dr2*si2*be2 +
+                     vol3*dr3*si2*be1;
+
+    return t;
+}
+
+static double
+radius_from_excluded_volume(double radius, double thick_rim, double thick_face, double length)
+{
+    const double radius_tot = radius + thick_rim;
+    const double length_tot = length + 2.0*thick_face;
+    return 0.5*cbrt(0.75*radius_tot*(2.0*radius_tot*length_tot + (radius_tot + length_tot)*(M_PI*radius_tot + length_tot)));
+}
+
+static double
+radius_from_volume(double radius, double thick_rim, double thick_face, double length)
+{
+    const double volume_bicelle = form_volume(radius,thick_rim,thick_face,length);
+    return cbrt(volume_bicelle/M_4PI_3);
+}
+
+static double
+radius_from_diagonal(double radius, double thick_rim, double thick_face, double length)
+{
+    const double radius_tot = radius + thick_rim;
+    const double length_tot = length + 2.0*thick_face;
+    return sqrt(radius_tot*radius_tot + 0.25*length_tot*length_tot);
+}
+
+static double
+radius_effective(int mode, double radius, double thick_rim, double thick_face, double length)
+{
+    switch (mode) {
+    default:
+    case 1: // equivalent cylinder excluded volume
+        return radius_from_excluded_volume(radius, thick_rim, thick_face, length);
+    case 2: // equivalent sphere
+        return radius_from_volume(radius, thick_rim, thick_face, length);
+    case 3: // outer rim radius
+        return radius + thick_rim;
+    case 4: // half outer thickness
+        return 0.5*length + thick_face;
+    case 5: // half diagonal
+        return radius_from_diagonal(radius,thick_rim,thick_face,length);
+    }
+}
+
+static void
+Fq(double q,
+    double *F1,
+    double *F2,
+    double radius,
+    double thick_radius,
+    double thick_face,
+    double length,
+    double sld_core,
+    double sld_face,
+    double sld_rim,
+    double sld_solvent)
+{
+    // set up the integration end points
+    const double uplim = M_PI_4;
+    const double halflength = 0.5*length;
+
+    double total_F1 = 0.0;
+    double total_F2 = 0.0;
+    for(int i=0;i<GAUSS_N;i++) {
+        double theta = (GAUSS_Z[i] + 1.0)*uplim;
+        double sin_theta, cos_theta; // slots to hold sincos function output
+        SINCOS(theta, sin_theta, cos_theta);
+        double form = bicelle_kernel(q*sin_theta, q*cos_theta, radius, thick_radius, thick_face,
+                                   halflength, sld_core, sld_face, sld_rim, sld_solvent);
+        total_F1 += GAUSS_W[i]*form*sin_theta;
+        total_F2 += GAUSS_W[i]*form*form*sin_theta;
+    }
+    // Correct for integration range
+    total_F1 *= uplim;
+    total_F2 *= uplim;
+
+    *F1 = 1.0e-2*total_F1;
+    *F2 = 1.0e-4*total_F2;
+}
+
+static double
+Iqac(double qab, double qc,
+    double radius,
+    double thick_rim,
+    double thick_face,
+    double length,
+    double core_sld,
+    double face_sld,
+    double rim_sld,
+    double solvent_sld)
+{
+    double fq = bicelle_kernel(qab, qc, radius, thick_rim, thick_face,
+                           0.5*length, core_sld, face_sld, rim_sld,
+                           solvent_sld);
+    return 1.0e-4*fq*fq;
+}
+
+

--- a/mcstas-comps/share/sas_core_shell_bicelle_elliptical.c
+++ b/mcstas-comps/share/sas_core_shell_bicelle_elliptical.c
@@ -1,0 +1,1099 @@
+#define HAS_Iqabc
+#define HAS_FQ
+#define FORM_VOL
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/sas_Si.c"
+
+// integral of sin(x)/x Taylor series approximated to w/i 0.1%
+double sas_Si(double x);
+
+    
+#pragma acc routine seq
+double sas_Si(double x)
+{
+    if (x >= M_PI*6.2/4.0) {
+        const double xxinv = 1./(x*x);
+        // Explicitly writing factorial values triples the speed of the calculation
+        const double out_cos = (((-720.*xxinv + 24.)*xxinv - 2.)*xxinv + 1.)/x;
+        const double out_sin = (((-5040.*xxinv + 120.)*xxinv - 6.)*xxinv + 1)*xxinv;
+
+        double sin_x, cos_x;
+        SINCOS(x, sin_x, cos_x);
+        return M_PI_2 - cos_x*out_cos - sin_x*out_sin;
+    } else {
+        const double xx = x*x;
+        // Explicitly writing factorial values triples the speed of the calculation
+        return (((((-1./439084800.*xx
+            + 1./3265920.)*xx
+            - 1./35280.)*xx
+            + 1./600.)*xx
+            - 1./18.)*xx
+            + 1.)*x;
+    }
+}
+
+
+#line 1 ".././models/lib/polevl.c"
+
+/*							polevl.c
+ *							p1evl.c
+ *
+ *	Evaluate polynomial
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * int N;
+ * double x, y, coef[N+1], polevl[];
+ *
+ * y = polevl( x, coef, N );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Evaluates polynomial of degree N:
+ *
+ *                     2          N
+ * y  =  C  + C x + C x  +...+ C x
+ *        0    1     2          N
+ *
+ * Coefficients are stored in reverse order:
+ *
+ * coef[0] = C  , ..., coef[N] = C  .
+ *            N                   0
+ *
+ * The function p1evl() assumes that C_N = 1.0 and is
+ * omitted from the array.  Its calling arguments are
+ * otherwise the same as polevl().
+ *
+ *
+ * SPEED:
+ *
+ * In the interest of speed, there are no checks for out
+ * of bounds arithmetic.  This routine is used by most of
+ * the functions in the library.  Depending on available
+ * equipment features, the user may wish to rewrite the
+ * program in microcode or assembly language.
+ *
+ */
+
+
+/*
+Cephes Math Library Release 2.1:  December, 1988
+Copyright 1984, 1987, 1988 by Stephen L. Moshier
+Direct inquiries to 30 Frost Street, Cambridge, MA 02140
+*/
+#pragma acc routine seq
+static
+double polevl( double x, pconstant double *coef, int N )
+{
+
+    int i = 0;
+    double ans = coef[i];
+
+    while (i < N) {
+        i++;
+        ans = ans * x + coef[i];
+    }
+
+    return ans;
+}
+
+/*							p1evl()	*/
+/*                                          N
+ * Evaluate polynomial when coefficient of x  is 1.0.
+ * Otherwise same as polevl.
+ */
+#pragma acc routine seq
+static
+double p1evl( double x, pconstant double *coef, int N )
+{
+    int i=0;
+    double ans = x+coef[i];
+
+    while (i < N-1) {
+        i++;
+        ans = ans*x + coef[i];
+    }
+
+    return ans;
+}
+
+
+#line 1 ".././models/lib/sas_J1.c"
+
+/*							j1.c
+ *
+ *	Bessel function of order one
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * double x, y, j1();
+ *
+ * y = j1( x );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Returns Bessel function of order one of the argument.
+ *
+ * The domain is divided into the intervals [0, 8] and
+ * (8, infinity). In the first interval a 24 term Chebyshev
+ * expansion is used. In the second, the asymptotic
+ * trigonometric representation is employed using two
+ * rational functions of degree 5/5.
+ *
+ *
+ *
+ * ACCURACY:
+ *
+ *                      Absolute error:
+ * arithmetic   domain      # trials      peak         rms
+ *    DEC       0, 30       10000       4.0e-17     1.1e-17
+ *    IEEE      0, 30       30000       2.6e-16     1.1e-16
+ *
+ *
+ */
+
+/*
+Cephes Math Library Release 2.8:  June, 2000
+Copyright 1984, 1987, 1989, 2000 by Stephen L. Moshier
+*/
+
+#if FLOAT_SIZE>4
+//Cephes double pression function
+
+constant double RPJ1[8] = {
+    -8.99971225705559398224E8,
+    4.52228297998194034323E11,
+    -7.27494245221818276015E13,
+    3.68295732863852883286E15,
+    0.0,
+    0.0,
+    0.0,
+    0.0 };
+
+constant double RQJ1[8] = {
+    6.20836478118054335476E2,
+    2.56987256757748830383E5,
+    8.35146791431949253037E7,
+    2.21511595479792499675E10,
+    4.74914122079991414898E12,
+    7.84369607876235854894E14,
+    8.95222336184627338078E16,
+    5.32278620332680085395E18
+    };
+
+constant double PPJ1[8] = {
+    7.62125616208173112003E-4,
+    7.31397056940917570436E-2,
+    1.12719608129684925192E0,
+    5.11207951146807644818E0,
+    8.42404590141772420927E0,
+    5.21451598682361504063E0,
+    1.00000000000000000254E0,
+    0.0} ;
+
+
+constant double PQJ1[8] = {
+    5.71323128072548699714E-4,
+    6.88455908754495404082E-2,
+    1.10514232634061696926E0,
+    5.07386386128601488557E0,
+    8.39985554327604159757E0,
+    5.20982848682361821619E0,
+    9.99999999999999997461E-1,
+    0.0 };
+
+constant double QPJ1[8] = {
+    5.10862594750176621635E-2,
+    4.98213872951233449420E0,
+    7.58238284132545283818E1,
+    3.66779609360150777800E2,
+    7.10856304998926107277E2,
+    5.97489612400613639965E2,
+    2.11688757100572135698E2,
+    2.52070205858023719784E1 };
+
+constant double QQJ1[8] = {
+    7.42373277035675149943E1,
+    1.05644886038262816351E3,
+    4.98641058337653607651E3,
+    9.56231892404756170795E3,
+    7.99704160447350683650E3,
+    2.82619278517639096600E3,
+    3.36093607810698293419E2,
+    0.0 };
+
+#pragma acc declare copyin( RPJ1[0:8], RQJ1[0:8], PPJ1[0:8], PQJ1[0:8], QPJ1[0:8], QQJ1[0:8])
+
+#pragma acc routine seq
+static
+double cephes_j1(double x)
+{
+
+    double w, z, p, q, abs_x, sign_x;
+
+    const double Z1 = 1.46819706421238932572E1;
+    const double Z2 = 4.92184563216946036703E1;
+
+    // 2017-05-18 PAK - mathematica and mpmath use J1(-x) = -J1(x)
+    if (x < 0) {
+        abs_x = -x;
+        sign_x = -1.0;
+    } else {
+        abs_x = x;
+        sign_x = 1.0;
+    }
+
+    if( abs_x <= 5.0 ) {
+        z = abs_x * abs_x;
+        w = polevl( z, RPJ1, 3 ) / p1evl( z, RQJ1, 8 );
+        w = w * abs_x * (z - Z1) * (z - Z2);
+        return( sign_x * w );
+    }
+
+    w = 5.0/abs_x;
+    z = w * w;
+    p = polevl( z, PPJ1, 6)/polevl( z, PQJ1, 6 );
+    q = polevl( z, QPJ1, 7)/p1evl( z, QQJ1, 7 );
+
+    // 2017-05-19 PAK improve accuracy using trig identies
+    // original:
+    //    const double THPIO4 =  2.35619449019234492885;
+    //    const double SQ2OPI = 0.79788456080286535588;
+    //    double sin_xn, cos_xn;
+    //    SINCOS(abs_x - THPIO4, sin_xn, cos_xn);
+    //    p = p * cos_xn - w * q * sin_xn;
+    //    return( sign_x * p * SQ2OPI / sqrt(abs_x) );
+    // expanding p*cos(a - 3 pi/4) - wq sin(a - 3 pi/4)
+    //    [ p(sin(a) - cos(a)) + wq(sin(a) + cos(a)) / sqrt(2)
+    // note that sqrt(1/2) * sqrt(2/pi) = sqrt(1/pi)
+    const double SQRT1_PI = 0.56418958354775628;
+    double sin_x, cos_x;
+    SINCOS(abs_x, sin_x, cos_x);
+    p = p*(sin_x - cos_x) + w*q*(sin_x + cos_x);
+    return( sign_x * p * SQRT1_PI / sqrt(abs_x) );
+}
+
+#else
+//Single precission version of cephes
+
+constant float JPJ1[8] = {
+    -4.878788132172128E-009,
+    6.009061827883699E-007,
+    -4.541343896997497E-005,
+    1.937383947804541E-003,
+    -3.405537384615824E-002,
+    0.0,
+    0.0,
+    0.0
+    };
+
+constant float MO1J1[8] = {
+    6.913942741265801E-002,
+    -2.284801500053359E-001,
+    3.138238455499697E-001,
+    -2.102302420403875E-001,
+    5.435364690523026E-003,
+    1.493389585089498E-001,
+    4.976029650847191E-006,
+    7.978845453073848E-001
+    };
+
+constant float PH1J1[8] = {
+    -4.497014141919556E+001,
+    5.073465654089319E+001,
+    -2.485774108720340E+001,
+    7.222973196770240E+000,
+    -1.544842782180211E+000,
+    3.503787691653334E-001,
+    -1.637986776941202E-001,
+    3.749989509080821E-001
+    };
+
+#pragma acc declare copyin( JPJ1[0:8], MO1J1[0:8], PH1J1[0:8])
+
+#pragma acc routine seq
+static
+float cephes_j1f(float xx)
+{
+
+    float x, w, z, p, q, xn;
+
+    const float Z1 = 1.46819706421238932572E1;
+
+
+    // 2017-05-18 PAK - mathematica and mpmath use J1(-x) = -J1(x)
+    x = xx;
+    if( x < 0 )
+        x = -xx;
+
+    if( x <= 2.0 ) {
+        z = x * x;
+        p = (z-Z1) * x * polevl( z, JPJ1, 4 );
+        return( xx < 0. ? -p : p );
+    }
+
+    q = 1.0/x;
+    w = sqrt(q);
+
+    p = w * polevl( q, MO1J1, 7);
+    w = q*q;
+    // 2017-05-19 PAK improve accuracy using trig identies
+    // original:
+    //    const float THPIO4F =  2.35619449019234492885;    /* 3*pi/4 */
+    //    xn = q * polevl( w, PH1J1, 7) - THPIO4F;
+    //    p = p * cos(xn + x);
+    //    return( xx < 0. ? -p : p );
+    // expanding cos(a + b - 3 pi/4) is
+    //    [sin(a)sin(b) + sin(a)cos(b) + cos(a)sin(b)-cos(a)cos(b)] / sqrt(2)
+    xn = q * polevl( w, PH1J1, 7);
+    float cos_xn, sin_xn;
+    float cos_x, sin_x;
+    SINCOS(xn, sin_xn, cos_xn);  // about xn and 1
+    SINCOS(x, sin_x, cos_x);
+    p *= M_SQRT1_2*(sin_xn*(sin_x+cos_x) + cos_xn*(sin_x-cos_x));
+
+    return( xx < 0. ? -p : p );
+}
+#endif
+
+#if FLOAT_SIZE>4
+#define sas_J1 cephes_j1
+#else
+#define sas_J1 cephes_j1f
+#endif
+
+//Finally J1c function that equals 2*J1(x)/x
+    
+#pragma acc routine seq
+static
+double sas_2J1x_x(double x)
+{
+    return (x != 0.0 ) ? 2.0*sas_J1(x)/x : 1.0;
+}
+
+
+#line 1 ".././models/lib/gauss76.c"
+
+// Created by Andrew Jackson on 4/23/07
+
+ #ifdef GAUSS_N
+ # undef GAUSS_N
+ # undef GAUSS_Z
+ # undef GAUSS_W
+ #endif
+ #define GAUSS_N 76
+ #define GAUSS_Z Gauss76Z
+ #define GAUSS_W Gauss76Wt
+
+// Gaussians
+constant double Gauss76Wt[76] = {
+	.00126779163408536,		//0
+	.00294910295364247,
+	.00462793522803742,
+	.00629918049732845,
+	.00795984747723973,
+	.00960710541471375,
+	.0112381685696677,
+	.0128502838475101,
+	.0144407317482767,
+	.0160068299122486,
+	.0175459372914742,		//10
+	.0190554584671906,
+	.020532847967908,
+	.0219756145344162,
+	.0233813253070112,
+	.0247476099206597,
+	.026072164497986,
+	.0273527555318275,
+	.028587223650054,
+	.029773487255905,
+	.0309095460374916,		//20
+	.0319934843404216,
+	.0330234743977917,
+	.0339977794120564,
+	.0349147564835508,
+	.0357728593807139,
+	.0365706411473296,
+	.0373067565423816,
+	.0379799643084053,
+	.0385891292645067,
+	.0391332242205184,		//30
+	.0396113317090621,
+	.0400226455325968,
+	.040366472122844,
+	.0406422317102947,
+	.0408494593018285,
+	.040987805464794,
+	.0410570369162294,
+	.0410570369162294,
+	.040987805464794,
+	.0408494593018285,		//40
+	.0406422317102947,
+	.040366472122844,
+	.0400226455325968,
+	.0396113317090621,
+	.0391332242205184,
+	.0385891292645067,
+	.0379799643084053,
+	.0373067565423816,
+	.0365706411473296,
+	.0357728593807139,		//50
+	.0349147564835508,
+	.0339977794120564,
+	.0330234743977917,
+	.0319934843404216,
+	.0309095460374916,
+	.029773487255905,
+	.028587223650054,
+	.0273527555318275,
+	.026072164497986,
+	.0247476099206597,		//60
+	.0233813253070112,
+	.0219756145344162,
+	.020532847967908,
+	.0190554584671906,
+	.0175459372914742,
+	.0160068299122486,
+	.0144407317482767,
+	.0128502838475101,
+	.0112381685696677,
+	.00960710541471375,		//70
+	.00795984747723973,
+	.00629918049732845,
+	.00462793522803742,
+	.00294910295364247,
+	.00126779163408536		//75 (indexed from 0)
+};
+
+constant double Gauss76Z[76] = {
+	-.999505948362153,		//0
+	-.997397786355355,
+	-.993608772723527,
+	-.988144453359837,
+	-.981013938975656,
+	-.972229228520377,
+	-.961805126758768,
+	-.949759207710896,
+	-.936111781934811,
+	-.92088586125215,
+	-.904107119545567,		//10
+	-.885803849292083,
+	-.866006913771982,
+	-.844749694983342,
+	-.822068037328975,
+	-.7980001871612,
+	-.77258672828181,
+	-.74587051350361,
+	-.717896592387704,
+	-.688712135277641,
+	-.658366353758143,		//20
+	-.626910417672267,
+	-.594397368836793,
+	-.560882031601237,
+	-.526420920401243,
+	-.491072144462194,
+	-.454895309813726,
+	-.417951418780327,
+	-.380302767117504,
+	-.342012838966962,
+	-.303146199807908,		//30
+	-.263768387584994,
+	-.223945802196474,
+	-.183745593528914,
+	-.143235548227268,
+	-.102483975391227,
+	-.0615595913906112,
+	-.0205314039939986,
+	.0205314039939986,
+	.0615595913906112,
+	.102483975391227,			//40
+	.143235548227268,
+	.183745593528914,
+	.223945802196474,
+	.263768387584994,
+	.303146199807908,
+	.342012838966962,
+	.380302767117504,
+	.417951418780327,
+	.454895309813726,
+	.491072144462194,		//50
+	.526420920401243,
+	.560882031601237,
+	.594397368836793,
+	.626910417672267,
+	.658366353758143,
+	.688712135277641,
+	.717896592387704,
+	.74587051350361,
+	.77258672828181,
+	.7980001871612,	//60
+	.822068037328975,
+	.844749694983342,
+	.866006913771982,
+	.885803849292083,
+	.904107119545567,
+	.92088586125215,
+	.936111781934811,
+	.949759207710896,
+	.961805126758768,
+	.972229228520377,		//70
+	.981013938975656,
+	.988144453359837,
+	.993608772723527,
+	.997397786355355,
+	.999505948362153		//75
+};
+
+
+#pragma acc declare copyin(Gauss76Wt[0:76], Gauss76Z[0:76])
+
+#line 1 ".././models/core_shell_bicelle_elliptical.c"
+
+// NOTE that "length" here is the full height of the core!
+static double
+form_volume(double r_minor,
+    double x_core,
+    double thick_rim,
+    double thick_face,
+    double length)
+{
+    return M_PI*(r_minor+thick_rim)*(r_minor*x_core+thick_rim)*(length+2.0*thick_face);
+}
+
+static double
+radius_from_excluded_volume(double r_minor, double x_core, double thick_rim, double thick_face, double length)
+{
+    const double r_equiv     = sqrt((r_minor + thick_rim)*(r_minor*x_core + thick_rim));
+    const double length_tot  = length + 2.0*thick_face;
+    return 0.5*cbrt(0.75*r_equiv*(2.0*r_equiv*length_tot + (r_equiv + length_tot)*(M_PI*r_equiv + length_tot)));
+}
+
+static double
+radius_from_volume(double r_minor, double x_core, double thick_rim, double thick_face, double length)
+{
+    const double volume_bicelle = form_volume(r_minor, x_core, thick_rim,thick_face,length);
+    return cbrt(volume_bicelle/M_4PI_3);
+}
+
+static double
+radius_from_diagonal(double r_minor, double x_core, double thick_rim, double thick_face, double length)
+{
+    const double radius_max = (x_core < 1.0 ? r_minor : x_core*r_minor);
+    const double radius_max_tot = radius_max + thick_rim;
+    const double length_tot = length + 2.0*thick_face;
+    return sqrt(radius_max_tot*radius_max_tot + 0.25*length_tot*length_tot);
+}
+
+static double
+radius_effective(int mode, double r_minor, double x_core, double thick_rim, double thick_face, double length)
+{
+    switch (mode) {
+    default:
+    case 1: // equivalent cylinder excluded volume
+        return radius_from_excluded_volume(r_minor, x_core, thick_rim, thick_face, length);
+    case 2: // equivalent volume sphere
+        return radius_from_volume(r_minor, x_core, thick_rim, thick_face, length);
+    case 3: // outer rim average radius
+        return 0.5*r_minor*(1.0 + x_core) + thick_rim;
+    case 4: // outer rim min radius
+        return (x_core < 1.0 ? x_core*r_minor+thick_rim : r_minor+thick_rim);
+    case 5: // outer max radius
+        return (x_core > 1.0 ? x_core*r_minor+thick_rim : r_minor+thick_rim);
+    case 6: // half outer thickness
+        return 0.5*length + thick_face;
+    case 7: // half diagonal
+        return radius_from_diagonal(r_minor,x_core,thick_rim,thick_face,length);
+    }
+}
+
+static void
+Fq(double q,
+    double *F1,
+    double *F2,
+    double r_minor,
+    double x_core,
+    double thick_rim,
+    double thick_face,
+    double length,
+    double sld_core,
+    double sld_face,
+    double sld_rim,
+    double sld_solvent)
+{
+     // core_shell_bicelle_elliptical, RKH Dec 2016, based on elliptical_cylinder and core_shell_bicelle
+     // tested against limiting cases of cylinder, elliptical_cylinder, stacked_discs, and core_shell_bicelle
+    const double halfheight = 0.5*length;
+    const double r_major = r_minor * x_core;
+    const double r2A = 0.5*(square(r_major) + square(r_minor));
+    const double r2B = 0.5*(square(r_major) - square(r_minor));
+    const double vol1 = M_PI*r_minor*r_major*(2.0*halfheight);
+    const double vol2 = M_PI*(r_minor+thick_rim)*(r_major+thick_rim)*2.0*(halfheight+thick_face);
+    const double vol3 = M_PI*r_minor*r_major*2.0*(halfheight+thick_face);
+    const double dr1 = vol1*(sld_core-sld_face);
+    const double dr2 = vol2*(sld_rim-sld_solvent);
+    const double dr3 = vol3*(sld_face-sld_rim);
+
+    //initialize integral
+    double outer_total_F1 = 0.0;
+    double outer_total_F2 = 0.0;
+    for(int i=0;i<GAUSS_N;i++) {
+        //setup inner integral over the ellipsoidal cross-section
+        //const double cos_theta = ( GAUSS_Z[i]*(vb-va) + va + vb )/2.0;
+        const double cos_theta = ( GAUSS_Z[i] + 1.0 )/2.0;
+        const double sin_theta = sqrt(1.0 - cos_theta*cos_theta);
+        const double qab = q*sin_theta;
+        const double qc = q*cos_theta;
+        const double si1 = sas_sinx_x(halfheight*qc);
+        const double si2 = sas_sinx_x((halfheight+thick_face)*qc);
+        double inner_total_F1 = 0;
+        double inner_total_F2 = 0;
+        for(int j=0;j<GAUSS_N;j++) {
+            //76 gauss points for the inner integral (WAS 20 points,so this may make unecessarily slow, but playing safe)
+            //const double beta = ( GAUSS_Z[j]*(vbj-vaj) + vaj + vbj )/2.0;
+            const double beta = ( GAUSS_Z[j] +1.0)*M_PI_2;
+            const double rr = sqrt(r2A - r2B*cos(beta));
+            const double be1 = sas_2J1x_x(rr*qab);
+            const double be2 = sas_2J1x_x((rr+thick_rim)*qab);
+            const double f = dr1*si1*be1 + dr2*si2*be2 + dr3*si2*be1;
+
+            inner_total_F1 += GAUSS_W[j] * f;
+            inner_total_F2 += GAUSS_W[j] * f * f;
+        }
+        //now calculate outer integral
+        outer_total_F1 += GAUSS_W[i] * inner_total_F1;
+        outer_total_F2 += GAUSS_W[i] * inner_total_F2;
+    }
+    // now complete change of integration variables (1-0)/(1-(-1))= 0.5
+    outer_total_F1 *= 0.25;
+    outer_total_F2 *= 0.25;
+
+    //convert from [1e-12 A-1] to [cm-1]
+    *F1 = 1e-2*outer_total_F1;
+    *F2 = 1e-4*outer_total_F2;
+}
+
+static double
+Iqabc(double qa, double qb, double qc,
+    double r_minor,
+    double x_core,
+    double thick_rim,
+    double thick_face,
+    double length,
+    double sld_core,
+    double sld_face,
+    double sld_rim,
+    double sld_solvent)
+{
+    const double dr1 = sld_core-sld_face;
+    const double dr2 = sld_rim-sld_solvent;
+    const double dr3 = sld_face-sld_rim;
+    const double r_major = r_minor*x_core;
+    const double halfheight = 0.5*length;
+    const double vol1 = M_PI*r_minor*r_major*length;
+    const double vol2 = M_PI*(r_minor+thick_rim)*(r_major+thick_rim)*2.0*(halfheight+thick_face);
+    const double vol3 = M_PI*r_minor*r_major*2.0*(halfheight+thick_face);
+
+    // Compute effective radius in rotated coordinates
+    const double qr_hat = sqrt(square(r_major*qb) + square(r_minor*qa));
+    const double qrshell_hat = sqrt(square((r_major+thick_rim)*qb)
+                                   + square((r_minor+thick_rim)*qa));
+    const double be1 = sas_2J1x_x( qr_hat );
+    const double be2 = sas_2J1x_x( qrshell_hat );
+    const double si1 = sas_sinx_x( halfheight*qc );
+    const double si2 = sas_sinx_x( (halfheight + thick_face)*qc );
+    const double fq = vol1*dr1*si1*be1 + vol2*dr2*si2*be2 +  vol3*dr3*si2*be1;
+    return 1.0e-4 * fq*fq;
+}
+
+

--- a/mcstas-comps/share/sas_core_shell_bicelle_elliptical_belt_rough.c
+++ b/mcstas-comps/share/sas_core_shell_bicelle_elliptical_belt_rough.c
@@ -1,0 +1,1116 @@
+#define HAS_Iqabc
+#define HAS_FQ
+#define FORM_VOL
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/sas_Si.c"
+
+// integral of sin(x)/x Taylor series approximated to w/i 0.1%
+double sas_Si(double x);
+
+    
+#pragma acc routine seq
+double sas_Si(double x)
+{
+    if (x >= M_PI*6.2/4.0) {
+        const double xxinv = 1./(x*x);
+        // Explicitly writing factorial values triples the speed of the calculation
+        const double out_cos = (((-720.*xxinv + 24.)*xxinv - 2.)*xxinv + 1.)/x;
+        const double out_sin = (((-5040.*xxinv + 120.)*xxinv - 6.)*xxinv + 1)*xxinv;
+
+        double sin_x, cos_x;
+        SINCOS(x, sin_x, cos_x);
+        return M_PI_2 - cos_x*out_cos - sin_x*out_sin;
+    } else {
+        const double xx = x*x;
+        // Explicitly writing factorial values triples the speed of the calculation
+        return (((((-1./439084800.*xx
+            + 1./3265920.)*xx
+            - 1./35280.)*xx
+            + 1./600.)*xx
+            - 1./18.)*xx
+            + 1.)*x;
+    }
+}
+
+
+#line 1 ".././models/lib/polevl.c"
+
+/*							polevl.c
+ *							p1evl.c
+ *
+ *	Evaluate polynomial
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * int N;
+ * double x, y, coef[N+1], polevl[];
+ *
+ * y = polevl( x, coef, N );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Evaluates polynomial of degree N:
+ *
+ *                     2          N
+ * y  =  C  + C x + C x  +...+ C x
+ *        0    1     2          N
+ *
+ * Coefficients are stored in reverse order:
+ *
+ * coef[0] = C  , ..., coef[N] = C  .
+ *            N                   0
+ *
+ * The function p1evl() assumes that C_N = 1.0 and is
+ * omitted from the array.  Its calling arguments are
+ * otherwise the same as polevl().
+ *
+ *
+ * SPEED:
+ *
+ * In the interest of speed, there are no checks for out
+ * of bounds arithmetic.  This routine is used by most of
+ * the functions in the library.  Depending on available
+ * equipment features, the user may wish to rewrite the
+ * program in microcode or assembly language.
+ *
+ */
+
+
+/*
+Cephes Math Library Release 2.1:  December, 1988
+Copyright 1984, 1987, 1988 by Stephen L. Moshier
+Direct inquiries to 30 Frost Street, Cambridge, MA 02140
+*/
+#pragma acc routine seq
+static
+double polevl( double x, pconstant double *coef, int N )
+{
+
+    int i = 0;
+    double ans = coef[i];
+
+    while (i < N) {
+        i++;
+        ans = ans * x + coef[i];
+    }
+
+    return ans;
+}
+
+/*							p1evl()	*/
+/*                                          N
+ * Evaluate polynomial when coefficient of x  is 1.0.
+ * Otherwise same as polevl.
+ */
+#pragma acc routine seq
+static
+double p1evl( double x, pconstant double *coef, int N )
+{
+    int i=0;
+    double ans = x+coef[i];
+
+    while (i < N-1) {
+        i++;
+        ans = ans*x + coef[i];
+    }
+
+    return ans;
+}
+
+
+#line 1 ".././models/lib/sas_J1.c"
+
+/*							j1.c
+ *
+ *	Bessel function of order one
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * double x, y, j1();
+ *
+ * y = j1( x );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Returns Bessel function of order one of the argument.
+ *
+ * The domain is divided into the intervals [0, 8] and
+ * (8, infinity). In the first interval a 24 term Chebyshev
+ * expansion is used. In the second, the asymptotic
+ * trigonometric representation is employed using two
+ * rational functions of degree 5/5.
+ *
+ *
+ *
+ * ACCURACY:
+ *
+ *                      Absolute error:
+ * arithmetic   domain      # trials      peak         rms
+ *    DEC       0, 30       10000       4.0e-17     1.1e-17
+ *    IEEE      0, 30       30000       2.6e-16     1.1e-16
+ *
+ *
+ */
+
+/*
+Cephes Math Library Release 2.8:  June, 2000
+Copyright 1984, 1987, 1989, 2000 by Stephen L. Moshier
+*/
+
+#if FLOAT_SIZE>4
+//Cephes double pression function
+
+constant double RPJ1[8] = {
+    -8.99971225705559398224E8,
+    4.52228297998194034323E11,
+    -7.27494245221818276015E13,
+    3.68295732863852883286E15,
+    0.0,
+    0.0,
+    0.0,
+    0.0 };
+
+constant double RQJ1[8] = {
+    6.20836478118054335476E2,
+    2.56987256757748830383E5,
+    8.35146791431949253037E7,
+    2.21511595479792499675E10,
+    4.74914122079991414898E12,
+    7.84369607876235854894E14,
+    8.95222336184627338078E16,
+    5.32278620332680085395E18
+    };
+
+constant double PPJ1[8] = {
+    7.62125616208173112003E-4,
+    7.31397056940917570436E-2,
+    1.12719608129684925192E0,
+    5.11207951146807644818E0,
+    8.42404590141772420927E0,
+    5.21451598682361504063E0,
+    1.00000000000000000254E0,
+    0.0} ;
+
+
+constant double PQJ1[8] = {
+    5.71323128072548699714E-4,
+    6.88455908754495404082E-2,
+    1.10514232634061696926E0,
+    5.07386386128601488557E0,
+    8.39985554327604159757E0,
+    5.20982848682361821619E0,
+    9.99999999999999997461E-1,
+    0.0 };
+
+constant double QPJ1[8] = {
+    5.10862594750176621635E-2,
+    4.98213872951233449420E0,
+    7.58238284132545283818E1,
+    3.66779609360150777800E2,
+    7.10856304998926107277E2,
+    5.97489612400613639965E2,
+    2.11688757100572135698E2,
+    2.52070205858023719784E1 };
+
+constant double QQJ1[8] = {
+    7.42373277035675149943E1,
+    1.05644886038262816351E3,
+    4.98641058337653607651E3,
+    9.56231892404756170795E3,
+    7.99704160447350683650E3,
+    2.82619278517639096600E3,
+    3.36093607810698293419E2,
+    0.0 };
+
+#pragma acc declare copyin( RPJ1[0:8], RQJ1[0:8], PPJ1[0:8], PQJ1[0:8], QPJ1[0:8], QQJ1[0:8])
+
+#pragma acc routine seq
+static
+double cephes_j1(double x)
+{
+
+    double w, z, p, q, abs_x, sign_x;
+
+    const double Z1 = 1.46819706421238932572E1;
+    const double Z2 = 4.92184563216946036703E1;
+
+    // 2017-05-18 PAK - mathematica and mpmath use J1(-x) = -J1(x)
+    if (x < 0) {
+        abs_x = -x;
+        sign_x = -1.0;
+    } else {
+        abs_x = x;
+        sign_x = 1.0;
+    }
+
+    if( abs_x <= 5.0 ) {
+        z = abs_x * abs_x;
+        w = polevl( z, RPJ1, 3 ) / p1evl( z, RQJ1, 8 );
+        w = w * abs_x * (z - Z1) * (z - Z2);
+        return( sign_x * w );
+    }
+
+    w = 5.0/abs_x;
+    z = w * w;
+    p = polevl( z, PPJ1, 6)/polevl( z, PQJ1, 6 );
+    q = polevl( z, QPJ1, 7)/p1evl( z, QQJ1, 7 );
+
+    // 2017-05-19 PAK improve accuracy using trig identies
+    // original:
+    //    const double THPIO4 =  2.35619449019234492885;
+    //    const double SQ2OPI = 0.79788456080286535588;
+    //    double sin_xn, cos_xn;
+    //    SINCOS(abs_x - THPIO4, sin_xn, cos_xn);
+    //    p = p * cos_xn - w * q * sin_xn;
+    //    return( sign_x * p * SQ2OPI / sqrt(abs_x) );
+    // expanding p*cos(a - 3 pi/4) - wq sin(a - 3 pi/4)
+    //    [ p(sin(a) - cos(a)) + wq(sin(a) + cos(a)) / sqrt(2)
+    // note that sqrt(1/2) * sqrt(2/pi) = sqrt(1/pi)
+    const double SQRT1_PI = 0.56418958354775628;
+    double sin_x, cos_x;
+    SINCOS(abs_x, sin_x, cos_x);
+    p = p*(sin_x - cos_x) + w*q*(sin_x + cos_x);
+    return( sign_x * p * SQRT1_PI / sqrt(abs_x) );
+}
+
+#else
+//Single precission version of cephes
+
+constant float JPJ1[8] = {
+    -4.878788132172128E-009,
+    6.009061827883699E-007,
+    -4.541343896997497E-005,
+    1.937383947804541E-003,
+    -3.405537384615824E-002,
+    0.0,
+    0.0,
+    0.0
+    };
+
+constant float MO1J1[8] = {
+    6.913942741265801E-002,
+    -2.284801500053359E-001,
+    3.138238455499697E-001,
+    -2.102302420403875E-001,
+    5.435364690523026E-003,
+    1.493389585089498E-001,
+    4.976029650847191E-006,
+    7.978845453073848E-001
+    };
+
+constant float PH1J1[8] = {
+    -4.497014141919556E+001,
+    5.073465654089319E+001,
+    -2.485774108720340E+001,
+    7.222973196770240E+000,
+    -1.544842782180211E+000,
+    3.503787691653334E-001,
+    -1.637986776941202E-001,
+    3.749989509080821E-001
+    };
+
+#pragma acc declare copyin( JPJ1[0:8], MO1J1[0:8], PH1J1[0:8])
+
+#pragma acc routine seq
+static
+float cephes_j1f(float xx)
+{
+
+    float x, w, z, p, q, xn;
+
+    const float Z1 = 1.46819706421238932572E1;
+
+
+    // 2017-05-18 PAK - mathematica and mpmath use J1(-x) = -J1(x)
+    x = xx;
+    if( x < 0 )
+        x = -xx;
+
+    if( x <= 2.0 ) {
+        z = x * x;
+        p = (z-Z1) * x * polevl( z, JPJ1, 4 );
+        return( xx < 0. ? -p : p );
+    }
+
+    q = 1.0/x;
+    w = sqrt(q);
+
+    p = w * polevl( q, MO1J1, 7);
+    w = q*q;
+    // 2017-05-19 PAK improve accuracy using trig identies
+    // original:
+    //    const float THPIO4F =  2.35619449019234492885;    /* 3*pi/4 */
+    //    xn = q * polevl( w, PH1J1, 7) - THPIO4F;
+    //    p = p * cos(xn + x);
+    //    return( xx < 0. ? -p : p );
+    // expanding cos(a + b - 3 pi/4) is
+    //    [sin(a)sin(b) + sin(a)cos(b) + cos(a)sin(b)-cos(a)cos(b)] / sqrt(2)
+    xn = q * polevl( w, PH1J1, 7);
+    float cos_xn, sin_xn;
+    float cos_x, sin_x;
+    SINCOS(xn, sin_xn, cos_xn);  // about xn and 1
+    SINCOS(x, sin_x, cos_x);
+    p *= M_SQRT1_2*(sin_xn*(sin_x+cos_x) + cos_xn*(sin_x-cos_x));
+
+    return( xx < 0. ? -p : p );
+}
+#endif
+
+#if FLOAT_SIZE>4
+#define sas_J1 cephes_j1
+#else
+#define sas_J1 cephes_j1f
+#endif
+
+//Finally J1c function that equals 2*J1(x)/x
+    
+#pragma acc routine seq
+static
+double sas_2J1x_x(double x)
+{
+    return (x != 0.0 ) ? 2.0*sas_J1(x)/x : 1.0;
+}
+
+
+#line 1 ".././models/lib/gauss76.c"
+
+// Created by Andrew Jackson on 4/23/07
+
+ #ifdef GAUSS_N
+ # undef GAUSS_N
+ # undef GAUSS_Z
+ # undef GAUSS_W
+ #endif
+ #define GAUSS_N 76
+ #define GAUSS_Z Gauss76Z
+ #define GAUSS_W Gauss76Wt
+
+// Gaussians
+constant double Gauss76Wt[76] = {
+	.00126779163408536,		//0
+	.00294910295364247,
+	.00462793522803742,
+	.00629918049732845,
+	.00795984747723973,
+	.00960710541471375,
+	.0112381685696677,
+	.0128502838475101,
+	.0144407317482767,
+	.0160068299122486,
+	.0175459372914742,		//10
+	.0190554584671906,
+	.020532847967908,
+	.0219756145344162,
+	.0233813253070112,
+	.0247476099206597,
+	.026072164497986,
+	.0273527555318275,
+	.028587223650054,
+	.029773487255905,
+	.0309095460374916,		//20
+	.0319934843404216,
+	.0330234743977917,
+	.0339977794120564,
+	.0349147564835508,
+	.0357728593807139,
+	.0365706411473296,
+	.0373067565423816,
+	.0379799643084053,
+	.0385891292645067,
+	.0391332242205184,		//30
+	.0396113317090621,
+	.0400226455325968,
+	.040366472122844,
+	.0406422317102947,
+	.0408494593018285,
+	.040987805464794,
+	.0410570369162294,
+	.0410570369162294,
+	.040987805464794,
+	.0408494593018285,		//40
+	.0406422317102947,
+	.040366472122844,
+	.0400226455325968,
+	.0396113317090621,
+	.0391332242205184,
+	.0385891292645067,
+	.0379799643084053,
+	.0373067565423816,
+	.0365706411473296,
+	.0357728593807139,		//50
+	.0349147564835508,
+	.0339977794120564,
+	.0330234743977917,
+	.0319934843404216,
+	.0309095460374916,
+	.029773487255905,
+	.028587223650054,
+	.0273527555318275,
+	.026072164497986,
+	.0247476099206597,		//60
+	.0233813253070112,
+	.0219756145344162,
+	.020532847967908,
+	.0190554584671906,
+	.0175459372914742,
+	.0160068299122486,
+	.0144407317482767,
+	.0128502838475101,
+	.0112381685696677,
+	.00960710541471375,		//70
+	.00795984747723973,
+	.00629918049732845,
+	.00462793522803742,
+	.00294910295364247,
+	.00126779163408536		//75 (indexed from 0)
+};
+
+constant double Gauss76Z[76] = {
+	-.999505948362153,		//0
+	-.997397786355355,
+	-.993608772723527,
+	-.988144453359837,
+	-.981013938975656,
+	-.972229228520377,
+	-.961805126758768,
+	-.949759207710896,
+	-.936111781934811,
+	-.92088586125215,
+	-.904107119545567,		//10
+	-.885803849292083,
+	-.866006913771982,
+	-.844749694983342,
+	-.822068037328975,
+	-.7980001871612,
+	-.77258672828181,
+	-.74587051350361,
+	-.717896592387704,
+	-.688712135277641,
+	-.658366353758143,		//20
+	-.626910417672267,
+	-.594397368836793,
+	-.560882031601237,
+	-.526420920401243,
+	-.491072144462194,
+	-.454895309813726,
+	-.417951418780327,
+	-.380302767117504,
+	-.342012838966962,
+	-.303146199807908,		//30
+	-.263768387584994,
+	-.223945802196474,
+	-.183745593528914,
+	-.143235548227268,
+	-.102483975391227,
+	-.0615595913906112,
+	-.0205314039939986,
+	.0205314039939986,
+	.0615595913906112,
+	.102483975391227,			//40
+	.143235548227268,
+	.183745593528914,
+	.223945802196474,
+	.263768387584994,
+	.303146199807908,
+	.342012838966962,
+	.380302767117504,
+	.417951418780327,
+	.454895309813726,
+	.491072144462194,		//50
+	.526420920401243,
+	.560882031601237,
+	.594397368836793,
+	.626910417672267,
+	.658366353758143,
+	.688712135277641,
+	.717896592387704,
+	.74587051350361,
+	.77258672828181,
+	.7980001871612,	//60
+	.822068037328975,
+	.844749694983342,
+	.866006913771982,
+	.885803849292083,
+	.904107119545567,
+	.92088586125215,
+	.936111781934811,
+	.949759207710896,
+	.961805126758768,
+	.972229228520377,		//70
+	.981013938975656,
+	.988144453359837,
+	.993608772723527,
+	.997397786355355,
+	.999505948362153		//75
+};
+
+
+#pragma acc declare copyin(Gauss76Wt[0:76], Gauss76Z[0:76])
+
+#line 1 ".././models/core_shell_bicelle_elliptical_belt_rough.c"
+
+// NOTE that "length" here is the full height of the core!
+static double
+form_volume(double r_minor,
+        double x_core,
+        double thick_rim,
+        double thick_face,
+        double length)
+{
+    return M_PI*(  (r_minor + thick_rim)*(r_minor*x_core + thick_rim)* length +
+                 square(r_minor)*x_core*2.0*thick_face  );
+}
+
+static double
+radius_from_excluded_volume(double r_minor, double x_core, double thick_rim, double thick_face, double length)
+{
+    const double r_equiv     = sqrt((r_minor + thick_rim)*(r_minor*x_core + thick_rim));
+    const double length_tot  = length + 2.0*thick_face;
+    return 0.5*cbrt(0.75*r_equiv*(2.0*r_equiv*length_tot + (r_equiv + length_tot)*(M_PI*r_equiv + length_tot)));
+}
+
+static double
+radius_from_volume(double r_minor, double x_core, double thick_rim, double thick_face, double length)
+{
+    const double volume_bicelle = form_volume(r_minor, x_core, thick_rim,thick_face,length);
+    return cbrt(volume_bicelle/M_4PI_3);
+}
+
+static double
+radius_from_diagonal(double r_minor, double x_core, double thick_rim, double thick_face, double length)
+{
+    const double radius_max = (x_core < 1.0 ? r_minor : x_core*r_minor);
+    const double radius_max_tot = radius_max + thick_rim;
+    const double length_tot = length + 2.0*thick_face;
+    return sqrt(radius_max_tot*radius_max_tot + 0.25*length_tot*length_tot);
+}
+
+static double
+radius_effective(int mode, double r_minor, double x_core, double thick_rim, double thick_face, double length)
+{
+    switch (mode) {
+    default:
+    case 1: // equivalent cylinder excluded volume
+        return radius_from_excluded_volume(r_minor, x_core, thick_rim, thick_face, length);
+    case 2: // equivalent sphere
+        return radius_from_volume(r_minor, x_core, thick_rim, thick_face, length);
+    case 3: // outer rim average radius
+        return 0.5*r_minor*(1.0 + x_core) + thick_rim;
+    case 4: // outer rim min radius
+        return (x_core < 1.0 ? x_core*r_minor+thick_rim : r_minor+thick_rim);
+    case 5: // outer max radius
+        return (x_core > 1.0 ? x_core*r_minor+thick_rim : r_minor+thick_rim);
+    case 6: // half outer thickness
+        return 0.5*length + thick_face;
+    case 7: // half diagonal (this ignores the missing "corners", so may give unexpected answer if thick_face
+            //  or thick_rim is extremely large)
+        return radius_from_diagonal(r_minor,x_core,thick_rim,thick_face,length);
+    }
+}
+
+static void
+Fq(double q,
+        double *F1,
+        double *F2,
+        double r_minor,
+        double x_core,
+        double thick_rim,
+        double thick_face,
+        double length,
+        double rhoc,
+        double rhoh,
+        double rhor,
+        double rhosolv,
+        double sigma)
+{
+     // core_shell_bicelle_elliptical_belt, RKH 5th Oct 2017, core_shell_bicelle_elliptical
+     // tested briefly against limiting cases of cylinder, hollow cylinder & elliptical cylinder models
+     //    const double uplim = M_PI_4;
+    const double halfheight = 0.5*length;
+    //const double va = 0.0;
+    //const double vb = 1.0;
+    // inner integral limits
+    //const double vaj=0.0;
+    //const double vbj=M_PI;
+
+    const double r_major = r_minor * x_core;
+    const double r2A = 0.5*(square(r_major) + square(r_minor));
+    const double r2B = 0.5*(square(r_major) - square(r_minor));
+    const double vol1 = M_PI*r_minor*r_major*(2.0*halfheight);
+    const double vol2 = M_PI*(r_minor+thick_rim)*(r_major+thick_rim)*2.0*halfheight;
+    const double vol3 = M_PI*r_minor*r_major*2.0*(halfheight+thick_face);
+    // dr1,2,3 are now for Vcore, Vcore+rim, Vcore+face,
+    const double dr1 = vol1*(-rhor - rhoh + rhoc + rhosolv);
+    const double dr2 = vol2*(rhor-rhosolv);
+    const double dr3 = vol3*(rhoh-rhosolv);
+
+    //initialize integral
+    double outer_total_F1 = 0.0;
+    double outer_total_F2 = 0.0;
+    for(int i=0;i<GAUSS_N;i++) {
+        //setup inner integral over the ellipsoidal cross-section
+        // since we generate these lots of times, why not store them somewhere?
+        //const double cos_theta = ( GAUSS_Z[i]*(vb-va) + va + vb )/2.0;
+        const double cos_theta = ( GAUSS_Z[i] + 1.0 )/2.0;
+        const double sin_theta = sqrt(1.0 - cos_theta*cos_theta);
+        const double qab = q*sin_theta;
+        const double qc = q*cos_theta;
+        const double si1 = sas_sinx_x(halfheight*qc);
+        const double si2 = sas_sinx_x((halfheight+thick_face)*qc);
+        double inner_total_F1 = 0;
+        double inner_total_F2 = 0;
+        for(int j=0;j<GAUSS_N;j++) {
+            //76 gauss points for the inner integral (WAS 20 points,so this may make unecessarily slow, but playing safe)
+            //const double beta = ( GAUSS_Z[j]*(vbj-vaj) + vaj + vbj )/2.0;
+            const double beta = ( GAUSS_Z[j] +1.0)*M_PI_2;
+            const double rr = sqrt(r2A - r2B*cos(beta));
+            const double be1 = sas_2J1x_x(rr*qab);
+            const double be2 = sas_2J1x_x((rr+thick_rim)*qab);
+            const double f = dr1*si1*be1 + dr2*si1*be2 + dr3*si2*be1;
+
+            inner_total_F1 += GAUSS_W[j] * f;
+            inner_total_F2 += GAUSS_W[j] * f * f;
+        }
+        //now calculate outer integral
+        outer_total_F1 += GAUSS_W[i] * inner_total_F1;
+        outer_total_F2 += GAUSS_W[i] * inner_total_F2;
+    }
+    // now complete change of integration variables (1-0)/(1-(-1))= 0.5
+    outer_total_F1 *= 0.25;
+    outer_total_F2 *= 0.25;
+
+    //convert from [1e-12 A-1] to [cm-1]
+    *F1 = 1e-2*outer_total_F1*exp(-0.25*square(q*sigma));
+    *F2 = 1e-4*outer_total_F2*exp(-0.5*square(q*sigma));
+}
+
+static double
+Iqabc(double qa, double qb, double qc,
+          double r_minor,
+          double x_core,
+          double thick_rim,
+          double thick_face,
+          double length,
+          double rhoc,
+          double rhoh,
+          double rhor,
+          double rhosolv,
+          double sigma)
+{
+    // integrated 2d seems to match 1d reasonably well, except perhaps at very high Q
+    // Vol1,2,3 and dr1,2,3 are now for Vcore, Vcore+rim, Vcore+face,
+    const double dr1 = -rhor - rhoh + rhoc + rhosolv;
+    const double dr2 = rhor-rhosolv;
+    const double dr3 = rhoh-rhosolv;
+    const double r_major = r_minor*x_core;
+    const double halfheight = 0.5*length;
+    const double vol1 = M_PI*r_minor*r_major*length;
+    const double vol2 = M_PI*(r_minor+thick_rim)*(r_major+thick_rim)*2.0*halfheight;
+    const double vol3 = M_PI*r_minor*r_major*2.0*(halfheight+thick_face);
+
+    // Compute effective radius in rotated coordinates
+    const double qr_hat = sqrt(square(r_major*qb) + square(r_minor*qa));
+    // does this need to be changed for the "missing corners" where there there is no "belt" ?
+    const double qrshell_hat = sqrt(square((r_major+thick_rim)*qb)
+                                   + square((r_minor+thick_rim)*qa));
+    const double be1 = sas_2J1x_x( qr_hat );
+    const double be2 = sas_2J1x_x( qrshell_hat );
+    const double si1 = sas_sinx_x( halfheight*qc );
+    const double si2 = sas_sinx_x( (halfheight + thick_face)*qc );
+    const double fq = vol1*dr1*si1*be1 + vol2*dr2*si1*be2 +  vol3*dr3*si2*be1;
+    const double atten = exp(-0.5*(qa*qa + qb*qb + qc*qc)*(sigma*sigma));
+    return 1.0e-4 * fq*fq * atten;
+}
+
+

--- a/mcstas-comps/share/sas_core_shell_cylinder.c
+++ b/mcstas-comps/share/sas_core_shell_cylinder.c
@@ -1,615 +1,1031 @@
-// GENERATED CODE --- DO NOT EDIT ---
-// Code is produced by sasmodels.gen from sasmodels/models/MODEL.c
+#define HAS_Iqac
+#define HAS_FQ
+#define FORM_VOL
+#line 1 "../kernel_header.c"
 
 #ifdef __OPENCL_VERSION__
 # define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
 #endif
 
-#define USE_KAHAN_SUMMATION 0
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
 
 // If opencl is not available, then we are compiling a C function
 // Note: if using a C++ compiler, then define kernel as extern "C"
-#ifndef USE_OPENCL
-#  ifdef __cplusplus
-     #include <cstdio>
-     #include <cmath>
-     using namespace std;
-     #if defined(_MSC_VER)
-     #   define kernel extern "C" __declspec( dllexport )
-         inline float trunc(float x) { return x>=0?floor(x):-floor(-x); }
-	 inline float fmin(float x, float y) { return x>y ? y : x; }
-	 inline float fmax(float x, float y) { return x<y ? y : x; }
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
      #else
-     #   define kernel extern "C"
+         #define kernel extern "C"
+         #include <cstdint>
      #endif
-     inline void SINCOS(float angle, float &svar, float &cvar) { svar=sin(angle); cvar=cos(angle); }
-#  else
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
      #include <stdio.h>
-     #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
      // MSVC doesn't support C99, so no need for dllexport on C99 branch
      #define kernel
-     #define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
-#  define global
-#  define local
-#  define constant const
-// OpenCL powr(a,b) = C99 pow(a,b), b >= 0
-// OpenCL pown(a,b) = C99 pow(a,b), b integer
-#  define powr(a,b) pow(a,b)
-#  define pown(a,b) pow(a,b)
-#else
-#  ifdef USE_SINCOS
-#    define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
-#  else
-#    define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
 #endif
 
 // Standard mathematical constants:
 //   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
 //   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
-// OpenCL defines M_constant_F for float constants, and nothing if float
+// OpenCL defines M_constant_F for float constants, and nothing if double
 // is not enabled on the card, which is why these constants may be missing
 #ifndef M_PI
-#  define M_PI 3.141592653589793f
+#  define M_PI 3.141592653589793
 #endif
 #ifndef M_PI_2
-#  define M_PI_2 1.570796326794897f
+#  define M_PI_2 1.570796326794897
 #endif
 #ifndef M_PI_4
-#  define M_PI_4 0.7853981633974483f
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
 #endif
 
-// Non-standard pi/180, used for converting between degrees and radians
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
 #ifndef M_PI_180
-#  define M_PI_180 0.017453292519943295f
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
 #endif
 
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
 
-#define VOLUME_PARAMETERS radius,thickness,length
-#define VOLUME_WEIGHT_PRODUCT radius_w*thickness_w*length_w
-#define IQ_KERNEL_NAME core_shell_cylinder_Iq
-#define IQ_PARAMETERS core_sld, shell_sld, solvent_sld, radius, thickness, length
-#define IQ_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float core_sld, \
-    const float shell_sld, \
-    const float solvent_sld
-#define IQ_WEIGHT_PRODUCT radius_w*thickness_w*length_w
-#define IQ_DISPERSION_LENGTH_DECLARATIONS const int Nradius, \
-    const int Nthickness, \
-    const int Nlength
-#define IQ_DISPERSION_LENGTH_SUM Nradius+Nthickness+Nlength
-#define IQ_OPEN_LOOPS     for (int radius_i=0; radius_i < Nradius; radius_i++) { \
-      const float radius = loops[2*(radius_i)]; \
-      const float radius_w = loops[2*(radius_i)+1]; \
-      for (int thickness_i=0; thickness_i < Nthickness; thickness_i++) { \
-        const float thickness = loops[2*(thickness_i+Nradius)]; \
-        const float thickness_w = loops[2*(thickness_i+Nradius)+1]; \
-        for (int length_i=0; length_i < Nlength; length_i++) { \
-          const float length = loops[2*(length_i+Nradius+Nthickness)]; \
-          const float length_w = loops[2*(length_i+Nradius+Nthickness)+1];
-#define IQ_CLOSE_LOOPS         } \
-      } \
-    }
-#define IQXY_KERNEL_NAME core_shell_cylinder_Iqxy
-#define IQXY_PARAMETERS core_sld, shell_sld, solvent_sld, radius, thickness, length, theta, phi
-#define IQXY_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float core_sld, \
-    const float shell_sld, \
-    const float solvent_sld
-#define IQXY_WEIGHT_PRODUCT radius_w*thickness_w*length_w*theta_w*phi_w
-#define IQXY_DISPERSION_LENGTH_DECLARATIONS const int Nradius, \
-    const int Nthickness, \
-    const int Nlength, \
-    const int Ntheta, \
-    const int Nphi
-#define IQXY_DISPERSION_LENGTH_SUM Nradius+Nthickness+Nlength+Ntheta+Nphi
-#define IQXY_OPEN_LOOPS     for (int radius_i=0; radius_i < Nradius; radius_i++) { \
-      const float radius = loops[2*(radius_i)]; \
-      const float radius_w = loops[2*(radius_i)+1]; \
-      for (int thickness_i=0; thickness_i < Nthickness; thickness_i++) { \
-        const float thickness = loops[2*(thickness_i+Nradius)]; \
-        const float thickness_w = loops[2*(thickness_i+Nradius)+1]; \
-        for (int length_i=0; length_i < Nlength; length_i++) { \
-          const float length = loops[2*(length_i+Nradius+Nthickness)]; \
-          const float length_w = loops[2*(length_i+Nradius+Nthickness)+1]; \
-          for (int theta_i=0; theta_i < Ntheta; theta_i++) { \
-            const float theta = loops[2*(theta_i+Nradius+Nthickness+Nlength)]; \
-            const float theta_w = loops[2*(theta_i+Nradius+Nthickness+Nlength)+1]; \
-            for (int phi_i=0; phi_i < Nphi; phi_i++) { \
-              const float phi = loops[2*(phi_i+Nradius+Nthickness+Nlength+Ntheta)]; \
-              const float phi_w = loops[2*(phi_i+Nradius+Nthickness+Nlength+Ntheta)+1];
-#define IQXY_CLOSE_LOOPS             } \
-          } \
-        } \
-      } \
-    }
-#define IQXY_HAS_THETA 1
+//# Beginning of rotational operation definitions
 
-float J1(float x);
-float J1(float x)
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
 {
-  const float ax = fabs(x);
-  if (ax < 8.0f) {
-    const float y = x*x;
-    const float ans1 = x*(72362614232.0f
-              + y*(-7895059235.0f
-              + y*(242396853.1f
-              + y*(-2972611.439f
-              + y*(15704.48260f
-              + y*(-30.16036606f))))));
-    const float ans2 = 144725228442.0f
-              + y*(2300535178.0f
-              + y*(18583304.74f
-              + y*(99447.43394f
-              + y*(376.9991397f
-              + y))));
-    return ans1/ans2;
-  } else {
-    const float y = 64.0f/(ax*ax);
-    const float xx = ax - 2.356194491f;
-    const float ans1 = 1.0f
-              + y*(0.183105e-2f
-              + y*(-0.3516396496e-4f
-              + y*(0.2457520174e-5f
-              + y*-0.240337019e-6f)));
-    const float ans2 = 0.04687499995f
-              + y*(-0.2002690873e-3f
-              + y*(0.8449199096e-5f
-              + y*(-0.88228987e-6f
-              + y*0.105787412e-6f)));
-    float sn,cn;
-    SINCOS(xx, sn, cn);
-    const float ans = sqrt(0.636619772f/ax) * (cn*ans1 - (8.0f/ax)*sn*ans2);
-    return (x < 0.0f) ? -ans : ans;
-  }
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/polevl.c"
+
+/*							polevl.c
+ *							p1evl.c
+ *
+ *	Evaluate polynomial
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * int N;
+ * double x, y, coef[N+1], polevl[];
+ *
+ * y = polevl( x, coef, N );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Evaluates polynomial of degree N:
+ *
+ *                     2          N
+ * y  =  C  + C x + C x  +...+ C x
+ *        0    1     2          N
+ *
+ * Coefficients are stored in reverse order:
+ *
+ * coef[0] = C  , ..., coef[N] = C  .
+ *            N                   0
+ *
+ * The function p1evl() assumes that C_N = 1.0 and is
+ * omitted from the array.  Its calling arguments are
+ * otherwise the same as polevl().
+ *
+ *
+ * SPEED:
+ *
+ * In the interest of speed, there are no checks for out
+ * of bounds arithmetic.  This routine is used by most of
+ * the functions in the library.  Depending on available
+ * equipment features, the user may wish to rewrite the
+ * program in microcode or assembly language.
+ *
+ */
+
+
+/*
+Cephes Math Library Release 2.1:  December, 1988
+Copyright 1984, 1987, 1988 by Stephen L. Moshier
+Direct inquiries to 30 Frost Street, Cambridge, MA 02140
+*/
+#pragma acc routine seq
+static
+double polevl( double x, pconstant double *coef, int N )
+{
+
+    int i = 0;
+    double ans = coef[i];
+
+    while (i < N) {
+        i++;
+        ans = ans * x + coef[i];
+    }
+
+    return ans;
+}
+
+/*							p1evl()	*/
+/*                                          N
+ * Evaluate polynomial when coefficient of x  is 1.0.
+ * Otherwise same as polevl.
+ */
+#pragma acc routine seq
+static
+double p1evl( double x, pconstant double *coef, int N )
+{
+    int i=0;
+    double ans = x+coef[i];
+
+    while (i < N-1) {
+        i++;
+        ans = ans*x + coef[i];
+    }
+
+    return ans;
 }
 
 
-/*
- *  GaussWeights.c
- *  SANSAnalysis
+#line 1 ".././models/lib/sas_J1.c"
+
+/*							j1.c
  *
- *  Created by Andrew Jackson on 4/23/07.f
- *  Copyright 2007 __MyCompanyName__. All rights reserved.
+ *	Bessel function of order one
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * double x, y, j1();
+ *
+ * y = j1( x );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Returns Bessel function of order one of the argument.
+ *
+ * The domain is divided into the intervals [0, 8] and
+ * (8, infinity). In the first interval a 24 term Chebyshev
+ * expansion is used. In the second, the asymptotic
+ * trigonometric representation is employed using two
+ * rational functions of degree 5/5.
+ *
+ *
+ *
+ * ACCURACY:
+ *
+ *                      Absolute error:
+ * arithmetic   domain      # trials      peak         rms
+ *    DEC       0, 30       10000       4.0e-17     1.1e-17
+ *    IEEE      0, 30       30000       2.6e-16     1.1e-16
+ *
  *
  */
 
-// Gaussians
-constant float Gauss76Wt[]={
-	.00126779163408536f,		//0
-	.00294910295364247f,
-	.00462793522803742f,
-	.00629918049732845f,
-	.00795984747723973f,
-	.00960710541471375f,
-	.0112381685696677f,
-	.0128502838475101f,
-	.0144407317482767f,
-	.0160068299122486f,
-	.0175459372914742f,		//10
-	.0190554584671906f,
-	.020532847967908f,
-	.0219756145344162f,
-	.0233813253070112f,
-	.0247476099206597f,
-	.026072164497986f,
-	.0273527555318275f,
-	.028587223650054f,
-	.029773487255905f,
-	.0309095460374916f,		//20
-	.0319934843404216f,
-	.0330234743977917f,
-	.0339977794120564f,
-	.0349147564835508f,
-	.0357728593807139f,
-	.0365706411473296f,
-	.0373067565423816f,
-	.0379799643084053f,
-	.0385891292645067f,
-	.0391332242205184f,		//30
-	.0396113317090621f,
-	.0400226455325968f,
-	.040366472122844f,
-	.0406422317102947f,
-	.0408494593018285f,
-	.040987805464794f,
-	.0410570369162294f,
-	.0410570369162294f,
-	.040987805464794f,
-	.0408494593018285f,		//40
-	.0406422317102947f,
-	.040366472122844f,
-	.0400226455325968f,
-	.0396113317090621f,
-	.0391332242205184f,
-	.0385891292645067f,
-	.0379799643084053f,
-	.0373067565423816f,
-	.0365706411473296f,
-	.0357728593807139f,		//50
-	.0349147564835508f,
-	.0339977794120564f,
-	.0330234743977917f,
-	.0319934843404216f,
-	.0309095460374916f,
-	.029773487255905f,
-	.028587223650054f,
-	.0273527555318275f,
-	.026072164497986f,
-	.0247476099206597f,		//60
-	.0233813253070112f,
-	.0219756145344162f,
-	.020532847967908f,
-	.0190554584671906f,
-	.0175459372914742f,
-	.0160068299122486f,
-	.0144407317482767f,
-	.0128502838475101f,
-	.0112381685696677f,
-	.00960710541471375f,		//70
-	.00795984747723973f,
-	.00629918049732845f,
-	.00462793522803742f,
-	.00294910295364247f,
-	.00126779163408536f		//75 (indexed from 0)
-};
-
-#pragma acc declare create ( Gauss76Wt )
-
-constant float Gauss76Z[]={
-	-.999505948362153f,		//0
-	-.997397786355355f,
-	-.993608772723527f,
-	-.988144453359837f,
-	-.981013938975656f,
-	-.972229228520377f,
-	-.961805126758768f,
-	-.949759207710896f,
-	-.936111781934811f,
-	-.92088586125215f,
-	-.904107119545567f,		//10
-	-.885803849292083f,
-	-.866006913771982f,
-	-.844749694983342f,
-	-.822068037328975f,
-	-.7980001871612f,
-	-.77258672828181f,
-	-.74587051350361f,
-	-.717896592387704f,
-	-.688712135277641f,
-	-.658366353758143f,		//20
-	-.626910417672267f,
-	-.594397368836793f,
-	-.560882031601237f,
-	-.526420920401243f,
-	-.491072144462194f,
-	-.454895309813726f,
-	-.417951418780327f,
-	-.380302767117504f,
-	-.342012838966962f,
-	-.303146199807908f,		//30
-	-.263768387584994f,
-	-.223945802196474f,
-	-.183745593528914f,
-	-.143235548227268f,
-	-.102483975391227f,
-	-.0615595913906112f,
-	-.0205314039939986f,
-	.0205314039939986f,
-	.0615595913906112f,
-	.102483975391227f,			//40
-	.143235548227268f,
-	.183745593528914f,
-	.223945802196474f,
-	.263768387584994f,
-	.303146199807908f,
-	.342012838966962f,
-	.380302767117504f,
-	.417951418780327f,
-	.454895309813726f,
-	.491072144462194f,		//50
-	.526420920401243f,
-	.560882031601237f,
-	.594397368836793f,
-	.626910417672267f,
-	.658366353758143f,
-	.688712135277641f,
-	.717896592387704f,
-	.74587051350361f,
-	.77258672828181f,
-	.7980001871612f,	//60
-	.822068037328975f,
-	.844749694983342f,
-	.866006913771982f,
-	.885803849292083f,
-	.904107119545567f,
-	.92088586125215f,
-	.936111781934811f,
-	.949759207710896f,
-	.961805126758768f,
-	.972229228520377f,		//70
-	.981013938975656f,
-	.988144453359837f,
-	.993608772723527f,
-	.997397786355355f,
-	.999505948362153f		//75
-};
-
-#pragma acc declare create ( Gauss76Z )
-
-float form_volume(float radius, float thickness, float length);
-float Iq(float q, float core_sld, float shell_sld, float solvent_sld,
-    float radius, float thickness, float length);
-float Iqxy(float qx, float qy, float core_sld, float shell_sld, float solvent_sld,
-    float radius, float thickness, float length, float theta, float phi);
-
-// twovd = 2 * volume * delta_rho
-// besarg = q * R * sin(alpha)
-// siarg = q * L/2 * cos(alpha)
-float _cyl(float twovd, float besarg, float siarg);
-float _cyl(float twovd, float besarg, float siarg)
-{
-    const float bj = (besarg == 0.0f ? 0.5f : J1(besarg)/besarg);
-    const float si = (siarg == 0.0f ? 1.0f : sin(siarg)/siarg);
-    return twovd*si*bj;
-}
-
-float form_volume(float radius, float thickness, float length)
-{
-    return M_PI*(radius+thickness)*(radius+thickness)*(length+2*thickness);
-}
-
-float Iq(float q,
-    float core_sld,
-    float shell_sld,
-    float solvent_sld,
-    float radius,
-    float thickness,
-    float length)
-{
-    // precalculate constants
-    const float core_qr = q*radius;
-    const float core_qh = q*0.5f*length;
-    const float core_twovd = 2.0f * form_volume(radius,0,length)
-                            * (core_sld-shell_sld);
-    const float shell_qr = q*(radius + thickness);
-    const float shell_qh = q*(0.5f*length + thickness);
-    const float shell_twovd = 2.0f * form_volume(radius,thickness,length)
-                             * (shell_sld-solvent_sld);
-    float total = 0.0f;
-    // float lower=0, upper=M_PI_2;
-    for (int i=0; i<76 ;i++) {
-        // translate a point in [-1,1] to a point in [lower,upper]
-        //const float alpha = ( Gauss76Z[i]*(upper-lower) + upper + lower )/2.0f;
-        float sn, cn;
-        const float alpha = 0.5f*(Gauss76Z[i]*M_PI_2 + M_PI_2);
-        SINCOS(alpha, sn, cn);
-        const float fq = _cyl(core_twovd, core_qr*sn, core_qh*cn)
-            + _cyl(shell_twovd, shell_qr*sn, shell_qh*cn);
-        total += Gauss76Wt[i] * fq * fq * sn;
-    }
-    // translate dx in [-1,1] to dx in [lower,upper]
-    //const float form = (upper-lower)/2.0f*total;
-    return 1.0e-4f * total * M_PI_4;
-}
-
-
-float Iqxy(float qx, float qy,
-    float core_sld,
-    float shell_sld,
-    float solvent_sld,
-    float radius,
-    float thickness,
-    float length,
-    float theta,
-    float phi)
-{
-    float sn, cn; // slots to hold sincos function output
-
-    // Compute angle alpha between q and the cylinder axis
-    SINCOS(theta*M_PI_180, sn, cn);
-    // # The following correction factor exists in sasview, but it can't be
-    // # right, so we are leaving it out for now.
-    // const float correction = fabs(cn)*M_PI_2;
-    const float q = sqrt(qx*qx+qy*qy);
-    const float cos_val = cn*cos(phi*M_PI_180)*(qx/q) + sn*(qy/q);
-    const float alpha = acos(cos_val);
-
-    const float core_qr = q*radius;
-    const float core_qh = q*0.5f*length;
-    const float core_twovd = 2.0f * form_volume(radius,0,length)
-                            * (core_sld-shell_sld);
-    const float shell_qr = q*(radius + thickness);
-    const float shell_qh = q*(0.5f*length + thickness);
-    const float shell_twovd = 2.0f * form_volume(radius,thickness,length)
-                             * (shell_sld-solvent_sld);
-
-    SINCOS(alpha, sn, cn);
-    const float fq = _cyl(core_twovd, core_qr*sn, core_qh*cn)
-        + _cyl(shell_twovd, shell_qr*sn, shell_qh*cn);
-    return 1.0e-4f * fq * fq;
-}
-
-
 /*
-    ##########################################################
-    #                                                        #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #   !!                                              !!   #
-    #   !!  KEEP THIS CODE CONSISTENT WITH KERNELPY.PY  !!   #
-    #   !!                                              !!   #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #                                                        #
-    ##########################################################
+Cephes Math Library Release 2.8:  June, 2000
+Copyright 1984, 1987, 1989, 2000 by Stephen L. Moshier
 */
 
-#ifdef IQ_KERNEL_NAME
-kernel void IQ_KERNEL_NAME(
-    global const float *q,
-    global float *result,
-    const int Nq,
-#ifdef IQ_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQ_DISPERSION_LENGTH_DECLARATIONS,
-#endif
-    IQ_FIXED_PARAMETER_DECLARATIONS
-    )
+#if FLOAT_SIZE>4
+//Cephes double pression function
+
+constant double RPJ1[8] = {
+    -8.99971225705559398224E8,
+    4.52228297998194034323E11,
+    -7.27494245221818276015E13,
+    3.68295732863852883286E15,
+    0.0,
+    0.0,
+    0.0,
+    0.0 };
+
+constant double RQJ1[8] = {
+    6.20836478118054335476E2,
+    2.56987256757748830383E5,
+    8.35146791431949253037E7,
+    2.21511595479792499675E10,
+    4.74914122079991414898E12,
+    7.84369607876235854894E14,
+    8.95222336184627338078E16,
+    5.32278620332680085395E18
+    };
+
+constant double PPJ1[8] = {
+    7.62125616208173112003E-4,
+    7.31397056940917570436E-2,
+    1.12719608129684925192E0,
+    5.11207951146807644818E0,
+    8.42404590141772420927E0,
+    5.21451598682361504063E0,
+    1.00000000000000000254E0,
+    0.0} ;
+
+
+constant double PQJ1[8] = {
+    5.71323128072548699714E-4,
+    6.88455908754495404082E-2,
+    1.10514232634061696926E0,
+    5.07386386128601488557E0,
+    8.39985554327604159757E0,
+    5.20982848682361821619E0,
+    9.99999999999999997461E-1,
+    0.0 };
+
+constant double QPJ1[8] = {
+    5.10862594750176621635E-2,
+    4.98213872951233449420E0,
+    7.58238284132545283818E1,
+    3.66779609360150777800E2,
+    7.10856304998926107277E2,
+    5.97489612400613639965E2,
+    2.11688757100572135698E2,
+    2.52070205858023719784E1 };
+
+constant double QQJ1[8] = {
+    7.42373277035675149943E1,
+    1.05644886038262816351E3,
+    4.98641058337653607651E3,
+    9.56231892404756170795E3,
+    7.99704160447350683650E3,
+    2.82619278517639096600E3,
+    3.36093607810698293419E2,
+    0.0 };
+
+#pragma acc declare copyin( RPJ1[0:8], RQJ1[0:8], PPJ1[0:8], PQJ1[0:8], QPJ1[0:8], QQJ1[0:8])
+
+#pragma acc routine seq
+static
+double cephes_j1(double x)
 {
-#ifdef USE_OPENCL
-  #ifdef IQ_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQ_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
 
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qi = q[i];
-#ifdef IQ_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-  #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-  #endif
-    IQ_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
+    double w, z, p, q, abs_x, sign_x;
 
-    const float weight = IQ_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-      const float scattering = Iq(qi, IQ_PARAMETERS);
-      // allow kernels to exclude invalid regions by returning NaN
-      if (!isnan(scattering)) {
-        ret += weight*scattering;
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-        norm_vol += vol_weight;
-      #endif
-      }
-    //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
+    const double Z1 = 1.46819706421238932572E1;
+    const double Z2 = 4.92184563216946036703E1;
+
+    // 2017-05-18 PAK - mathematica and mpmath use J1(-x) = -J1(x)
+    if (x < 0) {
+        abs_x = -x;
+        sign_x = -1.0;
+    } else {
+        abs_x = x;
+        sign_x = 1.0;
     }
-    IQ_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
+
+    if( abs_x <= 5.0 ) {
+        z = abs_x * abs_x;
+        w = polevl( z, RPJ1, 3 ) / p1evl( z, RQJ1, 8 );
+        w = w * abs_x * (z - Z1) * (z - Z2);
+        return( sign_x * w );
     }
-  #endif
-    result[i] = scale*ret/norm+background;
+
+    w = 5.0/abs_x;
+    z = w * w;
+    p = polevl( z, PPJ1, 6)/polevl( z, PQJ1, 6 );
+    q = polevl( z, QPJ1, 7)/p1evl( z, QQJ1, 7 );
+
+    // 2017-05-19 PAK improve accuracy using trig identies
+    // original:
+    //    const double THPIO4 =  2.35619449019234492885;
+    //    const double SQ2OPI = 0.79788456080286535588;
+    //    double sin_xn, cos_xn;
+    //    SINCOS(abs_x - THPIO4, sin_xn, cos_xn);
+    //    p = p * cos_xn - w * q * sin_xn;
+    //    return( sign_x * p * SQ2OPI / sqrt(abs_x) );
+    // expanding p*cos(a - 3 pi/4) - wq sin(a - 3 pi/4)
+    //    [ p(sin(a) - cos(a)) + wq(sin(a) + cos(a)) / sqrt(2)
+    // note that sqrt(1/2) * sqrt(2/pi) = sqrt(1/pi)
+    const double SQRT1_PI = 0.56418958354775628;
+    double sin_x, cos_x;
+    SINCOS(abs_x, sin_x, cos_x);
+    p = p*(sin_x - cos_x) + w*q*(sin_x + cos_x);
+    return( sign_x * p * SQRT1_PI / sqrt(abs_x) );
+}
+
 #else
-    result[i] = scale*Iq(qi, IQ_PARAMETERS) + background;
-#endif
-  }
+//Single precission version of cephes
+
+constant float JPJ1[8] = {
+    -4.878788132172128E-009,
+    6.009061827883699E-007,
+    -4.541343896997497E-005,
+    1.937383947804541E-003,
+    -3.405537384615824E-002,
+    0.0,
+    0.0,
+    0.0
+    };
+
+constant float MO1J1[8] = {
+    6.913942741265801E-002,
+    -2.284801500053359E-001,
+    3.138238455499697E-001,
+    -2.102302420403875E-001,
+    5.435364690523026E-003,
+    1.493389585089498E-001,
+    4.976029650847191E-006,
+    7.978845453073848E-001
+    };
+
+constant float PH1J1[8] = {
+    -4.497014141919556E+001,
+    5.073465654089319E+001,
+    -2.485774108720340E+001,
+    7.222973196770240E+000,
+    -1.544842782180211E+000,
+    3.503787691653334E-001,
+    -1.637986776941202E-001,
+    3.749989509080821E-001
+    };
+
+#pragma acc declare copyin( JPJ1[0:8], MO1J1[0:8], PH1J1[0:8])
+
+#pragma acc routine seq
+static
+float cephes_j1f(float xx)
+{
+
+    float x, w, z, p, q, xn;
+
+    const float Z1 = 1.46819706421238932572E1;
+
+
+    // 2017-05-18 PAK - mathematica and mpmath use J1(-x) = -J1(x)
+    x = xx;
+    if( x < 0 )
+        x = -xx;
+
+    if( x <= 2.0 ) {
+        z = x * x;
+        p = (z-Z1) * x * polevl( z, JPJ1, 4 );
+        return( xx < 0. ? -p : p );
+    }
+
+    q = 1.0/x;
+    w = sqrt(q);
+
+    p = w * polevl( q, MO1J1, 7);
+    w = q*q;
+    // 2017-05-19 PAK improve accuracy using trig identies
+    // original:
+    //    const float THPIO4F =  2.35619449019234492885;    /* 3*pi/4 */
+    //    xn = q * polevl( w, PH1J1, 7) - THPIO4F;
+    //    p = p * cos(xn + x);
+    //    return( xx < 0. ? -p : p );
+    // expanding cos(a + b - 3 pi/4) is
+    //    [sin(a)sin(b) + sin(a)cos(b) + cos(a)sin(b)-cos(a)cos(b)] / sqrt(2)
+    xn = q * polevl( w, PH1J1, 7);
+    float cos_xn, sin_xn;
+    float cos_x, sin_x;
+    SINCOS(xn, sin_xn, cos_xn);  // about xn and 1
+    SINCOS(x, sin_x, cos_x);
+    p *= M_SQRT1_2*(sin_xn*(sin_x+cos_x) + cos_xn*(sin_x-cos_x));
+
+    return( xx < 0. ? -p : p );
 }
 #endif
 
-
-#ifdef IQXY_KERNEL_NAME
-kernel void IQXY_KERNEL_NAME(
-    global const float *qx,
-    global const float *qy,
-    global float *result,
-    const int Nq,
-#ifdef IQXY_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQXY_DISPERSION_LENGTH_DECLARATIONS,
+#if FLOAT_SIZE>4
+#define sas_J1 cephes_j1
+#else
+#define sas_J1 cephes_j1f
 #endif
-    IQXY_FIXED_PARAMETER_DECLARATIONS
-    )
+
+//Finally J1c function that equals 2*J1(x)/x
+    
+#pragma acc routine seq
+static
+double sas_2J1x_x(double x)
 {
-#ifdef USE_OPENCL
-  #ifdef IQXY_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQXY_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
-
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qxi = qx[i];
-    const float qyi = qy[i];
-    #if USE_KAHAN_SUMMATION
-    float accumulated_error = 0.0f;
-    #endif
-#ifdef IQXY_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-    #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-    #endif
-    IQXY_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
-
-    const float weight = IQXY_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-
-      const float scattering = Iqxy(qxi, qyi, IQXY_PARAMETERS);
-      if (!isnan(scattering)) { // if scattering is bad, exclude it from sum
-      //if (scattering >= 0.0f) { // scattering cannot be negative
-        // TODO: use correct angle for spherical correction
-        // Definition of theta and phi are probably reversed relative to the
-        // equation which gave rise to this correction, leading to an
-        // attenuation of the pattern as theta moves through pi/2.f  Either
-        // reverse the meanings of phi and theta in the forms, or use phi
-        // rather than theta in this correction.  Current code uses cos(theta)
-        // so that values match those of sasview.
-      #if defined(IQXY_HAS_THETA) // && 0
-        const float spherical_correction
-          = (Ntheta>1 ? fabs(cos(M_PI_180*theta))*M_PI_2:1.0f);
-        const float next = spherical_correction * weight * scattering;
-      #else
-        const float next = weight * scattering;
-      #endif
-      #if USE_KAHAN_SUMMATION
-        const float y = next - accumulated_error;
-        const float t = ret + y;
-        accumulated_error = (t - ret) - y;
-        ret = t;
-      #else
-        ret += next;
-      #endif
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-      #endif
-        norm_vol += vol_weight;
-      }
-      //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
-    }
-    IQXY_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iqxy(qxi, qyi, IQXY_PARAMETERS) + background;
-#endif
-  }
+    return (x != 0.0 ) ? 2.0*sas_J1(x)/x : 1.0;
 }
-#endif
+
+
+#line 1 ".././models/lib/gauss76.c"
+
+// Created by Andrew Jackson on 4/23/07
+
+ #ifdef GAUSS_N
+ # undef GAUSS_N
+ # undef GAUSS_Z
+ # undef GAUSS_W
+ #endif
+ #define GAUSS_N 76
+ #define GAUSS_Z Gauss76Z
+ #define GAUSS_W Gauss76Wt
+
+// Gaussians
+constant double Gauss76Wt[76] = {
+	.00126779163408536,		//0
+	.00294910295364247,
+	.00462793522803742,
+	.00629918049732845,
+	.00795984747723973,
+	.00960710541471375,
+	.0112381685696677,
+	.0128502838475101,
+	.0144407317482767,
+	.0160068299122486,
+	.0175459372914742,		//10
+	.0190554584671906,
+	.020532847967908,
+	.0219756145344162,
+	.0233813253070112,
+	.0247476099206597,
+	.026072164497986,
+	.0273527555318275,
+	.028587223650054,
+	.029773487255905,
+	.0309095460374916,		//20
+	.0319934843404216,
+	.0330234743977917,
+	.0339977794120564,
+	.0349147564835508,
+	.0357728593807139,
+	.0365706411473296,
+	.0373067565423816,
+	.0379799643084053,
+	.0385891292645067,
+	.0391332242205184,		//30
+	.0396113317090621,
+	.0400226455325968,
+	.040366472122844,
+	.0406422317102947,
+	.0408494593018285,
+	.040987805464794,
+	.0410570369162294,
+	.0410570369162294,
+	.040987805464794,
+	.0408494593018285,		//40
+	.0406422317102947,
+	.040366472122844,
+	.0400226455325968,
+	.0396113317090621,
+	.0391332242205184,
+	.0385891292645067,
+	.0379799643084053,
+	.0373067565423816,
+	.0365706411473296,
+	.0357728593807139,		//50
+	.0349147564835508,
+	.0339977794120564,
+	.0330234743977917,
+	.0319934843404216,
+	.0309095460374916,
+	.029773487255905,
+	.028587223650054,
+	.0273527555318275,
+	.026072164497986,
+	.0247476099206597,		//60
+	.0233813253070112,
+	.0219756145344162,
+	.020532847967908,
+	.0190554584671906,
+	.0175459372914742,
+	.0160068299122486,
+	.0144407317482767,
+	.0128502838475101,
+	.0112381685696677,
+	.00960710541471375,		//70
+	.00795984747723973,
+	.00629918049732845,
+	.00462793522803742,
+	.00294910295364247,
+	.00126779163408536		//75 (indexed from 0)
+};
+
+constant double Gauss76Z[76] = {
+	-.999505948362153,		//0
+	-.997397786355355,
+	-.993608772723527,
+	-.988144453359837,
+	-.981013938975656,
+	-.972229228520377,
+	-.961805126758768,
+	-.949759207710896,
+	-.936111781934811,
+	-.92088586125215,
+	-.904107119545567,		//10
+	-.885803849292083,
+	-.866006913771982,
+	-.844749694983342,
+	-.822068037328975,
+	-.7980001871612,
+	-.77258672828181,
+	-.74587051350361,
+	-.717896592387704,
+	-.688712135277641,
+	-.658366353758143,		//20
+	-.626910417672267,
+	-.594397368836793,
+	-.560882031601237,
+	-.526420920401243,
+	-.491072144462194,
+	-.454895309813726,
+	-.417951418780327,
+	-.380302767117504,
+	-.342012838966962,
+	-.303146199807908,		//30
+	-.263768387584994,
+	-.223945802196474,
+	-.183745593528914,
+	-.143235548227268,
+	-.102483975391227,
+	-.0615595913906112,
+	-.0205314039939986,
+	.0205314039939986,
+	.0615595913906112,
+	.102483975391227,			//40
+	.143235548227268,
+	.183745593528914,
+	.223945802196474,
+	.263768387584994,
+	.303146199807908,
+	.342012838966962,
+	.380302767117504,
+	.417951418780327,
+	.454895309813726,
+	.491072144462194,		//50
+	.526420920401243,
+	.560882031601237,
+	.594397368836793,
+	.626910417672267,
+	.658366353758143,
+	.688712135277641,
+	.717896592387704,
+	.74587051350361,
+	.77258672828181,
+	.7980001871612,	//60
+	.822068037328975,
+	.844749694983342,
+	.866006913771982,
+	.885803849292083,
+	.904107119545567,
+	.92088586125215,
+	.936111781934811,
+	.949759207710896,
+	.961805126758768,
+	.972229228520377,		//70
+	.981013938975656,
+	.988144453359837,
+	.993608772723527,
+	.997397786355355,
+	.999505948362153		//75
+};
+
+
+#pragma acc declare copyin(Gauss76Wt[0:76], Gauss76Z[0:76])
+
+#line 1 ".././models/core_shell_cylinder.c"
+
+// vd = volume * delta_rho
+// besarg = q * R * sin(theta)
+// siarg = q * L/2 * cos(theta)
+static double _cyl(double vd, double besarg, double siarg)
+{
+    return vd * sas_sinx_x(siarg) * sas_2J1x_x(besarg);
+}
+
+static double
+form_volume(double radius, double thickness, double length)
+{
+    return M_PI*square(radius+thickness)*(length+2.0*thickness);
+}
+
+static double
+radius_from_excluded_volume(double radius, double thickness, double length)
+{
+    const double radius_tot = radius + thickness;
+    const double length_tot = length + 2.0*thickness;
+    return 0.5*cbrt(0.75*radius_tot*(2.0*radius_tot*length_tot + (radius_tot + length_tot)*(M_PI*radius_tot + length_tot)));
+}
+
+static double
+radius_from_volume(double radius, double thickness, double length)
+{
+    const double volume_outer_cyl = form_volume(radius,thickness,length);
+    return cbrt(volume_outer_cyl/M_4PI_3);
+}
+
+static double
+radius_from_diagonal(double radius, double thickness, double length)
+{
+    const double radius_outer = radius + thickness;
+    const double length_outer = length + 2.0*thickness;
+    return sqrt(radius_outer*radius_outer + 0.25*length_outer*length_outer);
+}
+
+static double
+radius_effective(int mode, double radius, double thickness, double length)
+{
+    switch (mode) {
+    default:
+    case 1: //cylinder excluded volume
+        return radius_from_excluded_volume(radius, thickness, length);
+    case 2: // equivalent volume sphere
+        return radius_from_volume(radius, thickness, length);
+    case 3: // outer radius
+        return radius + thickness;
+    case 4: // half outer length
+        return 0.5*length + thickness;
+    case 5: // half min outer length
+        return (radius < 0.5*length ? radius + thickness : 0.5*length + thickness);
+    case 6: // half max outer length
+        return (radius > 0.5*length ? radius + thickness : 0.5*length + thickness);
+    case 7: // half outer diagonal
+        return radius_from_diagonal(radius,thickness,length);
+    }
+}
+
+static void
+Fq(double q,
+    double *F1,
+    double *F2,
+    double core_sld,
+    double shell_sld,
+    double solvent_sld,
+    double radius,
+    double thickness,
+    double length)
+{
+    // precalculate constants
+    const double core_r = radius;
+    const double core_h = 0.5*length;
+    const double core_vd = form_volume(radius,0,length) * (core_sld-shell_sld);
+    const double shell_r = (radius + thickness);
+    const double shell_h = (0.5*length + thickness);
+    const double shell_vd = form_volume(radius,thickness,length) * (shell_sld-solvent_sld);
+    double total_F1 = 0.0;
+    double total_F2 = 0.0;
+    for (int i=0; i<GAUSS_N ;i++) {
+        // translate a point in [-1,1] to a point in [0, pi/2]
+        //const double theta = ( GAUSS_Z[i]*(upper-lower) + upper + lower )/2.0;
+        double sin_theta, cos_theta;
+        const double theta = GAUSS_Z[i]*M_PI_4 + M_PI_4;
+        SINCOS(theta, sin_theta,  cos_theta);
+        const double qab = q*sin_theta;
+        const double qc = q*cos_theta;
+        const double fq = _cyl(core_vd, core_r*qab, core_h*qc)
+            + _cyl(shell_vd, shell_r*qab, shell_h*qc);
+        total_F1 += GAUSS_W[i] * fq * sin_theta;
+        total_F2 += GAUSS_W[i] * fq * fq * sin_theta;
+    }
+    // translate dx in [-1,1] to dx in [lower,upper]
+    //const double form = (upper-lower)/2.0*total;
+    *F1 = 1.0e-2 * total_F1 * M_PI_4;
+    *F2 = 1.0e-4 * total_F2 * M_PI_4;
+}
+
+static double
+Iqac(double qab, double qc,
+    double core_sld,
+    double shell_sld,
+    double solvent_sld,
+    double radius,
+    double thickness,
+    double length)
+{
+    const double core_r = radius;
+    const double core_h = 0.5*length;
+    const double core_vd = form_volume(radius,0,length) * (core_sld-shell_sld);
+    const double shell_r = (radius + thickness);
+    const double shell_h = (0.5*length + thickness);
+    const double shell_vd = form_volume(radius,thickness,length) * (shell_sld-solvent_sld);
+
+    const double fq = _cyl(core_vd, core_r*qab, core_h*qc)
+        + _cyl(shell_vd, shell_r*qab, shell_h*qc);
+    return 1.0e-4 * fq * fq;
+}
+
+

--- a/mcstas-comps/share/sas_core_shell_ellipsoid.c
+++ b/mcstas-comps/share/sas_core_shell_ellipsoid.c
@@ -1,0 +1,782 @@
+#define HAS_Iqac
+#define HAS_FQ
+#define FORM_VOL
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/sas_3j1x_x.c"
+
+/**
+* Spherical Bessel function 3*j1(x)/x
+*
+* Used for low q to avoid cancellation error.
+* Note that the values differ from sasview ~ 5e-12 rather than 5e-14, but
+* in this case it is likely cancellation errors in the original expression
+* using double precision that are the source.
+*/
+double sas_3j1x_x(double q);
+
+// The choice of the number of terms in the series and the cutoff value for
+// switching between series and direct calculation depends on the numeric
+// precision.
+//
+// Point where direct calculation reaches machine precision:
+//
+//   single machine precision eps 3e-8 at qr=1.1 **
+//   double machine precision eps 4e-16 at qr=1.1
+//
+// Point where Taylor series reaches machine precision (eps), where taylor
+// series matches direct calculation (cross) and the error at that point:
+//
+//   prec   n eps  cross  error
+//   single 3 0.28  0.4   6.2e-7
+//   single 4 0.68  0.7   2.3e-7
+//   single 5 1.18  1.2   7.5e-8
+//   double 3 0.01  0.03  2.3e-13
+//   double 4 0.06  0.1   3.1e-14
+//   double 5 0.16  0.2   5.0e-15
+//
+// ** Note: relative error on single precision starts increase on the direct
+// method at qr=1.1, rising from 3e-8 to 5e-5 by qr=1e3.  This should be
+// safe for the sans range, with objects of 100 nm supported to a q of 0.1
+// while maintaining 5 digits of precision.  For usans/sesans, the objects
+// are larger but the q is smaller, so again it should be fine.
+//
+// See explore/sph_j1c.py for code to explore these ranges.
+
+// Use 4th order series
+#if FLOAT_SIZE>4
+#define SPH_J1C_CUTOFF 0.1
+#else
+#define SPH_J1C_CUTOFF 0.7
+#endif
+#pragma acc routine seq
+double sas_3j1x_x(double q)
+{
+    // 2017-05-18 PAK - support negative q
+    if (fabs(q) < SPH_J1C_CUTOFF) {
+        const double q2 = q*q;
+        return (1.0 + q2*(-3./30. + q2*(3./840. + q2*(-3./45360.))));// + q2*(3./3991680.)))));
+    } else {
+        double sin_q, cos_q;
+        SINCOS(q, sin_q, cos_q);
+        return 3.0*(sin_q/q - cos_q)/(q*q);
+    }
+}
+
+
+#line 1 ".././models/lib/gauss76.c"
+
+// Created by Andrew Jackson on 4/23/07
+
+ #ifdef GAUSS_N
+ # undef GAUSS_N
+ # undef GAUSS_Z
+ # undef GAUSS_W
+ #endif
+ #define GAUSS_N 76
+ #define GAUSS_Z Gauss76Z
+ #define GAUSS_W Gauss76Wt
+
+// Gaussians
+constant double Gauss76Wt[76] = {
+	.00126779163408536,		//0
+	.00294910295364247,
+	.00462793522803742,
+	.00629918049732845,
+	.00795984747723973,
+	.00960710541471375,
+	.0112381685696677,
+	.0128502838475101,
+	.0144407317482767,
+	.0160068299122486,
+	.0175459372914742,		//10
+	.0190554584671906,
+	.020532847967908,
+	.0219756145344162,
+	.0233813253070112,
+	.0247476099206597,
+	.026072164497986,
+	.0273527555318275,
+	.028587223650054,
+	.029773487255905,
+	.0309095460374916,		//20
+	.0319934843404216,
+	.0330234743977917,
+	.0339977794120564,
+	.0349147564835508,
+	.0357728593807139,
+	.0365706411473296,
+	.0373067565423816,
+	.0379799643084053,
+	.0385891292645067,
+	.0391332242205184,		//30
+	.0396113317090621,
+	.0400226455325968,
+	.040366472122844,
+	.0406422317102947,
+	.0408494593018285,
+	.040987805464794,
+	.0410570369162294,
+	.0410570369162294,
+	.040987805464794,
+	.0408494593018285,		//40
+	.0406422317102947,
+	.040366472122844,
+	.0400226455325968,
+	.0396113317090621,
+	.0391332242205184,
+	.0385891292645067,
+	.0379799643084053,
+	.0373067565423816,
+	.0365706411473296,
+	.0357728593807139,		//50
+	.0349147564835508,
+	.0339977794120564,
+	.0330234743977917,
+	.0319934843404216,
+	.0309095460374916,
+	.029773487255905,
+	.028587223650054,
+	.0273527555318275,
+	.026072164497986,
+	.0247476099206597,		//60
+	.0233813253070112,
+	.0219756145344162,
+	.020532847967908,
+	.0190554584671906,
+	.0175459372914742,
+	.0160068299122486,
+	.0144407317482767,
+	.0128502838475101,
+	.0112381685696677,
+	.00960710541471375,		//70
+	.00795984747723973,
+	.00629918049732845,
+	.00462793522803742,
+	.00294910295364247,
+	.00126779163408536		//75 (indexed from 0)
+};
+
+constant double Gauss76Z[76] = {
+	-.999505948362153,		//0
+	-.997397786355355,
+	-.993608772723527,
+	-.988144453359837,
+	-.981013938975656,
+	-.972229228520377,
+	-.961805126758768,
+	-.949759207710896,
+	-.936111781934811,
+	-.92088586125215,
+	-.904107119545567,		//10
+	-.885803849292083,
+	-.866006913771982,
+	-.844749694983342,
+	-.822068037328975,
+	-.7980001871612,
+	-.77258672828181,
+	-.74587051350361,
+	-.717896592387704,
+	-.688712135277641,
+	-.658366353758143,		//20
+	-.626910417672267,
+	-.594397368836793,
+	-.560882031601237,
+	-.526420920401243,
+	-.491072144462194,
+	-.454895309813726,
+	-.417951418780327,
+	-.380302767117504,
+	-.342012838966962,
+	-.303146199807908,		//30
+	-.263768387584994,
+	-.223945802196474,
+	-.183745593528914,
+	-.143235548227268,
+	-.102483975391227,
+	-.0615595913906112,
+	-.0205314039939986,
+	.0205314039939986,
+	.0615595913906112,
+	.102483975391227,			//40
+	.143235548227268,
+	.183745593528914,
+	.223945802196474,
+	.263768387584994,
+	.303146199807908,
+	.342012838966962,
+	.380302767117504,
+	.417951418780327,
+	.454895309813726,
+	.491072144462194,		//50
+	.526420920401243,
+	.560882031601237,
+	.594397368836793,
+	.626910417672267,
+	.658366353758143,
+	.688712135277641,
+	.717896592387704,
+	.74587051350361,
+	.77258672828181,
+	.7980001871612,	//60
+	.822068037328975,
+	.844749694983342,
+	.866006913771982,
+	.885803849292083,
+	.904107119545567,
+	.92088586125215,
+	.936111781934811,
+	.949759207710896,
+	.961805126758768,
+	.972229228520377,		//70
+	.981013938975656,
+	.988144453359837,
+	.993608772723527,
+	.997397786355355,
+	.999505948362153		//75
+};
+
+
+#pragma acc declare copyin(Gauss76Wt[0:76], Gauss76Z[0:76])
+
+#line 1 ".././models/core_shell_ellipsoid.c"
+
+
+// Converted from Igor function gfn4, using the same pattern as ellipsoid
+// for evaluating the parts of the integral.
+//     FUNCTION gfn4:    CONTAINS F(Q,A,B,MU)**2  AS GIVEN
+//                       BY (53) & (58-59) IN CHEN AND
+//                       KOTLARCHYK REFERENCE
+//
+//       <OBLATE ELLIPSOID>
+static double
+_cs_ellipsoid_kernel(double qab, double qc,
+    double equat_core, double polar_core,
+    double equat_shell, double polar_shell,
+    double sld_core_shell, double sld_shell_solvent)
+{
+    const double qr_core = sqrt(square(equat_core*qab) + square(polar_core*qc));
+    const double si_core = sas_3j1x_x(qr_core);
+    const double volume_core = M_4PI_3*equat_core*equat_core*polar_core;
+    const double fq_core = si_core*volume_core*sld_core_shell;
+
+    const double qr_shell = sqrt(square(equat_shell*qab) + square(polar_shell*qc));
+    const double si_shell = sas_3j1x_x(qr_shell);
+    const double volume_shell = M_4PI_3*equat_shell*equat_shell*polar_shell;
+    const double fq_shell = si_shell*volume_shell*sld_shell_solvent;
+
+    return fq_core + fq_shell;
+}
+
+static double
+form_volume(double radius_equat_core,
+    double x_core,
+    double thick_shell,
+    double x_polar_shell)
+{
+    const double equat_shell = radius_equat_core + thick_shell;
+    const double polar_shell = radius_equat_core*x_core + thick_shell*x_polar_shell;
+    double vol = M_4PI_3*equat_shell*equat_shell*polar_shell;
+    return vol;
+}
+
+static double
+radius_from_volume(double radius_equat_core, double x_core, double thick_shell, double x_polar_shell)
+{
+    const double volume_ellipsoid = form_volume(radius_equat_core, x_core, thick_shell, x_polar_shell);
+    return cbrt(volume_ellipsoid/M_4PI_3);
+}
+
+static double
+radius_from_curvature(double radius_equat_core, double x_core, double thick_shell, double x_polar_shell)
+{
+    // Trivial cases
+    if (1.0 == x_core && 1.0 == x_polar_shell) return radius_equat_core + thick_shell;
+    if ((radius_equat_core + thick_shell)*(radius_equat_core*x_core + thick_shell*x_polar_shell) == 0.)  return 0.;
+
+    // see equation (26) in A.Isihara, J.Chem.Phys. 18(1950)1446-1449
+    const double radius_equat_tot = radius_equat_core + thick_shell;
+    const double radius_polar_tot = radius_equat_core*x_core + thick_shell*x_polar_shell;
+    const double ratio = (radius_polar_tot < radius_equat_tot
+                          ? radius_polar_tot / radius_equat_tot
+                          : radius_equat_tot / radius_polar_tot);
+    const double e1 = sqrt(1.0 - ratio*ratio);
+    const double b1 = 1.0 + asin(e1) / (e1 * ratio);
+    const double bL = (1.0 + e1) / (1.0 - e1);
+    const double b2 = 1.0 + 0.5 * ratio * ratio / e1 * log(bL);
+    const double delta = 0.75 * b1 * b2;
+    const double ddd = 2.0 * (delta + 1.0) * radius_polar_tot * radius_equat_tot * radius_equat_tot;
+    return 0.5 * cbrt(ddd);
+}
+
+static double
+radius_effective(int mode, double radius_equat_core, double x_core, double thick_shell, double x_polar_shell)
+{
+    const double radius_equat_tot = radius_equat_core + thick_shell;
+    const double radius_polar_tot = radius_equat_core*x_core + thick_shell*x_polar_shell;
+
+    switch (mode) {
+    default:
+    case 1: // average outer curvature
+        return radius_from_curvature(radius_equat_core, x_core, thick_shell, x_polar_shell);
+    case 2: // equivalent volume sphere
+        return radius_from_volume(radius_equat_core, x_core, thick_shell, x_polar_shell);
+    case 3: // min outer radius
+        return (radius_polar_tot < radius_equat_tot ? radius_polar_tot : radius_equat_tot);
+    case 4: // max outer radius
+        return (radius_polar_tot > radius_equat_tot ? radius_polar_tot : radius_equat_tot);
+    }
+}
+
+static void
+Fq(double q,
+    double *F1,
+    double *F2,
+    double radius_equat_core,
+    double x_core,
+    double thick_shell,
+    double x_polar_shell,
+    double core_sld,
+    double shell_sld,
+    double solvent_sld)
+{
+    const double sld_core_shell = core_sld - shell_sld;
+    const double sld_shell_solvent = shell_sld - solvent_sld;
+
+    const double polar_core = radius_equat_core*x_core;
+    const double equat_shell = radius_equat_core + thick_shell;
+    const double polar_shell = radius_equat_core*x_core + thick_shell*x_polar_shell;
+
+    // translate from [-1, 1] => [0, 1]
+    const double m = 0.5;
+    const double b = 0.5;
+    double total_F1 = 0.0;     //initialize intergral
+    double total_F2 = 0.0;     //initialize intergral
+    for(int i=0;i<GAUSS_N;i++) {
+        const double cos_theta = GAUSS_Z[i]*m + b;
+        const double sin_theta = sqrt(1.0 - cos_theta*cos_theta);
+        double fq = _cs_ellipsoid_kernel(q*sin_theta, q*cos_theta,
+            radius_equat_core, polar_core,
+            equat_shell, polar_shell,
+            sld_core_shell, sld_shell_solvent);
+        total_F1 += GAUSS_W[i] * fq;
+        total_F2 += GAUSS_W[i] * fq * fq;
+    }
+    total_F1 *= m;
+    total_F2 *= m;
+
+    // convert to [cm-1]
+    *F1 = 1.0e-2 * total_F1;
+    *F2 = 1.0e-4 * total_F2;
+}
+
+
+static double
+Iqac(double qab, double qc,
+    double radius_equat_core,
+    double x_core,
+    double thick_shell,
+    double x_polar_shell,
+    double core_sld,
+    double shell_sld,
+    double solvent_sld)
+{
+    const double sld_core_shell = core_sld - shell_sld;
+    const double sld_shell_solvent = shell_sld - solvent_sld;
+
+    const double polar_core = radius_equat_core*x_core;
+    const double equat_shell = radius_equat_core + thick_shell;
+    const double polar_shell = radius_equat_core*x_core + thick_shell*x_polar_shell;
+
+    double fq = _cs_ellipsoid_kernel(qab, qc,
+                  radius_equat_core, polar_core,
+                  equat_shell, polar_shell,
+                  sld_core_shell, sld_shell_solvent);
+
+    //convert to [cm-1]
+    return 1.0e-4 * fq * fq;
+}
+
+

--- a/mcstas-comps/share/sas_core_shell_parallelepiped.c
+++ b/mcstas-comps/share/sas_core_shell_parallelepiped.c
@@ -1,0 +1,795 @@
+#define HAS_Iqabc
+#define HAS_FQ
+#define FORM_VOL
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/gauss76.c"
+
+// Created by Andrew Jackson on 4/23/07
+
+ #ifdef GAUSS_N
+ # undef GAUSS_N
+ # undef GAUSS_Z
+ # undef GAUSS_W
+ #endif
+ #define GAUSS_N 76
+ #define GAUSS_Z Gauss76Z
+ #define GAUSS_W Gauss76Wt
+
+// Gaussians
+constant double Gauss76Wt[76] = {
+	.00126779163408536,		//0
+	.00294910295364247,
+	.00462793522803742,
+	.00629918049732845,
+	.00795984747723973,
+	.00960710541471375,
+	.0112381685696677,
+	.0128502838475101,
+	.0144407317482767,
+	.0160068299122486,
+	.0175459372914742,		//10
+	.0190554584671906,
+	.020532847967908,
+	.0219756145344162,
+	.0233813253070112,
+	.0247476099206597,
+	.026072164497986,
+	.0273527555318275,
+	.028587223650054,
+	.029773487255905,
+	.0309095460374916,		//20
+	.0319934843404216,
+	.0330234743977917,
+	.0339977794120564,
+	.0349147564835508,
+	.0357728593807139,
+	.0365706411473296,
+	.0373067565423816,
+	.0379799643084053,
+	.0385891292645067,
+	.0391332242205184,		//30
+	.0396113317090621,
+	.0400226455325968,
+	.040366472122844,
+	.0406422317102947,
+	.0408494593018285,
+	.040987805464794,
+	.0410570369162294,
+	.0410570369162294,
+	.040987805464794,
+	.0408494593018285,		//40
+	.0406422317102947,
+	.040366472122844,
+	.0400226455325968,
+	.0396113317090621,
+	.0391332242205184,
+	.0385891292645067,
+	.0379799643084053,
+	.0373067565423816,
+	.0365706411473296,
+	.0357728593807139,		//50
+	.0349147564835508,
+	.0339977794120564,
+	.0330234743977917,
+	.0319934843404216,
+	.0309095460374916,
+	.029773487255905,
+	.028587223650054,
+	.0273527555318275,
+	.026072164497986,
+	.0247476099206597,		//60
+	.0233813253070112,
+	.0219756145344162,
+	.020532847967908,
+	.0190554584671906,
+	.0175459372914742,
+	.0160068299122486,
+	.0144407317482767,
+	.0128502838475101,
+	.0112381685696677,
+	.00960710541471375,		//70
+	.00795984747723973,
+	.00629918049732845,
+	.00462793522803742,
+	.00294910295364247,
+	.00126779163408536		//75 (indexed from 0)
+};
+
+constant double Gauss76Z[76] = {
+	-.999505948362153,		//0
+	-.997397786355355,
+	-.993608772723527,
+	-.988144453359837,
+	-.981013938975656,
+	-.972229228520377,
+	-.961805126758768,
+	-.949759207710896,
+	-.936111781934811,
+	-.92088586125215,
+	-.904107119545567,		//10
+	-.885803849292083,
+	-.866006913771982,
+	-.844749694983342,
+	-.822068037328975,
+	-.7980001871612,
+	-.77258672828181,
+	-.74587051350361,
+	-.717896592387704,
+	-.688712135277641,
+	-.658366353758143,		//20
+	-.626910417672267,
+	-.594397368836793,
+	-.560882031601237,
+	-.526420920401243,
+	-.491072144462194,
+	-.454895309813726,
+	-.417951418780327,
+	-.380302767117504,
+	-.342012838966962,
+	-.303146199807908,		//30
+	-.263768387584994,
+	-.223945802196474,
+	-.183745593528914,
+	-.143235548227268,
+	-.102483975391227,
+	-.0615595913906112,
+	-.0205314039939986,
+	.0205314039939986,
+	.0615595913906112,
+	.102483975391227,			//40
+	.143235548227268,
+	.183745593528914,
+	.223945802196474,
+	.263768387584994,
+	.303146199807908,
+	.342012838966962,
+	.380302767117504,
+	.417951418780327,
+	.454895309813726,
+	.491072144462194,		//50
+	.526420920401243,
+	.560882031601237,
+	.594397368836793,
+	.626910417672267,
+	.658366353758143,
+	.688712135277641,
+	.717896592387704,
+	.74587051350361,
+	.77258672828181,
+	.7980001871612,	//60
+	.822068037328975,
+	.844749694983342,
+	.866006913771982,
+	.885803849292083,
+	.904107119545567,
+	.92088586125215,
+	.936111781934811,
+	.949759207710896,
+	.961805126758768,
+	.972229228520377,		//70
+	.981013938975656,
+	.988144453359837,
+	.993608772723527,
+	.997397786355355,
+	.999505948362153		//75
+};
+
+
+#pragma acc declare copyin(Gauss76Wt[0:76], Gauss76Z[0:76])
+
+#line 1 ".././models/core_shell_parallelepiped.c"
+
+// Set OVERLAPPING to 1 in order to fill in the edges of the box, with
+// c endcaps and b overlapping a.  With the proper choice of parameters,
+// (setting rim slds to sld, core sld to solvent, rim thickness to thickness
+// and subtracting 2*thickness from length, this should match the hollow
+// rectangular prism.)  Set it to 0 for the documented behaviour.
+#define OVERLAPPING 0
+static double
+form_volume(double length_a, double length_b, double length_c,
+    double thick_rim_a, double thick_rim_b, double thick_rim_c)
+{
+    return
+#if OVERLAPPING
+        // Hollow rectangular prism only includes the volume of the shell
+        // so uncomment the next line when comparing.  Solid rectangular
+        // prism, or parallelepiped want filled cores, so comment when
+        // comparing.
+        //-length_a * length_b * length_c +
+        (length_a + 2.0*thick_rim_a) *
+        (length_b + 2.0*thick_rim_b) *
+        (length_c + 2.0*thick_rim_c);
+#else
+        length_a * length_b * length_c +
+        2.0 * thick_rim_a * length_b * length_c +
+        2.0 * length_a * thick_rim_b * length_c +
+        2.0 * length_a * length_b * thick_rim_c;
+#endif
+}
+
+static double
+radius_from_excluded_volume(double length_a, double length_b, double length_c,
+                   double thick_rim_a, double thick_rim_b, double thick_rim_c)
+{
+    double r_equiv, length;
+    double lengths[3] = {length_a+thick_rim_a, length_b+thick_rim_b, length_c+thick_rim_c};
+    double lengthmax = fmax(lengths[0],fmax(lengths[1],lengths[2]));
+    double length_1 = lengthmax;
+    double length_2 = lengthmax;
+    double length_3 = lengthmax;
+
+    for(int ilen=0; ilen<3; ilen++) {
+        if (lengths[ilen] < length_1) {
+            length_2 = length_1;
+            length_1 = lengths[ilen];
+            } else {
+                if (lengths[ilen] < length_2) {
+                        length_2 = lengths[ilen];
+                }
+            }
+    }
+    if(length_2-length_1 > length_3-length_2) {
+        r_equiv = sqrt(length_2*length_3/M_PI);
+        length  = length_1;
+    } else  {
+        r_equiv = sqrt(length_1*length_2/M_PI);
+        length  = length_3;
+    }
+
+    return 0.5*cbrt(0.75*r_equiv*(2.0*r_equiv*length + (r_equiv + length)*(M_PI*r_equiv + length)));
+}
+
+static double
+radius_from_volume(double length_a, double length_b, double length_c,
+                   double thick_rim_a, double thick_rim_b, double thick_rim_c)
+{
+    const double volume = form_volume(length_a, length_b, length_c, thick_rim_a, thick_rim_b, thick_rim_c);
+    return cbrt(volume/M_4PI_3);
+}
+
+static double
+radius_from_crosssection(double length_a, double length_b, double thick_rim_a, double thick_rim_b)
+{
+    const double area_xsec_paral = length_a*length_b + 2.0*thick_rim_a*length_b + 2.0*thick_rim_b*length_a;
+    return sqrt(area_xsec_paral/M_PI);
+}
+
+static double
+radius_effective(int mode, double length_a, double length_b, double length_c,
+                 double thick_rim_a, double thick_rim_b, double thick_rim_c)
+{
+    switch (mode) {
+    default:
+    case 1: // equivalent cylinder excluded volume
+        return radius_from_excluded_volume(length_a, length_b, length_c, thick_rim_a, thick_rim_b, thick_rim_c);
+    case 2: // equivalent volume sphere
+        return radius_from_volume(length_a, length_b, length_c, thick_rim_a, thick_rim_b, thick_rim_c);
+    case 3: // half outer length a
+        return 0.5 * length_a + thick_rim_a;
+    case 4: // half outer length b
+        return 0.5 * length_b + thick_rim_b;
+    case 5: // half outer length c
+        return 0.5 * length_c + thick_rim_c;
+    case 6: // equivalent circular cross-section
+        return radius_from_crosssection(length_a, length_b, thick_rim_a, thick_rim_b);
+    case 7: // half outer ab diagonal
+        return 0.5*sqrt(square(length_a+ 2.0*thick_rim_a) + square(length_b+ 2.0*thick_rim_b));
+    case 8: // half outer diagonal
+        return 0.5*sqrt(square(length_a+ 2.0*thick_rim_a) + square(length_b+ 2.0*thick_rim_b) + square(length_c+ 2.0*thick_rim_c));
+    }
+}
+
+static void
+Fq(double q,
+    double *F1,
+    double *F2,
+    double core_sld,
+    double arim_sld,
+    double brim_sld,
+    double crim_sld,
+    double solvent_sld,
+    double length_a,
+    double length_b,
+    double length_c,
+    double thick_rim_a,
+    double thick_rim_b,
+    double thick_rim_c)
+{
+    // Code converted from functions CSPPKernel and CSParallelepiped in libCylinder.c
+    // Did not understand the code completely, it should be rechecked (Miguel Gonzalez)
+    // Code is rewritten, the code is compliant with Diva Singh's thesis now (Dirk Honecker)
+    // Code rewritten; cross checked against hollow rectangular prism and realspace (PAK)
+
+    const double half_q = 0.5*q;
+
+    const double tA = length_a + 2.0*thick_rim_a;
+    const double tB = length_b + 2.0*thick_rim_b;
+    const double tC = length_c + 2.0*thick_rim_c;
+
+    // Scale factors
+    const double dr0 = (core_sld-solvent_sld);
+    const double drA = (arim_sld-solvent_sld);
+    const double drB = (brim_sld-solvent_sld);
+    const double drC = (crim_sld-solvent_sld);
+
+    // outer integral (with gauss points), integration limits = 0, 1
+    // substitute d_cos_alpha for sin_alpha d_alpha
+    double outer_sum_F1 = 0; //initialize integral
+    double outer_sum_F2 = 0; //initialize integral
+    for( int i=0; i<GAUSS_N; i++) {
+        const double cos_alpha = 0.5 * ( GAUSS_Z[i] + 1.0 );
+        const double mu = half_q * sqrt(1.0-cos_alpha*cos_alpha);
+        const double siC = length_c * sas_sinx_x(length_c * cos_alpha * half_q);
+        const double siCt = tC * sas_sinx_x(tC * cos_alpha * half_q);
+
+        // inner integral (with gauss points), integration limits = 0, 1
+        // substitute beta = PI/2 u (so 2/PI * d_(PI/2 * beta) = d_beta)
+        double inner_sum_F1 = 0.0;
+        double inner_sum_F2 = 0.0;
+        for(int j=0; j<GAUSS_N; j++) {
+            const double u = 0.5 * ( GAUSS_Z[j] + 1.0 );
+            double sin_beta, cos_beta;
+            SINCOS(M_PI_2*u, sin_beta, cos_beta);
+            const double siA = length_a * sas_sinx_x(length_a * mu * sin_beta);
+            const double siB = length_b * sas_sinx_x(length_b * mu * cos_beta);
+            const double siAt = tA * sas_sinx_x(tA * mu * sin_beta);
+            const double siBt = tB * sas_sinx_x(tB * mu * cos_beta);
+
+#if OVERLAPPING
+            const double f = dr0*siA*siB*siC
+                + drA*(siAt-siA)*siB*siC
+                + drB*siAt*(siBt-siB)*siC
+                + drC*siAt*siBt*(siCt-siC);
+#else
+            const double f = dr0*siA*siB*siC
+                + drA*(siAt-siA)*siB*siC
+                + drB*siA*(siBt-siB)*siC
+                + drC*siA*siB*(siCt-siC);
+#endif
+
+            inner_sum_F1 += GAUSS_W[j] * f;
+            inner_sum_F2 += GAUSS_W[j] * f * f;
+        }
+        // now complete change of inner integration variable (1-0)/(1-(-1))= 0.5
+        // and sum up the outer integral
+        outer_sum_F1 += GAUSS_W[i] * inner_sum_F1 * 0.5;
+        outer_sum_F2 += GAUSS_W[i] * inner_sum_F2 * 0.5;
+    }
+    // now complete change of outer integration variable (1-0)/(1-(-1))= 0.5
+    outer_sum_F1 *= 0.5;
+    outer_sum_F2 *= 0.5;
+
+    //convert from [1e-12 A-1] to [cm-1]
+    *F1 = 1.0e-2 * outer_sum_F1;
+    *F2 = 1.0e-4 * outer_sum_F2;
+}
+
+static double
+Iqabc(double qa, double qb, double qc,
+    double core_sld,
+    double arim_sld,
+    double brim_sld,
+    double crim_sld,
+    double solvent_sld,
+    double length_a,
+    double length_b,
+    double length_c,
+    double thick_rim_a,
+    double thick_rim_b,
+    double thick_rim_c)
+{
+    // cspkernel in csparallelepiped recoded here
+    const double dr0 = core_sld-solvent_sld;
+    const double drA = arim_sld-solvent_sld;
+    const double drB = brim_sld-solvent_sld;
+    const double drC = crim_sld-solvent_sld;
+
+    const double tA = length_a + 2.0*thick_rim_a;
+    const double tB = length_b + 2.0*thick_rim_b;
+    const double tC = length_c + 2.0*thick_rim_c;
+    const double siA = length_a*sas_sinx_x(0.5*length_a*qa);
+    const double siB = length_b*sas_sinx_x(0.5*length_b*qb);
+    const double siC = length_c*sas_sinx_x(0.5*length_c*qc);
+    const double siAt = tA*sas_sinx_x(0.5*tA*qa);
+    const double siBt = tB*sas_sinx_x(0.5*tB*qb);
+    const double siCt = tC*sas_sinx_x(0.5*tC*qc);
+
+#if OVERLAPPING
+    const double f = dr0*siA*siB*siC
+        + drA*(siAt-siA)*siB*siC
+        + drB*siAt*(siBt-siB)*siC
+        + drC*siAt*siBt*(siCt-siC);
+#else
+    const double f = dr0*siA*siB*siC
+        + drA*(siAt-siA)*siB*siC
+        + drB*siA*(siBt-siB)*siC
+        + drC*siA*siB*(siCt-siC);
+#endif
+
+    return 1.0e-4 * f * f;
+}
+
+

--- a/mcstas-comps/share/sas_core_shell_sphere.c
+++ b/mcstas-comps/share/sas_core_shell_sphere.c
@@ -1,0 +1,530 @@
+#define HAS_FQ
+#define FORM_VOL
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/sas_3j1x_x.c"
+
+/**
+* Spherical Bessel function 3*j1(x)/x
+*
+* Used for low q to avoid cancellation error.
+* Note that the values differ from sasview ~ 5e-12 rather than 5e-14, but
+* in this case it is likely cancellation errors in the original expression
+* using double precision that are the source.
+*/
+double sas_3j1x_x(double q);
+
+// The choice of the number of terms in the series and the cutoff value for
+// switching between series and direct calculation depends on the numeric
+// precision.
+//
+// Point where direct calculation reaches machine precision:
+//
+//   single machine precision eps 3e-8 at qr=1.1 **
+//   double machine precision eps 4e-16 at qr=1.1
+//
+// Point where Taylor series reaches machine precision (eps), where taylor
+// series matches direct calculation (cross) and the error at that point:
+//
+//   prec   n eps  cross  error
+//   single 3 0.28  0.4   6.2e-7
+//   single 4 0.68  0.7   2.3e-7
+//   single 5 1.18  1.2   7.5e-8
+//   double 3 0.01  0.03  2.3e-13
+//   double 4 0.06  0.1   3.1e-14
+//   double 5 0.16  0.2   5.0e-15
+//
+// ** Note: relative error on single precision starts increase on the direct
+// method at qr=1.1, rising from 3e-8 to 5e-5 by qr=1e3.  This should be
+// safe for the sans range, with objects of 100 nm supported to a q of 0.1
+// while maintaining 5 digits of precision.  For usans/sesans, the objects
+// are larger but the q is smaller, so again it should be fine.
+//
+// See explore/sph_j1c.py for code to explore these ranges.
+
+// Use 4th order series
+#if FLOAT_SIZE>4
+#define SPH_J1C_CUTOFF 0.1
+#else
+#define SPH_J1C_CUTOFF 0.7
+#endif
+#pragma acc routine seq
+double sas_3j1x_x(double q)
+{
+    // 2017-05-18 PAK - support negative q
+    if (fabs(q) < SPH_J1C_CUTOFF) {
+        const double q2 = q*q;
+        return (1.0 + q2*(-3./30. + q2*(3./840. + q2*(-3./45360.))));// + q2*(3./3991680.)))));
+    } else {
+        double sin_q, cos_q;
+        SINCOS(q, sin_q, cos_q);
+        return 3.0*(sin_q/q - cos_q)/(q*q);
+    }
+}
+
+
+#line 1 ".././models/lib/core_shell.c"
+
+/*******************************************************************
+
+core_shell_kernel
+
+Form factor used in core_shell and fractal_core_shell
+
+********************************************************************/
+#pragma acc routine seq
+static
+double core_shell_fq(double q,
+                         double radius,
+                         double thickness,
+                         double core_sld,
+                         double shell_sld,
+                         double solvent_sld)
+{
+    // Core first, then add in shell
+    const double core_qr = q * radius;
+    const double core_contrast = core_sld - shell_sld;
+    const double core_bes = sas_3j1x_x(core_qr);
+    const double core_volume = M_4PI_3 * cube(radius);
+    double f = core_volume * core_bes * core_contrast;
+
+    // Now the shell
+    const double shell_qr = q * (radius + thickness);
+    const double shell_contrast = shell_sld - solvent_sld;
+    const double shell_bes = sas_3j1x_x(shell_qr);
+    const double shell_volume = M_4PI_3 * cube(radius + thickness);
+    f += shell_volume * shell_bes * shell_contrast;
+    return f;
+}
+
+// Deprecated function: use core_shell_fq instead.
+#pragma acc routine seq
+static
+double core_shell_kernel(double q,
+                         double radius,
+                         double thickness,
+                         double core_sld,
+                         double shell_sld,
+                         double solvent_sld)
+{
+    const double fq = core_shell_fq(q, radius, thickness, core_sld, shell_sld, solvent_sld);
+    return 1.0e-4 * fq*fq;
+}
+
+
+#line 1 ".././models/core_shell_sphere.c"
+
+static double
+form_volume(double radius, double thickness)
+{
+    return M_4PI_3 * cube(radius + thickness);
+}
+
+static double
+radius_effective(int mode, double radius, double thickness)
+{
+    switch (mode) {
+    default:
+    case 1: // outer radius
+        return radius + thickness;
+    case 2: // core radius
+        return radius;
+    }
+}
+
+static void
+Fq(double q, double *F1, double *F2, double radius,
+   double thickness, double core_sld, double shell_sld, double solvent_sld) {
+    double form = core_shell_fq(q,
+                              radius,
+                              thickness,
+                              core_sld,
+                              shell_sld,
+                              solvent_sld);
+    *F1 = 1.0e-2*form;
+    *F2 = 1.0e-4*form*form;
+}
+
+

--- a/mcstas-comps/share/sas_correlation_length.c
+++ b/mcstas-comps/share/sas_correlation_length.c
@@ -1,0 +1,404 @@
+#define HAS_Iq
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/correlation_length.c"
+
+#include <math.h>
+
+double Iq(double q, double lorentz_scale, double porod_scale, double cor_length, double porod_exp, double lorentz_exp);
+
+#pragma acc routine seq
+double Iq(double q, double lorentz_scale, double porod_scale, double cor_length, double porod_exp, double lorentz_exp) {
+    double porod, lorentz, inten;
+
+    porod = porod_scale / pow(q, porod_exp);
+    lorentz = lorentz_scale / (1.0 + pow(q * cor_length, lorentz_exp));
+    inten = porod + lorentz;
+
+    return inten;
+}
+
+
+

--- a/mcstas-comps/share/sas_cylinder.c
+++ b/mcstas-comps/share/sas_cylinder.c
@@ -1,587 +1,1012 @@
-// GENERATED CODE --- DO NOT EDIT ---
-// Code is produced by sasmodels.gen from sasmodels/models/MODEL.c
+#define HAS_Iqac
+#define HAS_FQ
+#define FORM_VOL
+#line 1 "../kernel_header.c"
 
 #ifdef __OPENCL_VERSION__
 # define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
 #endif
 
-#define USE_KAHAN_SUMMATION 0
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
 
 // If opencl is not available, then we are compiling a C function
 // Note: if using a C++ compiler, then define kernel as extern "C"
-#ifndef USE_OPENCL
-#  ifdef __cplusplus
-     #include <cstdio>
-     #include <cmath>
-     using namespace std;
-     #if defined(_MSC_VER)
-     #   define kernel extern "C" __declspec( dllexport )
-         inline float trunc(float x) { return x>=0?floor(x):-floor(-x); }
-	 inline float fmin(float x, float y) { return x>y ? y : x; }
-	 inline float fmax(float x, float y) { return x<y ? y : x; }
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
      #else
-     #   define kernel extern "C"
+         #define kernel extern "C"
+         #include <cstdint>
      #endif
-     inline void SINCOS(float angle, float &svar, float &cvar) { svar=sin(angle); cvar=cos(angle); }
-#  else
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
      #include <stdio.h>
-     #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
      // MSVC doesn't support C99, so no need for dllexport on C99 branch
      #define kernel
-     #define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
-#  define global
-#  define local
-#  define constant const
-// OpenCL powr(a,b) = C99 pow(a,b), b >= 0
-// OpenCL pown(a,b) = C99 pow(a,b), b integer
-#  define powr(a,b) pow(a,b)
-#  define pown(a,b) pow(a,b)
-#else
-#  ifdef USE_SINCOS
-#    define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
-#  else
-#    define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
 #endif
 
 // Standard mathematical constants:
 //   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
 //   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
-// OpenCL defines M_constant_F for float constants, and nothing if float
+// OpenCL defines M_constant_F for float constants, and nothing if double
 // is not enabled on the card, which is why these constants may be missing
 #ifndef M_PI
-#  define M_PI 3.141592653589793f
+#  define M_PI 3.141592653589793
 #endif
 #ifndef M_PI_2
-#  define M_PI_2 1.570796326794897f
+#  define M_PI_2 1.570796326794897
 #endif
 #ifndef M_PI_4
-#  define M_PI_4 0.7853981633974483f
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
 #endif
 
-// Non-standard pi/180, used for converting between degrees and radians
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
 #ifndef M_PI_180
-#  define M_PI_180 0.017453292519943295f
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
 #endif
 
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
 
-#define VOLUME_PARAMETERS radius,length
-#define VOLUME_WEIGHT_PRODUCT radius_w*length_w
-#define IQ_KERNEL_NAME cylinder_Iq
-#define IQ_PARAMETERS sld, solvent_sld, radius, length
-#define IQ_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float sld, \
-    const float solvent_sld
-#define IQ_WEIGHT_PRODUCT radius_w*length_w
-#define IQ_DISPERSION_LENGTH_DECLARATIONS const int Nradius, \
-    const int Nlength
-#define IQ_DISPERSION_LENGTH_SUM Nradius+Nlength
-#define IQ_OPEN_LOOPS     for (int radius_i=0; radius_i < Nradius; radius_i++) { \
-      const float radius = loops[2*(radius_i)]; \
-      const float radius_w = loops[2*(radius_i)+1]; \
-      for (int length_i=0; length_i < Nlength; length_i++) { \
-        const float length = loops[2*(length_i+Nradius)]; \
-        const float length_w = loops[2*(length_i+Nradius)+1];
-#define IQ_CLOSE_LOOPS       } \
-    }
-#define IQXY_KERNEL_NAME cylinder_Iqxy
-#define IQXY_PARAMETERS sld, solvent_sld, radius, length, theta, phi
-#define IQXY_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float sld, \
-    const float solvent_sld
-#define IQXY_WEIGHT_PRODUCT radius_w*length_w*theta_w*phi_w
-#define IQXY_DISPERSION_LENGTH_DECLARATIONS const int Nradius, \
-    const int Nlength, \
-    const int Ntheta, \
-    const int Nphi
-#define IQXY_DISPERSION_LENGTH_SUM Nradius+Nlength+Ntheta+Nphi
-#define IQXY_OPEN_LOOPS     for (int radius_i=0; radius_i < Nradius; radius_i++) { \
-      const float radius = loops[2*(radius_i)]; \
-      const float radius_w = loops[2*(radius_i)+1]; \
-      for (int length_i=0; length_i < Nlength; length_i++) { \
-        const float length = loops[2*(length_i+Nradius)]; \
-        const float length_w = loops[2*(length_i+Nradius)+1]; \
-        for (int theta_i=0; theta_i < Ntheta; theta_i++) { \
-          const float theta = loops[2*(theta_i+Nradius+Nlength)]; \
-          const float theta_w = loops[2*(theta_i+Nradius+Nlength)+1]; \
-          for (int phi_i=0; phi_i < Nphi; phi_i++) { \
-            const float phi = loops[2*(phi_i+Nradius+Nlength+Ntheta)]; \
-            const float phi_w = loops[2*(phi_i+Nradius+Nlength+Ntheta)+1];
-#define IQXY_CLOSE_LOOPS           } \
-        } \
-      } \
-    }
-#define IQXY_HAS_THETA 1
+//# Beginning of rotational operation definitions
 
-float J1(float x);
-float J1(float x)
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
 {
-  const float ax = fabs(x);
-  if (ax < 8.0f) {
-    const float y = x*x;
-    const float ans1 = x*(72362614232.0f
-              + y*(-7895059235.0f
-              + y*(242396853.1f
-              + y*(-2972611.439f
-              + y*(15704.48260f
-              + y*(-30.16036606f))))));
-    const float ans2 = 144725228442.0f
-              + y*(2300535178.0f
-              + y*(18583304.74f
-              + y*(99447.43394f
-              + y*(376.9991397f
-              + y))));
-    return ans1/ans2;
-  } else {
-    const float y = 64.0f/(ax*ax);
-    const float xx = ax - 2.356194491f;
-    const float ans1 = 1.0f
-              + y*(0.183105e-2f
-              + y*(-0.3516396496e-4f
-              + y*(0.2457520174e-5f
-              + y*-0.240337019e-6f)));
-    const float ans2 = 0.04687499995f
-              + y*(-0.2002690873e-3f
-              + y*(0.8449199096e-5f
-              + y*(-0.88228987e-6f
-              + y*0.105787412e-6f)));
-    float sn,cn;
-    SINCOS(xx, sn, cn);
-    const float ans = sqrt(0.636619772f/ax) * (cn*ans1 - (8.0f/ax)*sn*ans2);
-    return (x < 0.0f) ? -ans : ans;
-  }
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/polevl.c"
+
+/*							polevl.c
+ *							p1evl.c
+ *
+ *	Evaluate polynomial
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * int N;
+ * double x, y, coef[N+1], polevl[];
+ *
+ * y = polevl( x, coef, N );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Evaluates polynomial of degree N:
+ *
+ *                     2          N
+ * y  =  C  + C x + C x  +...+ C x
+ *        0    1     2          N
+ *
+ * Coefficients are stored in reverse order:
+ *
+ * coef[0] = C  , ..., coef[N] = C  .
+ *            N                   0
+ *
+ * The function p1evl() assumes that C_N = 1.0 and is
+ * omitted from the array.  Its calling arguments are
+ * otherwise the same as polevl().
+ *
+ *
+ * SPEED:
+ *
+ * In the interest of speed, there are no checks for out
+ * of bounds arithmetic.  This routine is used by most of
+ * the functions in the library.  Depending on available
+ * equipment features, the user may wish to rewrite the
+ * program in microcode or assembly language.
+ *
+ */
+
+
+/*
+Cephes Math Library Release 2.1:  December, 1988
+Copyright 1984, 1987, 1988 by Stephen L. Moshier
+Direct inquiries to 30 Frost Street, Cambridge, MA 02140
+*/
+#pragma acc routine seq
+static
+double polevl( double x, pconstant double *coef, int N )
+{
+
+    int i = 0;
+    double ans = coef[i];
+
+    while (i < N) {
+        i++;
+        ans = ans * x + coef[i];
+    }
+
+    return ans;
+}
+
+/*							p1evl()	*/
+/*                                          N
+ * Evaluate polynomial when coefficient of x  is 1.0.
+ * Otherwise same as polevl.
+ */
+#pragma acc routine seq
+static
+double p1evl( double x, pconstant double *coef, int N )
+{
+    int i=0;
+    double ans = x+coef[i];
+
+    while (i < N-1) {
+        i++;
+        ans = ans*x + coef[i];
+    }
+
+    return ans;
 }
 
 
-/*
- *  GaussWeights.c
- *  SANSAnalysis
+#line 1 ".././models/lib/sas_J1.c"
+
+/*							j1.c
  *
- *  Created by Andrew Jackson on 4/23/07.f
- *  Copyright 2007 __MyCompanyName__. All rights reserved.
+ *	Bessel function of order one
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * double x, y, j1();
+ *
+ * y = j1( x );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Returns Bessel function of order one of the argument.
+ *
+ * The domain is divided into the intervals [0, 8] and
+ * (8, infinity). In the first interval a 24 term Chebyshev
+ * expansion is used. In the second, the asymptotic
+ * trigonometric representation is employed using two
+ * rational functions of degree 5/5.
+ *
+ *
+ *
+ * ACCURACY:
+ *
+ *                      Absolute error:
+ * arithmetic   domain      # trials      peak         rms
+ *    DEC       0, 30       10000       4.0e-17     1.1e-17
+ *    IEEE      0, 30       30000       2.6e-16     1.1e-16
+ *
  *
  */
 
-// Gaussians
-constant float Gauss76Wt[]={
-	.00126779163408536f,		//0
-	.00294910295364247f,
-	.00462793522803742f,
-	.00629918049732845f,
-	.00795984747723973f,
-	.00960710541471375f,
-	.0112381685696677f,
-	.0128502838475101f,
-	.0144407317482767f,
-	.0160068299122486f,
-	.0175459372914742f,		//10
-	.0190554584671906f,
-	.020532847967908f,
-	.0219756145344162f,
-	.0233813253070112f,
-	.0247476099206597f,
-	.026072164497986f,
-	.0273527555318275f,
-	.028587223650054f,
-	.029773487255905f,
-	.0309095460374916f,		//20
-	.0319934843404216f,
-	.0330234743977917f,
-	.0339977794120564f,
-	.0349147564835508f,
-	.0357728593807139f,
-	.0365706411473296f,
-	.0373067565423816f,
-	.0379799643084053f,
-	.0385891292645067f,
-	.0391332242205184f,		//30
-	.0396113317090621f,
-	.0400226455325968f,
-	.040366472122844f,
-	.0406422317102947f,
-	.0408494593018285f,
-	.040987805464794f,
-	.0410570369162294f,
-	.0410570369162294f,
-	.040987805464794f,
-	.0408494593018285f,		//40
-	.0406422317102947f,
-	.040366472122844f,
-	.0400226455325968f,
-	.0396113317090621f,
-	.0391332242205184f,
-	.0385891292645067f,
-	.0379799643084053f,
-	.0373067565423816f,
-	.0365706411473296f,
-	.0357728593807139f,		//50
-	.0349147564835508f,
-	.0339977794120564f,
-	.0330234743977917f,
-	.0319934843404216f,
-	.0309095460374916f,
-	.029773487255905f,
-	.028587223650054f,
-	.0273527555318275f,
-	.026072164497986f,
-	.0247476099206597f,		//60
-	.0233813253070112f,
-	.0219756145344162f,
-	.020532847967908f,
-	.0190554584671906f,
-	.0175459372914742f,
-	.0160068299122486f,
-	.0144407317482767f,
-	.0128502838475101f,
-	.0112381685696677f,
-	.00960710541471375f,		//70
-	.00795984747723973f,
-	.00629918049732845f,
-	.00462793522803742f,
-	.00294910295364247f,
-	.00126779163408536f		//75 (indexed from 0)
-};
+/*
+Cephes Math Library Release 2.8:  June, 2000
+Copyright 1984, 1987, 1989, 2000 by Stephen L. Moshier
+*/
 
-#pragma acc declare create ( Gauss76Wt )
+#if FLOAT_SIZE>4
+//Cephes double pression function
 
-constant float Gauss76Z[]={
-	-.999505948362153f,		//0
-	-.997397786355355f,
-	-.993608772723527f,
-	-.988144453359837f,
-	-.981013938975656f,
-	-.972229228520377f,
-	-.961805126758768f,
-	-.949759207710896f,
-	-.936111781934811f,
-	-.92088586125215f,
-	-.904107119545567f,		//10
-	-.885803849292083f,
-	-.866006913771982f,
-	-.844749694983342f,
-	-.822068037328975f,
-	-.7980001871612f,
-	-.77258672828181f,
-	-.74587051350361f,
-	-.717896592387704f,
-	-.688712135277641f,
-	-.658366353758143f,		//20
-	-.626910417672267f,
-	-.594397368836793f,
-	-.560882031601237f,
-	-.526420920401243f,
-	-.491072144462194f,
-	-.454895309813726f,
-	-.417951418780327f,
-	-.380302767117504f,
-	-.342012838966962f,
-	-.303146199807908f,		//30
-	-.263768387584994f,
-	-.223945802196474f,
-	-.183745593528914f,
-	-.143235548227268f,
-	-.102483975391227f,
-	-.0615595913906112f,
-	-.0205314039939986f,
-	.0205314039939986f,
-	.0615595913906112f,
-	.102483975391227f,			//40
-	.143235548227268f,
-	.183745593528914f,
-	.223945802196474f,
-	.263768387584994f,
-	.303146199807908f,
-	.342012838966962f,
-	.380302767117504f,
-	.417951418780327f,
-	.454895309813726f,
-	.491072144462194f,		//50
-	.526420920401243f,
-	.560882031601237f,
-	.594397368836793f,
-	.626910417672267f,
-	.658366353758143f,
-	.688712135277641f,
-	.717896592387704f,
-	.74587051350361f,
-	.77258672828181f,
-	.7980001871612f,	//60
-	.822068037328975f,
-	.844749694983342f,
-	.866006913771982f,
-	.885803849292083f,
-	.904107119545567f,
-	.92088586125215f,
-	.936111781934811f,
-	.949759207710896f,
-	.961805126758768f,
-	.972229228520377f,		//70
-	.981013938975656f,
-	.988144453359837f,
-	.993608772723527f,
-	.997397786355355f,
-	.999505948362153f		//75
-};
+constant double RPJ1[8] = {
+    -8.99971225705559398224E8,
+    4.52228297998194034323E11,
+    -7.27494245221818276015E13,
+    3.68295732863852883286E15,
+    0.0,
+    0.0,
+    0.0,
+    0.0 };
 
-#pragma acc declare create ( Gauss76Z )
+constant double RQJ1[8] = {
+    6.20836478118054335476E2,
+    2.56987256757748830383E5,
+    8.35146791431949253037E7,
+    2.21511595479792499675E10,
+    4.74914122079991414898E12,
+    7.84369607876235854894E14,
+    8.95222336184627338078E16,
+    5.32278620332680085395E18
+    };
 
-float form_volume(float radius, float length);
-float Iq(float q, float sld, float solvent_sld, float radius, float length);
-float Iqxy(float qx, float qy, float sld, float solvent_sld,
-    float radius, float length, float theta, float phi);
+constant double PPJ1[8] = {
+    7.62125616208173112003E-4,
+    7.31397056940917570436E-2,
+    1.12719608129684925192E0,
+    5.11207951146807644818E0,
+    8.42404590141772420927E0,
+    5.21451598682361504063E0,
+    1.00000000000000000254E0,
+    0.0} ;
 
-// twovd = 2 * volume * delta_rho
-// besarg = q * R * sin(alpha)
-// siarg = q * L/2 * cos(alpha)
-float _cyl(float besarg, float siarg);
-float _cyl(float besarg, float siarg)
+
+constant double PQJ1[8] = {
+    5.71323128072548699714E-4,
+    6.88455908754495404082E-2,
+    1.10514232634061696926E0,
+    5.07386386128601488557E0,
+    8.39985554327604159757E0,
+    5.20982848682361821619E0,
+    9.99999999999999997461E-1,
+    0.0 };
+
+constant double QPJ1[8] = {
+    5.10862594750176621635E-2,
+    4.98213872951233449420E0,
+    7.58238284132545283818E1,
+    3.66779609360150777800E2,
+    7.10856304998926107277E2,
+    5.97489612400613639965E2,
+    2.11688757100572135698E2,
+    2.52070205858023719784E1 };
+
+constant double QQJ1[8] = {
+    7.42373277035675149943E1,
+    1.05644886038262816351E3,
+    4.98641058337653607651E3,
+    9.56231892404756170795E3,
+    7.99704160447350683650E3,
+    2.82619278517639096600E3,
+    3.36093607810698293419E2,
+    0.0 };
+
+#pragma acc declare copyin( RPJ1[0:8], RQJ1[0:8], PPJ1[0:8], PQJ1[0:8], QPJ1[0:8], QQJ1[0:8])
+
+#pragma acc routine seq
+static
+double cephes_j1(double x)
 {
-    const float bj = (besarg == 0.0f ? 0.5f : J1(besarg)/besarg);
-    const float si = (siarg == 0.0f ? 1.0f : sin(siarg)/siarg);
-    return si*bj;
+
+    double w, z, p, q, abs_x, sign_x;
+
+    const double Z1 = 1.46819706421238932572E1;
+    const double Z2 = 4.92184563216946036703E1;
+
+    // 2017-05-18 PAK - mathematica and mpmath use J1(-x) = -J1(x)
+    if (x < 0) {
+        abs_x = -x;
+        sign_x = -1.0;
+    } else {
+        abs_x = x;
+        sign_x = 1.0;
+    }
+
+    if( abs_x <= 5.0 ) {
+        z = abs_x * abs_x;
+        w = polevl( z, RPJ1, 3 ) / p1evl( z, RQJ1, 8 );
+        w = w * abs_x * (z - Z1) * (z - Z2);
+        return( sign_x * w );
+    }
+
+    w = 5.0/abs_x;
+    z = w * w;
+    p = polevl( z, PPJ1, 6)/polevl( z, PQJ1, 6 );
+    q = polevl( z, QPJ1, 7)/p1evl( z, QQJ1, 7 );
+
+    // 2017-05-19 PAK improve accuracy using trig identies
+    // original:
+    //    const double THPIO4 =  2.35619449019234492885;
+    //    const double SQ2OPI = 0.79788456080286535588;
+    //    double sin_xn, cos_xn;
+    //    SINCOS(abs_x - THPIO4, sin_xn, cos_xn);
+    //    p = p * cos_xn - w * q * sin_xn;
+    //    return( sign_x * p * SQ2OPI / sqrt(abs_x) );
+    // expanding p*cos(a - 3 pi/4) - wq sin(a - 3 pi/4)
+    //    [ p(sin(a) - cos(a)) + wq(sin(a) + cos(a)) / sqrt(2)
+    // note that sqrt(1/2) * sqrt(2/pi) = sqrt(1/pi)
+    const double SQRT1_PI = 0.56418958354775628;
+    double sin_x, cos_x;
+    SINCOS(abs_x, sin_x, cos_x);
+    p = p*(sin_x - cos_x) + w*q*(sin_x + cos_x);
+    return( sign_x * p * SQRT1_PI / sqrt(abs_x) );
 }
 
-float form_volume(float radius, float length)
+#else
+//Single precission version of cephes
+
+constant float JPJ1[8] = {
+    -4.878788132172128E-009,
+    6.009061827883699E-007,
+    -4.541343896997497E-005,
+    1.937383947804541E-003,
+    -3.405537384615824E-002,
+    0.0,
+    0.0,
+    0.0
+    };
+
+constant float MO1J1[8] = {
+    6.913942741265801E-002,
+    -2.284801500053359E-001,
+    3.138238455499697E-001,
+    -2.102302420403875E-001,
+    5.435364690523026E-003,
+    1.493389585089498E-001,
+    4.976029650847191E-006,
+    7.978845453073848E-001
+    };
+
+constant float PH1J1[8] = {
+    -4.497014141919556E+001,
+    5.073465654089319E+001,
+    -2.485774108720340E+001,
+    7.222973196770240E+000,
+    -1.544842782180211E+000,
+    3.503787691653334E-001,
+    -1.637986776941202E-001,
+    3.749989509080821E-001
+    };
+
+#pragma acc declare copyin( JPJ1[0:8], MO1J1[0:8], PH1J1[0:8])
+
+#pragma acc routine seq
+static
+float cephes_j1f(float xx)
+{
+
+    float x, w, z, p, q, xn;
+
+    const float Z1 = 1.46819706421238932572E1;
+
+
+    // 2017-05-18 PAK - mathematica and mpmath use J1(-x) = -J1(x)
+    x = xx;
+    if( x < 0 )
+        x = -xx;
+
+    if( x <= 2.0 ) {
+        z = x * x;
+        p = (z-Z1) * x * polevl( z, JPJ1, 4 );
+        return( xx < 0. ? -p : p );
+    }
+
+    q = 1.0/x;
+    w = sqrt(q);
+
+    p = w * polevl( q, MO1J1, 7);
+    w = q*q;
+    // 2017-05-19 PAK improve accuracy using trig identies
+    // original:
+    //    const float THPIO4F =  2.35619449019234492885;    /* 3*pi/4 */
+    //    xn = q * polevl( w, PH1J1, 7) - THPIO4F;
+    //    p = p * cos(xn + x);
+    //    return( xx < 0. ? -p : p );
+    // expanding cos(a + b - 3 pi/4) is
+    //    [sin(a)sin(b) + sin(a)cos(b) + cos(a)sin(b)-cos(a)cos(b)] / sqrt(2)
+    xn = q * polevl( w, PH1J1, 7);
+    float cos_xn, sin_xn;
+    float cos_x, sin_x;
+    SINCOS(xn, sin_xn, cos_xn);  // about xn and 1
+    SINCOS(x, sin_x, cos_x);
+    p *= M_SQRT1_2*(sin_xn*(sin_x+cos_x) + cos_xn*(sin_x-cos_x));
+
+    return( xx < 0. ? -p : p );
+}
+#endif
+
+#if FLOAT_SIZE>4
+#define sas_J1 cephes_j1
+#else
+#define sas_J1 cephes_j1f
+#endif
+
+//Finally J1c function that equals 2*J1(x)/x
+    
+#pragma acc routine seq
+static
+double sas_2J1x_x(double x)
+{
+    return (x != 0.0 ) ? 2.0*sas_J1(x)/x : 1.0;
+}
+
+
+#line 1 ".././models/lib/gauss76.c"
+
+// Created by Andrew Jackson on 4/23/07
+
+ #ifdef GAUSS_N
+ # undef GAUSS_N
+ # undef GAUSS_Z
+ # undef GAUSS_W
+ #endif
+ #define GAUSS_N 76
+ #define GAUSS_Z Gauss76Z
+ #define GAUSS_W Gauss76Wt
+
+// Gaussians
+constant double Gauss76Wt[76] = {
+	.00126779163408536,		//0
+	.00294910295364247,
+	.00462793522803742,
+	.00629918049732845,
+	.00795984747723973,
+	.00960710541471375,
+	.0112381685696677,
+	.0128502838475101,
+	.0144407317482767,
+	.0160068299122486,
+	.0175459372914742,		//10
+	.0190554584671906,
+	.020532847967908,
+	.0219756145344162,
+	.0233813253070112,
+	.0247476099206597,
+	.026072164497986,
+	.0273527555318275,
+	.028587223650054,
+	.029773487255905,
+	.0309095460374916,		//20
+	.0319934843404216,
+	.0330234743977917,
+	.0339977794120564,
+	.0349147564835508,
+	.0357728593807139,
+	.0365706411473296,
+	.0373067565423816,
+	.0379799643084053,
+	.0385891292645067,
+	.0391332242205184,		//30
+	.0396113317090621,
+	.0400226455325968,
+	.040366472122844,
+	.0406422317102947,
+	.0408494593018285,
+	.040987805464794,
+	.0410570369162294,
+	.0410570369162294,
+	.040987805464794,
+	.0408494593018285,		//40
+	.0406422317102947,
+	.040366472122844,
+	.0400226455325968,
+	.0396113317090621,
+	.0391332242205184,
+	.0385891292645067,
+	.0379799643084053,
+	.0373067565423816,
+	.0365706411473296,
+	.0357728593807139,		//50
+	.0349147564835508,
+	.0339977794120564,
+	.0330234743977917,
+	.0319934843404216,
+	.0309095460374916,
+	.029773487255905,
+	.028587223650054,
+	.0273527555318275,
+	.026072164497986,
+	.0247476099206597,		//60
+	.0233813253070112,
+	.0219756145344162,
+	.020532847967908,
+	.0190554584671906,
+	.0175459372914742,
+	.0160068299122486,
+	.0144407317482767,
+	.0128502838475101,
+	.0112381685696677,
+	.00960710541471375,		//70
+	.00795984747723973,
+	.00629918049732845,
+	.00462793522803742,
+	.00294910295364247,
+	.00126779163408536		//75 (indexed from 0)
+};
+
+constant double Gauss76Z[76] = {
+	-.999505948362153,		//0
+	-.997397786355355,
+	-.993608772723527,
+	-.988144453359837,
+	-.981013938975656,
+	-.972229228520377,
+	-.961805126758768,
+	-.949759207710896,
+	-.936111781934811,
+	-.92088586125215,
+	-.904107119545567,		//10
+	-.885803849292083,
+	-.866006913771982,
+	-.844749694983342,
+	-.822068037328975,
+	-.7980001871612,
+	-.77258672828181,
+	-.74587051350361,
+	-.717896592387704,
+	-.688712135277641,
+	-.658366353758143,		//20
+	-.626910417672267,
+	-.594397368836793,
+	-.560882031601237,
+	-.526420920401243,
+	-.491072144462194,
+	-.454895309813726,
+	-.417951418780327,
+	-.380302767117504,
+	-.342012838966962,
+	-.303146199807908,		//30
+	-.263768387584994,
+	-.223945802196474,
+	-.183745593528914,
+	-.143235548227268,
+	-.102483975391227,
+	-.0615595913906112,
+	-.0205314039939986,
+	.0205314039939986,
+	.0615595913906112,
+	.102483975391227,			//40
+	.143235548227268,
+	.183745593528914,
+	.223945802196474,
+	.263768387584994,
+	.303146199807908,
+	.342012838966962,
+	.380302767117504,
+	.417951418780327,
+	.454895309813726,
+	.491072144462194,		//50
+	.526420920401243,
+	.560882031601237,
+	.594397368836793,
+	.626910417672267,
+	.658366353758143,
+	.688712135277641,
+	.717896592387704,
+	.74587051350361,
+	.77258672828181,
+	.7980001871612,	//60
+	.822068037328975,
+	.844749694983342,
+	.866006913771982,
+	.885803849292083,
+	.904107119545567,
+	.92088586125215,
+	.936111781934811,
+	.949759207710896,
+	.961805126758768,
+	.972229228520377,		//70
+	.981013938975656,
+	.988144453359837,
+	.993608772723527,
+	.997397786355355,
+	.999505948362153		//75
+};
+
+
+#pragma acc declare copyin(Gauss76Wt[0:76], Gauss76Z[0:76])
+
+#line 1 ".././models/cylinder.c"
+
+static double
+form_volume(double radius, double length)
 {
     return M_PI*radius*radius*length;
 }
 
-float Iq(float q,
-    float sld,
-    float solvent_sld,
-    float radius,
-    float length)
+static double
+_fq(double qab, double qc, double radius, double length)
 {
-    const float qr = q*radius;
-    const float qh = q*0.5f*length;
-    float total = 0.0f;
-    // float lower=0, upper=M_PI_2;
-    for (int i=0; i<76 ;i++) {
-        // translate a point in [-1,1] to a point in [lower,upper]
-        //const float alpha = ( Gauss76Z[i]*(upper-lower) + upper + lower )/2.0f;
-        const float alpha = M_PI_4*(Gauss76Z[i] + 1.0f);
-        float sn, cn;
-        SINCOS(alpha, sn, cn);
-        // For a bit of efficiency, we are moving the 2 V delta rho constant
-        // factor, 2Vdrho, out of the loop, so this is fq/2Vdrho rather than fq.
-        const float fq = _cyl(qr*sn, qh*cn);
-        total += Gauss76Wt[i] * fq * fq * sn;
+    return sas_2J1x_x(qab*radius) * sas_sinx_x(qc*0.5*length);
+}
+
+static double
+radius_from_excluded_volume(double radius, double length)
+{
+    return 0.5*cbrt(0.75*radius*(2.0*radius*length
+           + (radius + length)*(M_PI*radius + length)));
+}
+
+static double
+radius_from_volume(double radius, double length)
+{
+    return cbrt(M_PI*radius*radius*length/M_4PI_3);
+}
+
+static double
+radius_from_diagonal(double radius, double length)
+{
+    return sqrt(radius*radius + 0.25*length*length);
+}
+
+static double
+radius_effective(int mode, double radius, double length)
+{
+    switch (mode) {
+    default:
+    case 1:
+        return radius_from_excluded_volume(radius, length);
+    case 2:
+        return radius_from_volume(radius, length);
+    case 3:
+        return radius;
+    case 4:
+        return 0.5*length;
+    case 5:
+        return (radius < 0.5*length ? radius : 0.5*length);
+    case 6:
+        return (radius > 0.5*length ? radius : 0.5*length);
+    case 7:
+        return radius_from_diagonal(radius,length);
+    }
+}
+
+static void
+Fq(double q,
+    double *F1,
+    double *F2,
+    double sld,
+    double solvent_sld,
+    double radius,
+    double length)
+{
+    // translate a point in [-1,1] to a point in [0, pi/2]
+    const double zm = M_PI_4;
+    const double zb = M_PI_4;
+
+    double total_F1 = 0.0;
+    double total_F2 = 0.0;
+    for (int i=0; i<GAUSS_N ;i++) {
+        const double theta = GAUSS_Z[i]*zm + zb;
+        double sin_theta, cos_theta; // slots to hold sincos function output
+        // theta (theta,phi) the projection of the cylinder on the detector plane
+        SINCOS(theta , sin_theta, cos_theta);
+        const double form = _fq(q*sin_theta, q*cos_theta, radius, length);
+        total_F1 += GAUSS_W[i] * form * sin_theta;
+        total_F2 += GAUSS_W[i] * form * form * sin_theta;
     }
     // translate dx in [-1,1] to dx in [lower,upper]
-    //const float form = (upper-lower)/2.0f*total;
-    const float twoVdrho = 2.0f*(sld-solvent_sld)*form_volume(radius, length);
-    return 1.0e-4f * twoVdrho * twoVdrho * total * M_PI_4;
+    total_F1 *= zm;
+    total_F2 *= zm;
+    const double s = (sld - solvent_sld) * form_volume(radius, length);
+    *F1 = 1e-2 * s * total_F1;
+    *F2 = 1e-4 * s * s * total_F2;
 }
 
 
-float Iqxy(float qx, float qy,
-    float sld,
-    float solvent_sld,
-    float radius,
-    float length,
-    float theta,
-    float phi)
+
+static double
+Iqac(double qab, double qc,
+    double sld,
+    double solvent_sld,
+    double radius,
+    double length)
 {
-    // TODO: check that radius<0 and length<0 give zero scattering.
-    // This should be the case since the polydispersity weight vector should
-    // be zero length, and this function never called.
-    float sn, cn; // slots to hold sincos function output
-
-    // Compute angle alpha between q and the cylinder axis
-    SINCOS(theta*M_PI_180, sn, cn);
-    const float q = sqrt(qx*qx+qy*qy);
-    const float cos_val = (q==0.f ? 1.0f : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q);
-    const float alpha = acos(cos_val);
-    SINCOS(alpha, sn, cn);
-    //sn = sqrt(1.0f - cos_val*cos_val);
-    //sn = 1.0f - 0.5f*cos_val*cos_val;  // if cos_val is very small
-    //cn = cos_val;
-
-    const float twovd = 2.0f*(sld-solvent_sld)*form_volume(radius, length);
-    const float fq = twovd * _cyl(q*radius*sn, q*0.5f*length*cn);
-    return 1.0e-4f * fq * fq;
+    const double form = _fq(qab, qc, radius, length);
+    const double s = (sld-solvent_sld) * form_volume(radius, length);
+    return 1.0e-4 * square(s * form);
 }
 
 
-/*
-    ##########################################################
-    #                                                        #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #   !!                                              !!   #
-    #   !!  KEEP THIS CODE CONSISTENT WITH KERNELPY.PY  !!   #
-    #   !!                                              !!   #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #                                                        #
-    ##########################################################
-*/
 
-#ifdef IQ_KERNEL_NAME
-kernel void IQ_KERNEL_NAME(
-    global const float *q,
-    global float *result,
-    const int Nq,
-#ifdef IQ_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQ_DISPERSION_LENGTH_DECLARATIONS,
-#endif
-    IQ_FIXED_PARAMETER_DECLARATIONS
-    )
-{
-#ifdef USE_OPENCL
-  #ifdef IQ_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQ_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
-
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qi = q[i];
-#ifdef IQ_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-  #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-  #endif
-    IQ_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
-
-    const float weight = IQ_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-      const float scattering = Iq(qi, IQ_PARAMETERS);
-      // allow kernels to exclude invalid regions by returning NaN
-      if (!isnan(scattering)) {
-        ret += weight*scattering;
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-        norm_vol += vol_weight;
-      #endif
-      }
-    //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
-    }
-    IQ_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iq(qi, IQ_PARAMETERS) + background;
-#endif
-  }
-}
-#endif
-
-
-#ifdef IQXY_KERNEL_NAME
-kernel void IQXY_KERNEL_NAME(
-    global const float *qx,
-    global const float *qy,
-    global float *result,
-    const int Nq,
-#ifdef IQXY_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQXY_DISPERSION_LENGTH_DECLARATIONS,
-#endif
-    IQXY_FIXED_PARAMETER_DECLARATIONS
-    )
-{
-#ifdef USE_OPENCL
-  #ifdef IQXY_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQXY_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
-
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qxi = qx[i];
-    const float qyi = qy[i];
-    #if USE_KAHAN_SUMMATION
-    float accumulated_error = 0.0f;
-    #endif
-#ifdef IQXY_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-    #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-    #endif
-    IQXY_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
-
-    const float weight = IQXY_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-
-      const float scattering = Iqxy(qxi, qyi, IQXY_PARAMETERS);
-      if (!isnan(scattering)) { // if scattering is bad, exclude it from sum
-      //if (scattering >= 0.0f) { // scattering cannot be negative
-        // TODO: use correct angle for spherical correction
-        // Definition of theta and phi are probably reversed relative to the
-        // equation which gave rise to this correction, leading to an
-        // attenuation of the pattern as theta moves through pi/2.f  Either
-        // reverse the meanings of phi and theta in the forms, or use phi
-        // rather than theta in this correction.  Current code uses cos(theta)
-        // so that values match those of sasview.
-      #if defined(IQXY_HAS_THETA) // && 0
-        const float spherical_correction
-          = (Ntheta>1 ? fabs(cos(M_PI_180*theta))*M_PI_2:1.0f);
-        const float next = spherical_correction * weight * scattering;
-      #else
-        const float next = weight * scattering;
-      #endif
-      #if USE_KAHAN_SUMMATION
-        const float y = next - accumulated_error;
-        const float t = ret + y;
-        accumulated_error = (t - ret) - y;
-        ret = t;
-      #else
-        ret += next;
-      #endif
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-      #endif
-        norm_vol += vol_weight;
-      }
-      //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
-    }
-    IQXY_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iqxy(qxi, qyi, IQXY_PARAMETERS) + background;
-#endif
-  }
-}
-#endif

--- a/mcstas-comps/share/sas_dab.c
+++ b/mcstas-comps/share/sas_dab.c
@@ -1,281 +1,395 @@
-// GENERATED CODE --- DO NOT EDIT ---
-// Code is produced by sasmodels.gen from sasmodels/models/MODEL.c
+#define HAS_Iq
+#line 1 "../kernel_header.c"
 
 #ifdef __OPENCL_VERSION__
 # define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
 #endif
 
-#define USE_KAHAN_SUMMATION 0
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
 
 // If opencl is not available, then we are compiling a C function
 // Note: if using a C++ compiler, then define kernel as extern "C"
-#ifndef USE_OPENCL
-#  ifdef __cplusplus
-     #include <cstdio>
-     #include <cmath>
-     using namespace std;
-     #if defined(_MSC_VER)
-     #   define kernel extern "C" __declspec( dllexport )
-         inline float trunc(float x) { return x>=0?floor(x):-floor(-x); }
-	 inline float fmin(float x, float y) { return x>y ? y : x; }
-	 inline float fmax(float x, float y) { return x<y ? y : x; }
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
      #else
-     #   define kernel extern "C"
+         #define kernel extern "C"
+         #include <cstdint>
      #endif
-     inline void SINCOS(float angle, float &svar, float &cvar) { svar=sin(angle); cvar=cos(angle); }
-#  else
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
      #include <stdio.h>
-     #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
      // MSVC doesn't support C99, so no need for dllexport on C99 branch
      #define kernel
-     #define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
-#  define global
-#  define local
-#  define constant const
-// OpenCL powr(a,b) = C99 pow(a,b), b >= 0
-// OpenCL pown(a,b) = C99 pow(a,b), b integer
-#  define powr(a,b) pow(a,b)
-#  define pown(a,b) pow(a,b)
-#else
-#  ifdef USE_SINCOS
-#    define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
-#  else
-#    define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
 #endif
 
 // Standard mathematical constants:
 //   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
 //   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
-// OpenCL defines M_constant_F for float constants, and nothing if float
+// OpenCL defines M_constant_F for float constants, and nothing if double
 // is not enabled on the card, which is why these constants may be missing
 #ifndef M_PI
-#  define M_PI 3.141592653589793f
+#  define M_PI 3.141592653589793
 #endif
 #ifndef M_PI_2
-#  define M_PI_2 1.570796326794897f
+#  define M_PI_2 1.570796326794897
 #endif
 #ifndef M_PI_4
-#  define M_PI_4 0.7853981633974483f
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
 #endif
 
-// Non-standard pi/180, used for converting between degrees and radians
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
 #ifndef M_PI_180
-#  define M_PI_180 0.017453292519943295f
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
 #endif
 
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
 
-#define IQ_KERNEL_NAME dab_Iq
-#define IQ_PARAMETERS length
-#define IQ_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float length
-#define IQ_PARAMETER_DECLARATIONS float length
-#define IQXY_KERNEL_NAME dab_Iqxy
-#define IQXY_PARAMETERS length
-#define IQXY_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float length
-#define IQXY_PARAMETER_DECLARATIONS float length
+//# Beginning of rotational operation definitions
 
-float Iq(float q, IQ_PARAMETER_DECLARATIONS);
-float Iq(float q, IQ_PARAMETER_DECLARATIONS) {
-    
-    float numerator   = pow(length, 3);
-    float denominator = pow(1 + pow(q*length,2), 2);
-    
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/dab.c"
+
+double Iq(double q, double cor_length)
+{
+    double numerator   = cube(cor_length);
+    double denominator = square(1 + square(q*cor_length));
+
     return numerator / denominator ;
-    
 }
 
-
-float Iqxy(float qx, float qy, IQXY_PARAMETER_DECLARATIONS);
-float Iqxy(float qx, float qy, IQXY_PARAMETER_DECLARATIONS) {
-    
-    // never called since no orientation or magnetic parameters.
-    //return -1.0f;
-    return Iq(sqrt(qx*qx + qy*qy), length);
-    
-}
-
-
-/*
-    ##########################################################
-    #                                                        #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #   !!                                              !!   #
-    #   !!  KEEP THIS CODE CONSISTENT WITH KERNELPY.PY  !!   #
-    #   !!                                              !!   #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #                                                        #
-    ##########################################################
-*/
-
-#ifdef IQ_KERNEL_NAME
-kernel void IQ_KERNEL_NAME(
-    global const float *q,
-    global float *result,
-    const int Nq,
-#ifdef IQ_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQ_DISPERSION_LENGTH_DECLARATIONS,
-#endif
-    IQ_FIXED_PARAMETER_DECLARATIONS
-    )
-{
-#ifdef USE_OPENCL
-  #ifdef IQ_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQ_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
-
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qi = q[i];
-#ifdef IQ_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-  #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-  #endif
-    IQ_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
-
-    const float weight = IQ_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-      const float scattering = Iq(qi, IQ_PARAMETERS);
-      // allow kernels to exclude invalid regions by returning NaN
-      if (!isnan(scattering)) {
-        ret += weight*scattering;
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-        norm_vol += vol_weight;
-      #endif
-      }
-    //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
-    }
-    IQ_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iq(qi, IQ_PARAMETERS) + background;
-#endif
-  }
-}
-#endif
-
-
-#ifdef IQXY_KERNEL_NAME
-kernel void IQXY_KERNEL_NAME(
-    global const float *qx,
-    global const float *qy,
-    global float *result,
-    const int Nq,
-#ifdef IQXY_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQXY_DISPERSION_LENGTH_DECLARATIONS,
-#endif
-    IQXY_FIXED_PARAMETER_DECLARATIONS
-    )
-{
-#ifdef USE_OPENCL
-  #ifdef IQXY_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQXY_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
-
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qxi = qx[i];
-    const float qyi = qy[i];
-    #if USE_KAHAN_SUMMATION
-    float accumulated_error = 0.0f;
-    #endif
-#ifdef IQXY_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-    #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-    #endif
-    IQXY_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
-
-    const float weight = IQXY_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-
-      const float scattering = Iqxy(qxi, qyi, IQXY_PARAMETERS);
-      if (!isnan(scattering)) { // if scattering is bad, exclude it from sum
-      //if (scattering >= 0.0f) { // scattering cannot be negative
-        // TODO: use correct angle for spherical correction
-        // Definition of theta and phi are probably reversed relative to the
-        // equation which gave rise to this correction, leading to an
-        // attenuation of the pattern as theta moves through pi/2.f  Either
-        // reverse the meanings of phi and theta in the forms, or use phi
-        // rather than theta in this correction.  Current code uses cos(theta)
-        // so that values match those of sasview.
-      #if defined(IQXY_HAS_THETA) // && 0
-        const float spherical_correction
-          = (Ntheta>1 ? fabs(cos(M_PI_180*theta))*M_PI_2:1.0f);
-        const float next = spherical_correction * weight * scattering;
-      #else
-        const float next = weight * scattering;
-      #endif
-      #if USE_KAHAN_SUMMATION
-        const float y = next - accumulated_error;
-        const float t = ret + y;
-        accumulated_error = (t - ret) - y;
-        ret = t;
-      #else
-        ret += next;
-      #endif
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-      #endif
-        norm_vol += vol_weight;
-      }
-      //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
-    }
-    IQXY_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iqxy(qxi, qyi, IQXY_PARAMETERS) + background;
-#endif
-  }
-}
-#endif

--- a/mcstas-comps/share/sas_ellipsoid.c
+++ b/mcstas-comps/share/sas_ellipsoid.c
@@ -1,160 +1,391 @@
-// GENERATED CODE --- DO NOT EDIT ---
-// Code is produced by sasmodels.gen from sasmodels/models/MODEL.c
+#define HAS_Iqac
+#define HAS_FQ
+#define FORM_VOL
+#line 1 "../kernel_header.c"
 
 #ifdef __OPENCL_VERSION__
 # define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
 #endif
 
-#define USE_KAHAN_SUMMATION 0
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
 
 // If opencl is not available, then we are compiling a C function
 // Note: if using a C++ compiler, then define kernel as extern "C"
-#ifndef USE_OPENCL
-#  ifdef __cplusplus
-     #include <cstdio>
-     #include <cmath>
-     using namespace std;
-     #if defined(_MSC_VER)
-     #   define kernel extern "C" __declspec( dllexport )
-         inline float trunc(float x) { return x>=0?floor(x):-floor(-x); }
-	 inline float fmin(float x, float y) { return x>y ? y : x; }
-	 inline float fmax(float x, float y) { return x<y ? y : x; }
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
      #else
-     #   define kernel extern "C"
+         #define kernel extern "C"
+         #include <cstdint>
      #endif
-     inline void SINCOS(float angle, float &svar, float &cvar) { svar=sin(angle); cvar=cos(angle); }
-#  else
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
      #include <stdio.h>
-     #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
      // MSVC doesn't support C99, so no need for dllexport on C99 branch
      #define kernel
-     #define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
-#  define global
-#  define local
-#  define constant const
-// OpenCL powr(a,b) = C99 pow(a,b), b >= 0
-// OpenCL pown(a,b) = C99 pow(a,b), b integer
-#  define powr(a,b) pow(a,b)
-#  define pown(a,b) pow(a,b)
-#else
-#  ifdef USE_SINCOS
-#    define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
-#  else
-#    define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
 #endif
 
 // Standard mathematical constants:
 //   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
 //   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
-// OpenCL defines M_constant_F for float constants, and nothing if float
+// OpenCL defines M_constant_F for float constants, and nothing if double
 // is not enabled on the card, which is why these constants may be missing
 #ifndef M_PI
-#  define M_PI 3.141592653589793f
+#  define M_PI 3.141592653589793
 #endif
 #ifndef M_PI_2
-#  define M_PI_2 1.570796326794897f
+#  define M_PI_2 1.570796326794897
 #endif
 #ifndef M_PI_4
-#  define M_PI_4 0.7853981633974483f
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
 #endif
 
-// Non-standard pi/180, used for converting between degrees and radians
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
 #ifndef M_PI_180
-#  define M_PI_180 0.017453292519943295f
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
 #endif
 
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
 
-#define VOLUME_PARAMETERS rpolar,requatorial
-#define VOLUME_WEIGHT_PRODUCT rpolar_w*requatorial_w
-#define IQ_KERNEL_NAME ellipsoid_Iq
-#define IQ_PARAMETERS sld, solvent_sld, rpolar, requatorial
-#define IQ_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float sld, \
-    const float solvent_sld
-#define IQ_WEIGHT_PRODUCT rpolar_w*requatorial_w
-#define IQ_DISPERSION_LENGTH_DECLARATIONS const int Nrpolar, \
-    const int Nrequatorial
-#define IQ_DISPERSION_LENGTH_SUM Nrpolar+Nrequatorial
-#define IQ_OPEN_LOOPS     for (int rpolar_i=0; rpolar_i < Nrpolar; rpolar_i++) { \
-      const float rpolar = loops[2*(rpolar_i)]; \
-      const float rpolar_w = loops[2*(rpolar_i)+1]; \
-      for (int requatorial_i=0; requatorial_i < Nrequatorial; requatorial_i++) { \
-        const float requatorial = loops[2*(requatorial_i+Nrpolar)]; \
-        const float requatorial_w = loops[2*(requatorial_i+Nrpolar)+1];
-#define IQ_CLOSE_LOOPS       } \
-    }
-#define IQXY_KERNEL_NAME ellipsoid_Iqxy
-#define IQXY_PARAMETERS sld, solvent_sld, rpolar, requatorial, theta, phi
-#define IQXY_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float sld, \
-    const float solvent_sld
-#define IQXY_WEIGHT_PRODUCT rpolar_w*requatorial_w*theta_w*phi_w
-#define IQXY_DISPERSION_LENGTH_DECLARATIONS const int Nrpolar, \
-    const int Nrequatorial, \
-    const int Ntheta, \
-    const int Nphi
-#define IQXY_DISPERSION_LENGTH_SUM Nrpolar+Nrequatorial+Ntheta+Nphi
-#define IQXY_OPEN_LOOPS     for (int rpolar_i=0; rpolar_i < Nrpolar; rpolar_i++) { \
-      const float rpolar = loops[2*(rpolar_i)]; \
-      const float rpolar_w = loops[2*(rpolar_i)+1]; \
-      for (int requatorial_i=0; requatorial_i < Nrequatorial; requatorial_i++) { \
-        const float requatorial = loops[2*(requatorial_i+Nrpolar)]; \
-        const float requatorial_w = loops[2*(requatorial_i+Nrpolar)+1]; \
-        for (int theta_i=0; theta_i < Ntheta; theta_i++) { \
-          const float theta = loops[2*(theta_i+Nrpolar+Nrequatorial)]; \
-          const float theta_w = loops[2*(theta_i+Nrpolar+Nrequatorial)+1]; \
-          for (int phi_i=0; phi_i < Nphi; phi_i++) { \
-            const float phi = loops[2*(phi_i+Nrpolar+Nrequatorial+Ntheta)]; \
-            const float phi_w = loops[2*(phi_i+Nrpolar+Nrequatorial+Ntheta)+1];
-#define IQXY_CLOSE_LOOPS           } \
-        } \
-      } \
-    }
-#define IQXY_HAS_THETA 1
+//# Beginning of rotational operation definitions
 
-float J1(float x);
-float J1(float x)
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
 {
-  const float ax = fabs(x);
-  if (ax < 8.0f) {
-    const float y = x*x;
-    const float ans1 = x*(72362614232.0f
-              + y*(-7895059235.0f
-              + y*(242396853.1f
-              + y*(-2972611.439f
-              + y*(15704.48260f
-              + y*(-30.16036606f))))));
-    const float ans2 = 144725228442.0f
-              + y*(2300535178.0f
-              + y*(18583304.74f
-              + y*(99447.43394f
-              + y*(376.9991397f
-              + y))));
-    return ans1/ans2;
-  } else {
-    const float y = 64.0f/(ax*ax);
-    const float xx = ax - 2.356194491f;
-    const float ans1 = 1.0f
-              + y*(0.183105e-2f
-              + y*(-0.3516396496e-4f
-              + y*(0.2457520174e-5f
-              + y*-0.240337019e-6f)));
-    const float ans2 = 0.04687499995f
-              + y*(-0.2002690873e-3f
-              + y*(0.8449199096e-5f
-              + y*(-0.88228987e-6f
-              + y*0.105787412e-6f)));
-    float sn,cn;
-    SINCOS(xx, sn, cn);
-    const float ans = sqrt(0.636619772f/ax) * (cn*ans1 - (8.0f/ax)*sn*ans2);
-    return (x < 0.0f) ? -ans : ans;
-  }
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
 }
 
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/sas_3j1x_x.c"
 
 /**
 * Spherical Bessel function 3*j1(x)/x
@@ -162,458 +393,335 @@ float J1(float x)
 * Used for low q to avoid cancellation error.
 * Note that the values differ from sasview ~ 5e-12 rather than 5e-14, but
 * in this case it is likely cancellation errors in the original expression
-* using float precision that are the source.  Single precision only
-* requires the first 3 terms.  Double precision requires the 4th term.
-* The fifth term is not needed, and is commented out.
-* Taylor expansion:
-*      1.0f + q2*(-3.f/30.f + q2*(3.f/840.f))+ q2*(-3.f/45360.f + q2*(3.f/3991680.f))))
-* Expression returned from Herbie (herbie.uwpise.org/demo):
-*      const float t = ((1.f + 3.f*q2*q2/5600.f) - q2/20.f);
-*      return t*t;
+* using double precision that are the source.
 */
+double sas_3j1x_x(double q);
 
-float sph_j1c(float q);
-float sph_j1c(float q)
+// The choice of the number of terms in the series and the cutoff value for
+// switching between series and direct calculation depends on the numeric
+// precision.
+//
+// Point where direct calculation reaches machine precision:
+//
+//   single machine precision eps 3e-8 at qr=1.1 **
+//   double machine precision eps 4e-16 at qr=1.1
+//
+// Point where Taylor series reaches machine precision (eps), where taylor
+// series matches direct calculation (cross) and the error at that point:
+//
+//   prec   n eps  cross  error
+//   single 3 0.28  0.4   6.2e-7
+//   single 4 0.68  0.7   2.3e-7
+//   single 5 1.18  1.2   7.5e-8
+//   double 3 0.01  0.03  2.3e-13
+//   double 4 0.06  0.1   3.1e-14
+//   double 5 0.16  0.2   5.0e-15
+//
+// ** Note: relative error on single precision starts increase on the direct
+// method at qr=1.1, rising from 3e-8 to 5e-5 by qr=1e3.  This should be
+// safe for the sans range, with objects of 100 nm supported to a q of 0.1
+// while maintaining 5 digits of precision.  For usans/sesans, the objects
+// are larger but the q is smaller, so again it should be fine.
+//
+// See explore/sph_j1c.py for code to explore these ranges.
+
+// Use 4th order series
+#if FLOAT_SIZE>4
+#define SPH_J1C_CUTOFF 0.1
+#else
+#define SPH_J1C_CUTOFF 0.7
+#endif
+#pragma acc routine seq
+double sas_3j1x_x(double q)
 {
-    const float q2 = q*q;
-    float sin_q, cos_q;
-
-    SINCOS(q, sin_q, cos_q);
-
-    const float bessel = (q < 0.384038453352533f)
-        ? (1.0f + q2*(-3.f/30.f + q2*(3.f/840.f)))
-        : 3.0f*(sin_q/q - cos_q)/q2;
-
-    return bessel;
-
- /*
-    // Code to test various expressions
-    if (sizeof(q2) > 4) {
-        return 3.0f*(sin_q/q - cos_q)/q2;
-    } else if (q < 0.384038453352533f) {
-        //const float t = ((1.f + 3.f*q2*q2/5600.f) - q2/20.f); return t*t;
-        return 1.0f + q2*q2*(3.f/840.f) - q2*(3.f/30.f);
-        //return 1.0f + q2*(-3.f/30.f + q2*(3.f/840.f));
-        //return 1.0f + q2*(-3.f/30.f + q2*(3.f/840.f + q2*(-3.f/45360.f)));
-        //return 1.0f + q2*(-3.f/30.f + q2*(3.f/840.f + q2*(-3.f/45360.f + q2*(3.f/3991680.f))));
+    // 2017-05-18 PAK - support negative q
+    if (fabs(q) < SPH_J1C_CUTOFF) {
+        const double q2 = q*q;
+        return (1.0 + q2*(-3./30. + q2*(3./840. + q2*(-3./45360.))));// + q2*(3./3991680.)))));
     } else {
-        return 3.0f*(sin_q/q - cos_q)/q2;
+        double sin_q, cos_q;
+        SINCOS(q, sin_q, cos_q);
+        return 3.0*(sin_q/q - cos_q)/(q*q);
     }
-*/
 }
 
 
-/*
- *  GaussWeights.c
- *  SANSAnalysis
- *
- *  Created by Andrew Jackson on 4/23/07.f
- *  Copyright 2007 __MyCompanyName__. All rights reserved.
- *
- */
+#line 1 ".././models/lib/gauss76.c"
+
+// Created by Andrew Jackson on 4/23/07
+
+ #ifdef GAUSS_N
+ # undef GAUSS_N
+ # undef GAUSS_Z
+ # undef GAUSS_W
+ #endif
+ #define GAUSS_N 76
+ #define GAUSS_Z Gauss76Z
+ #define GAUSS_W Gauss76Wt
 
 // Gaussians
-constant float Gauss76Wt[]={
-	.00126779163408536f,		//0
-	.00294910295364247f,
-	.00462793522803742f,
-	.00629918049732845f,
-	.00795984747723973f,
-	.00960710541471375f,
-	.0112381685696677f,
-	.0128502838475101f,
-	.0144407317482767f,
-	.0160068299122486f,
-	.0175459372914742f,		//10
-	.0190554584671906f,
-	.020532847967908f,
-	.0219756145344162f,
-	.0233813253070112f,
-	.0247476099206597f,
-	.026072164497986f,
-	.0273527555318275f,
-	.028587223650054f,
-	.029773487255905f,
-	.0309095460374916f,		//20
-	.0319934843404216f,
-	.0330234743977917f,
-	.0339977794120564f,
-	.0349147564835508f,
-	.0357728593807139f,
-	.0365706411473296f,
-	.0373067565423816f,
-	.0379799643084053f,
-	.0385891292645067f,
-	.0391332242205184f,		//30
-	.0396113317090621f,
-	.0400226455325968f,
-	.040366472122844f,
-	.0406422317102947f,
-	.0408494593018285f,
-	.040987805464794f,
-	.0410570369162294f,
-	.0410570369162294f,
-	.040987805464794f,
-	.0408494593018285f,		//40
-	.0406422317102947f,
-	.040366472122844f,
-	.0400226455325968f,
-	.0396113317090621f,
-	.0391332242205184f,
-	.0385891292645067f,
-	.0379799643084053f,
-	.0373067565423816f,
-	.0365706411473296f,
-	.0357728593807139f,		//50
-	.0349147564835508f,
-	.0339977794120564f,
-	.0330234743977917f,
-	.0319934843404216f,
-	.0309095460374916f,
-	.029773487255905f,
-	.028587223650054f,
-	.0273527555318275f,
-	.026072164497986f,
-	.0247476099206597f,		//60
-	.0233813253070112f,
-	.0219756145344162f,
-	.020532847967908f,
-	.0190554584671906f,
-	.0175459372914742f,
-	.0160068299122486f,
-	.0144407317482767f,
-	.0128502838475101f,
-	.0112381685696677f,
-	.00960710541471375f,		//70
-	.00795984747723973f,
-	.00629918049732845f,
-	.00462793522803742f,
-	.00294910295364247f,
-	.00126779163408536f		//75 (indexed from 0)
+constant double Gauss76Wt[76] = {
+	.00126779163408536,		//0
+	.00294910295364247,
+	.00462793522803742,
+	.00629918049732845,
+	.00795984747723973,
+	.00960710541471375,
+	.0112381685696677,
+	.0128502838475101,
+	.0144407317482767,
+	.0160068299122486,
+	.0175459372914742,		//10
+	.0190554584671906,
+	.020532847967908,
+	.0219756145344162,
+	.0233813253070112,
+	.0247476099206597,
+	.026072164497986,
+	.0273527555318275,
+	.028587223650054,
+	.029773487255905,
+	.0309095460374916,		//20
+	.0319934843404216,
+	.0330234743977917,
+	.0339977794120564,
+	.0349147564835508,
+	.0357728593807139,
+	.0365706411473296,
+	.0373067565423816,
+	.0379799643084053,
+	.0385891292645067,
+	.0391332242205184,		//30
+	.0396113317090621,
+	.0400226455325968,
+	.040366472122844,
+	.0406422317102947,
+	.0408494593018285,
+	.040987805464794,
+	.0410570369162294,
+	.0410570369162294,
+	.040987805464794,
+	.0408494593018285,		//40
+	.0406422317102947,
+	.040366472122844,
+	.0400226455325968,
+	.0396113317090621,
+	.0391332242205184,
+	.0385891292645067,
+	.0379799643084053,
+	.0373067565423816,
+	.0365706411473296,
+	.0357728593807139,		//50
+	.0349147564835508,
+	.0339977794120564,
+	.0330234743977917,
+	.0319934843404216,
+	.0309095460374916,
+	.029773487255905,
+	.028587223650054,
+	.0273527555318275,
+	.026072164497986,
+	.0247476099206597,		//60
+	.0233813253070112,
+	.0219756145344162,
+	.020532847967908,
+	.0190554584671906,
+	.0175459372914742,
+	.0160068299122486,
+	.0144407317482767,
+	.0128502838475101,
+	.0112381685696677,
+	.00960710541471375,		//70
+	.00795984747723973,
+	.00629918049732845,
+	.00462793522803742,
+	.00294910295364247,
+	.00126779163408536		//75 (indexed from 0)
 };
 
-#pragma acc declare create ( Gauss76Wt )
-
-constant float Gauss76Z[]={
-	-.999505948362153f,		//0
-	-.997397786355355f,
-	-.993608772723527f,
-	-.988144453359837f,
-	-.981013938975656f,
-	-.972229228520377f,
-	-.961805126758768f,
-	-.949759207710896f,
-	-.936111781934811f,
-	-.92088586125215f,
-	-.904107119545567f,		//10
-	-.885803849292083f,
-	-.866006913771982f,
-	-.844749694983342f,
-	-.822068037328975f,
-	-.7980001871612f,
-	-.77258672828181f,
-	-.74587051350361f,
-	-.717896592387704f,
-	-.688712135277641f,
-	-.658366353758143f,		//20
-	-.626910417672267f,
-	-.594397368836793f,
-	-.560882031601237f,
-	-.526420920401243f,
-	-.491072144462194f,
-	-.454895309813726f,
-	-.417951418780327f,
-	-.380302767117504f,
-	-.342012838966962f,
-	-.303146199807908f,		//30
-	-.263768387584994f,
-	-.223945802196474f,
-	-.183745593528914f,
-	-.143235548227268f,
-	-.102483975391227f,
-	-.0615595913906112f,
-	-.0205314039939986f,
-	.0205314039939986f,
-	.0615595913906112f,
-	.102483975391227f,			//40
-	.143235548227268f,
-	.183745593528914f,
-	.223945802196474f,
-	.263768387584994f,
-	.303146199807908f,
-	.342012838966962f,
-	.380302767117504f,
-	.417951418780327f,
-	.454895309813726f,
-	.491072144462194f,		//50
-	.526420920401243f,
-	.560882031601237f,
-	.594397368836793f,
-	.626910417672267f,
-	.658366353758143f,
-	.688712135277641f,
-	.717896592387704f,
-	.74587051350361f,
-	.77258672828181f,
-	.7980001871612f,	//60
-	.822068037328975f,
-	.844749694983342f,
-	.866006913771982f,
-	.885803849292083f,
-	.904107119545567f,
-	.92088586125215f,
-	.936111781934811f,
-	.949759207710896f,
-	.961805126758768f,
-	.972229228520377f,		//70
-	.981013938975656f,
-	.988144453359837f,
-	.993608772723527f,
-	.997397786355355f,
-	.999505948362153f		//75
+constant double Gauss76Z[76] = {
+	-.999505948362153,		//0
+	-.997397786355355,
+	-.993608772723527,
+	-.988144453359837,
+	-.981013938975656,
+	-.972229228520377,
+	-.961805126758768,
+	-.949759207710896,
+	-.936111781934811,
+	-.92088586125215,
+	-.904107119545567,		//10
+	-.885803849292083,
+	-.866006913771982,
+	-.844749694983342,
+	-.822068037328975,
+	-.7980001871612,
+	-.77258672828181,
+	-.74587051350361,
+	-.717896592387704,
+	-.688712135277641,
+	-.658366353758143,		//20
+	-.626910417672267,
+	-.594397368836793,
+	-.560882031601237,
+	-.526420920401243,
+	-.491072144462194,
+	-.454895309813726,
+	-.417951418780327,
+	-.380302767117504,
+	-.342012838966962,
+	-.303146199807908,		//30
+	-.263768387584994,
+	-.223945802196474,
+	-.183745593528914,
+	-.143235548227268,
+	-.102483975391227,
+	-.0615595913906112,
+	-.0205314039939986,
+	.0205314039939986,
+	.0615595913906112,
+	.102483975391227,			//40
+	.143235548227268,
+	.183745593528914,
+	.223945802196474,
+	.263768387584994,
+	.303146199807908,
+	.342012838966962,
+	.380302767117504,
+	.417951418780327,
+	.454895309813726,
+	.491072144462194,		//50
+	.526420920401243,
+	.560882031601237,
+	.594397368836793,
+	.626910417672267,
+	.658366353758143,
+	.688712135277641,
+	.717896592387704,
+	.74587051350361,
+	.77258672828181,
+	.7980001871612,	//60
+	.822068037328975,
+	.844749694983342,
+	.866006913771982,
+	.885803849292083,
+	.904107119545567,
+	.92088586125215,
+	.936111781934811,
+	.949759207710896,
+	.961805126758768,
+	.972229228520377,		//70
+	.981013938975656,
+	.988144453359837,
+	.993608772723527,
+	.997397786355355,
+	.999505948362153		//75
 };
 
-#pragma acc declare create ( Gauss76Z )
 
-float form_volume(float rpolar, float requatorial);
-float Iq(float q, float sld, float solvent_sld, float rpolar, float requatorial);
-float Iqxy(float qx, float qy, float sld, float solvent_sld,
-    float rpolar, float requatorial, float theta, float phi);
+#pragma acc declare copyin(Gauss76Wt[0:76], Gauss76Z[0:76])
 
-float _ellipsoid_kernel(float q, float rpolar, float requatorial, float sin_alpha);
-float _ellipsoid_kernel(float q, float rpolar, float requatorial, float sin_alpha)
+#line 1 ".././models/ellipsoid.c"
+
+static double
+form_volume(double radius_polar, double radius_equatorial)
 {
-    float ratio = rpolar/requatorial;
-    const float u = q*requatorial*sqrt(1.0f
-                   + sin_alpha*sin_alpha*(ratio*ratio - 1.0f));
-    const float f = sph_j1c(u);
-
-    return f*f;
+    return M_4PI_3*radius_polar*radius_equatorial*radius_equatorial;
 }
 
-float form_volume(float rpolar, float requatorial)
+static double
+radius_from_volume(double radius_polar, double radius_equatorial)
 {
-    return 1.333333333333333f*M_PI*rpolar*requatorial*requatorial;
+    return cbrt(radius_polar*radius_equatorial*radius_equatorial);
 }
 
-float Iq(float q,
-    float sld,
-    float solvent_sld,
-    float rpolar,
-    float requatorial)
+static double
+radius_from_curvature(double radius_polar, double radius_equatorial)
 {
-    //const float lower = 0.0f;
-    //const float upper = 1.0f;
-    float total = 0.0f;
-    for (int i=0;i<76;i++) {
-        //const float sin_alpha = (Gauss76Z[i]*(upper-lower) + upper + lower)/2;
-        const float sin_alpha = 0.5f*(Gauss76Z[i] + 1.0f);
-        total += Gauss76Wt[i] * _ellipsoid_kernel(q, rpolar, requatorial, sin_alpha);
+    // Trivial cases
+    if (radius_polar == radius_equatorial) return radius_polar;
+    if (radius_polar * radius_equatorial == 0.)  return 0.;
+
+    // see equation (26) in A.Isihara, J.Chem.Phys. 18(1950)1446-1449
+    const double ratio = (radius_polar < radius_equatorial
+                          ? radius_polar / radius_equatorial
+                          : radius_equatorial / radius_polar);
+    const double e1 = sqrt(1.0 - ratio*ratio);
+    const double b1 = 1.0 + asin(e1) / (e1 * ratio);
+    const double bL = (1.0 + e1) / (1.0 - e1);
+    const double b2 = 1.0 + 0.5 * ratio * ratio / e1 * log(bL);
+    const double delta = 0.75 * b1 * b2;
+    const double ddd = 2.0 * (delta + 1.0) * radius_polar * radius_equatorial * radius_equatorial;
+    return 0.5 * cbrt(ddd);
+}
+
+static double
+radius_effective(int mode, double radius_polar, double radius_equatorial)
+{
+    switch (mode) {
+    default:
+    case 1: // average curvature
+        return radius_from_curvature(radius_polar, radius_equatorial);
+    case 2: // equivalent volume sphere
+        return radius_from_volume(radius_polar, radius_equatorial);
+    case 3: // min radius
+        return (radius_polar < radius_equatorial ? radius_polar : radius_equatorial);
+    case 4: // max radius
+        return (radius_polar > radius_equatorial ? radius_polar : radius_equatorial);
     }
-    //const float form = (upper-lower)/2*total;
-    const float form = 0.5f*total;
-    const float s = (sld - solvent_sld) * form_volume(rpolar, requatorial);
-    return 1.0e-4f * form * s * s;
 }
 
-float Iqxy(float qx, float qy,
-    float sld,
-    float solvent_sld,
-    float rpolar,
-    float requatorial,
-    float theta,
-    float phi)
+
+static void
+Fq(double q,
+    double *F1,
+    double *F2,
+    double sld,
+    double sld_solvent,
+    double radius_polar,
+    double radius_equatorial)
 {
-    float sn, cn;
-
-    const float q = sqrt(qx*qx + qy*qy);
-    SINCOS(theta*M_PI_180, sn, cn);
-    // TODO: check if this is actually sin(alpha), not cos(alpha)
-    const float cos_alpha = cn*cos(phi*M_PI_180)*(qx/q) + sn*(qy/q);
-    const float form = _ellipsoid_kernel(q, rpolar, requatorial, cos_alpha);
-    const float s = (sld - solvent_sld) * form_volume(rpolar, requatorial);
-
-    return 1.0e-4f * form * s * s;
+    // Using ratio v = Rp/Re, we can implement the form given in Guinier (1955)
+    //     i(h) = int_0^pi/2 Phi^2(h a sqrt(cos^2 + v^2 sin^2) cos dT
+    //          = int_0^pi/2 Phi^2(h a sqrt((1-sin^2) + v^2 sin^2) cos dT
+    //          = int_0^pi/2 Phi^2(h a sqrt(1 + sin^2(v^2-1)) cos dT
+    // u-substitution of
+    //     u = sin, du = cos dT
+    //     i(h) = int_0^1 Phi^2(h a sqrt(1 + u^2(v^2-1)) du
+    const double v_square_minus_one = square(radius_polar/radius_equatorial) - 1.0;
+    // translate a point in [-1,1] to a point in [0, 1]
+    // const double u = GAUSS_Z[i]*(upper-lower)/2 + (upper+lower)/2;
+    const double zm = 0.5;
+    const double zb = 0.5;
+    double total_F2 = 0.0;
+    double total_F1 = 0.0;
+    for (int i=0;i<GAUSS_N;i++) {
+        const double u = GAUSS_Z[i]*zm + zb;
+        const double r = radius_equatorial*sqrt(1.0 + u*u*v_square_minus_one);
+        const double f = sas_3j1x_x(q*r);
+        total_F2 += GAUSS_W[i] * f * f;
+        total_F1 += GAUSS_W[i] * f;
+    }
+    // translate dx in [-1,1] to dx in [lower,upper]
+    total_F1 *= zm;
+    total_F2 *= zm;
+    const double s = (sld - sld_solvent) * form_volume(radius_polar, radius_equatorial);
+    *F1 = 1e-2 * s * total_F1;
+    *F2 = 1e-4 * s * s * total_F2;
 }
 
-
-
-/*
-    ##########################################################
-    #                                                        #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #   !!                                              !!   #
-    #   !!  KEEP THIS CODE CONSISTENT WITH KERNELPY.PY  !!   #
-    #   !!                                              !!   #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #                                                        #
-    ##########################################################
-*/
-
-#ifdef IQ_KERNEL_NAME
-kernel void IQ_KERNEL_NAME(
-    global const float *q,
-    global float *result,
-    const int Nq,
-#ifdef IQ_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQ_DISPERSION_LENGTH_DECLARATIONS,
-#endif
-    IQ_FIXED_PARAMETER_DECLARATIONS
-    )
+static double
+Iqac(double qab, double qc,
+    double sld,
+    double sld_solvent,
+    double radius_polar,
+    double radius_equatorial)
 {
-#ifdef USE_OPENCL
-  #ifdef IQ_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQ_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
+    const double qr = sqrt(square(radius_equatorial*qab) + square(radius_polar*qc));
+    const double f = sas_3j1x_x(qr);
+    const double s = (sld - sld_solvent) * form_volume(radius_polar, radius_equatorial);
 
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qi = q[i];
-#ifdef IQ_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-  #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-  #endif
-    IQ_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
-
-    const float weight = IQ_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-      const float scattering = Iq(qi, IQ_PARAMETERS);
-      // allow kernels to exclude invalid regions by returning NaN
-      if (!isnan(scattering)) {
-        ret += weight*scattering;
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-        norm_vol += vol_weight;
-      #endif
-      }
-    //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
-    }
-    IQ_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iq(qi, IQ_PARAMETERS) + background;
-#endif
-  }
+    return 1.0e-4 * square(f * s);
 }
-#endif
 
 
-#ifdef IQXY_KERNEL_NAME
-kernel void IQXY_KERNEL_NAME(
-    global const float *qx,
-    global const float *qy,
-    global float *result,
-    const int Nq,
-#ifdef IQXY_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQXY_DISPERSION_LENGTH_DECLARATIONS,
-#endif
-    IQXY_FIXED_PARAMETER_DECLARATIONS
-    )
-{
-#ifdef USE_OPENCL
-  #ifdef IQXY_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQXY_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
-
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qxi = qx[i];
-    const float qyi = qy[i];
-    #if USE_KAHAN_SUMMATION
-    float accumulated_error = 0.0f;
-    #endif
-#ifdef IQXY_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-    #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-    #endif
-    IQXY_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
-
-    const float weight = IQXY_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-
-      const float scattering = Iqxy(qxi, qyi, IQXY_PARAMETERS);
-      if (!isnan(scattering)) { // if scattering is bad, exclude it from sum
-      //if (scattering >= 0.0f) { // scattering cannot be negative
-        // TODO: use correct angle for spherical correction
-        // Definition of theta and phi are probably reversed relative to the
-        // equation which gave rise to this correction, leading to an
-        // attenuation of the pattern as theta moves through pi/2.f  Either
-        // reverse the meanings of phi and theta in the forms, or use phi
-        // rather than theta in this correction.  Current code uses cos(theta)
-        // so that values match those of sasview.
-      #if defined(IQXY_HAS_THETA) // && 0
-        const float spherical_correction
-          = (Ntheta>1 ? fabs(cos(M_PI_180*theta))*M_PI_2:1.0f);
-        const float next = spherical_correction * weight * scattering;
-      #else
-        const float next = weight * scattering;
-      #endif
-      #if USE_KAHAN_SUMMATION
-        const float y = next - accumulated_error;
-        const float t = ret + y;
-        accumulated_error = (t - ret) - y;
-        ret = t;
-      #else
-        ret += next;
-      #endif
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-      #endif
-        norm_vol += vol_weight;
-      }
-      //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
-    }
-    IQXY_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iqxy(qxi, qyi, IQXY_PARAMETERS) + background;
-#endif
-  }
-}
-#endif

--- a/mcstas-comps/share/sas_elliptical_cylinder.c
+++ b/mcstas-comps/share/sas_elliptical_cylinder.c
@@ -1,0 +1,1051 @@
+#define HAS_Iqabc
+#define HAS_FQ
+#define FORM_VOL
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/polevl.c"
+
+/*							polevl.c
+ *							p1evl.c
+ *
+ *	Evaluate polynomial
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * int N;
+ * double x, y, coef[N+1], polevl[];
+ *
+ * y = polevl( x, coef, N );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Evaluates polynomial of degree N:
+ *
+ *                     2          N
+ * y  =  C  + C x + C x  +...+ C x
+ *        0    1     2          N
+ *
+ * Coefficients are stored in reverse order:
+ *
+ * coef[0] = C  , ..., coef[N] = C  .
+ *            N                   0
+ *
+ * The function p1evl() assumes that C_N = 1.0 and is
+ * omitted from the array.  Its calling arguments are
+ * otherwise the same as polevl().
+ *
+ *
+ * SPEED:
+ *
+ * In the interest of speed, there are no checks for out
+ * of bounds arithmetic.  This routine is used by most of
+ * the functions in the library.  Depending on available
+ * equipment features, the user may wish to rewrite the
+ * program in microcode or assembly language.
+ *
+ */
+
+
+/*
+Cephes Math Library Release 2.1:  December, 1988
+Copyright 1984, 1987, 1988 by Stephen L. Moshier
+Direct inquiries to 30 Frost Street, Cambridge, MA 02140
+*/
+#pragma acc routine seq
+static
+double polevl( double x, pconstant double *coef, int N )
+{
+
+    int i = 0;
+    double ans = coef[i];
+
+    while (i < N) {
+        i++;
+        ans = ans * x + coef[i];
+    }
+
+    return ans;
+}
+
+/*							p1evl()	*/
+/*                                          N
+ * Evaluate polynomial when coefficient of x  is 1.0.
+ * Otherwise same as polevl.
+ */
+#pragma acc routine seq
+static
+double p1evl( double x, pconstant double *coef, int N )
+{
+    int i=0;
+    double ans = x+coef[i];
+
+    while (i < N-1) {
+        i++;
+        ans = ans*x + coef[i];
+    }
+
+    return ans;
+}
+
+
+#line 1 ".././models/lib/sas_J1.c"
+
+/*							j1.c
+ *
+ *	Bessel function of order one
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * double x, y, j1();
+ *
+ * y = j1( x );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Returns Bessel function of order one of the argument.
+ *
+ * The domain is divided into the intervals [0, 8] and
+ * (8, infinity). In the first interval a 24 term Chebyshev
+ * expansion is used. In the second, the asymptotic
+ * trigonometric representation is employed using two
+ * rational functions of degree 5/5.
+ *
+ *
+ *
+ * ACCURACY:
+ *
+ *                      Absolute error:
+ * arithmetic   domain      # trials      peak         rms
+ *    DEC       0, 30       10000       4.0e-17     1.1e-17
+ *    IEEE      0, 30       30000       2.6e-16     1.1e-16
+ *
+ *
+ */
+
+/*
+Cephes Math Library Release 2.8:  June, 2000
+Copyright 1984, 1987, 1989, 2000 by Stephen L. Moshier
+*/
+
+#if FLOAT_SIZE>4
+//Cephes double pression function
+
+constant double RPJ1[8] = {
+    -8.99971225705559398224E8,
+    4.52228297998194034323E11,
+    -7.27494245221818276015E13,
+    3.68295732863852883286E15,
+    0.0,
+    0.0,
+    0.0,
+    0.0 };
+
+constant double RQJ1[8] = {
+    6.20836478118054335476E2,
+    2.56987256757748830383E5,
+    8.35146791431949253037E7,
+    2.21511595479792499675E10,
+    4.74914122079991414898E12,
+    7.84369607876235854894E14,
+    8.95222336184627338078E16,
+    5.32278620332680085395E18
+    };
+
+constant double PPJ1[8] = {
+    7.62125616208173112003E-4,
+    7.31397056940917570436E-2,
+    1.12719608129684925192E0,
+    5.11207951146807644818E0,
+    8.42404590141772420927E0,
+    5.21451598682361504063E0,
+    1.00000000000000000254E0,
+    0.0} ;
+
+
+constant double PQJ1[8] = {
+    5.71323128072548699714E-4,
+    6.88455908754495404082E-2,
+    1.10514232634061696926E0,
+    5.07386386128601488557E0,
+    8.39985554327604159757E0,
+    5.20982848682361821619E0,
+    9.99999999999999997461E-1,
+    0.0 };
+
+constant double QPJ1[8] = {
+    5.10862594750176621635E-2,
+    4.98213872951233449420E0,
+    7.58238284132545283818E1,
+    3.66779609360150777800E2,
+    7.10856304998926107277E2,
+    5.97489612400613639965E2,
+    2.11688757100572135698E2,
+    2.52070205858023719784E1 };
+
+constant double QQJ1[8] = {
+    7.42373277035675149943E1,
+    1.05644886038262816351E3,
+    4.98641058337653607651E3,
+    9.56231892404756170795E3,
+    7.99704160447350683650E3,
+    2.82619278517639096600E3,
+    3.36093607810698293419E2,
+    0.0 };
+
+#pragma acc declare copyin( RPJ1[0:8], RQJ1[0:8], PPJ1[0:8], PQJ1[0:8], QPJ1[0:8], QQJ1[0:8])
+
+#pragma acc routine seq
+static
+double cephes_j1(double x)
+{
+
+    double w, z, p, q, abs_x, sign_x;
+
+    const double Z1 = 1.46819706421238932572E1;
+    const double Z2 = 4.92184563216946036703E1;
+
+    // 2017-05-18 PAK - mathematica and mpmath use J1(-x) = -J1(x)
+    if (x < 0) {
+        abs_x = -x;
+        sign_x = -1.0;
+    } else {
+        abs_x = x;
+        sign_x = 1.0;
+    }
+
+    if( abs_x <= 5.0 ) {
+        z = abs_x * abs_x;
+        w = polevl( z, RPJ1, 3 ) / p1evl( z, RQJ1, 8 );
+        w = w * abs_x * (z - Z1) * (z - Z2);
+        return( sign_x * w );
+    }
+
+    w = 5.0/abs_x;
+    z = w * w;
+    p = polevl( z, PPJ1, 6)/polevl( z, PQJ1, 6 );
+    q = polevl( z, QPJ1, 7)/p1evl( z, QQJ1, 7 );
+
+    // 2017-05-19 PAK improve accuracy using trig identies
+    // original:
+    //    const double THPIO4 =  2.35619449019234492885;
+    //    const double SQ2OPI = 0.79788456080286535588;
+    //    double sin_xn, cos_xn;
+    //    SINCOS(abs_x - THPIO4, sin_xn, cos_xn);
+    //    p = p * cos_xn - w * q * sin_xn;
+    //    return( sign_x * p * SQ2OPI / sqrt(abs_x) );
+    // expanding p*cos(a - 3 pi/4) - wq sin(a - 3 pi/4)
+    //    [ p(sin(a) - cos(a)) + wq(sin(a) + cos(a)) / sqrt(2)
+    // note that sqrt(1/2) * sqrt(2/pi) = sqrt(1/pi)
+    const double SQRT1_PI = 0.56418958354775628;
+    double sin_x, cos_x;
+    SINCOS(abs_x, sin_x, cos_x);
+    p = p*(sin_x - cos_x) + w*q*(sin_x + cos_x);
+    return( sign_x * p * SQRT1_PI / sqrt(abs_x) );
+}
+
+#else
+//Single precission version of cephes
+
+constant float JPJ1[8] = {
+    -4.878788132172128E-009,
+    6.009061827883699E-007,
+    -4.541343896997497E-005,
+    1.937383947804541E-003,
+    -3.405537384615824E-002,
+    0.0,
+    0.0,
+    0.0
+    };
+
+constant float MO1J1[8] = {
+    6.913942741265801E-002,
+    -2.284801500053359E-001,
+    3.138238455499697E-001,
+    -2.102302420403875E-001,
+    5.435364690523026E-003,
+    1.493389585089498E-001,
+    4.976029650847191E-006,
+    7.978845453073848E-001
+    };
+
+constant float PH1J1[8] = {
+    -4.497014141919556E+001,
+    5.073465654089319E+001,
+    -2.485774108720340E+001,
+    7.222973196770240E+000,
+    -1.544842782180211E+000,
+    3.503787691653334E-001,
+    -1.637986776941202E-001,
+    3.749989509080821E-001
+    };
+
+#pragma acc declare copyin( JPJ1[0:8], MO1J1[0:8], PH1J1[0:8])
+
+#pragma acc routine seq
+static
+float cephes_j1f(float xx)
+{
+
+    float x, w, z, p, q, xn;
+
+    const float Z1 = 1.46819706421238932572E1;
+
+
+    // 2017-05-18 PAK - mathematica and mpmath use J1(-x) = -J1(x)
+    x = xx;
+    if( x < 0 )
+        x = -xx;
+
+    if( x <= 2.0 ) {
+        z = x * x;
+        p = (z-Z1) * x * polevl( z, JPJ1, 4 );
+        return( xx < 0. ? -p : p );
+    }
+
+    q = 1.0/x;
+    w = sqrt(q);
+
+    p = w * polevl( q, MO1J1, 7);
+    w = q*q;
+    // 2017-05-19 PAK improve accuracy using trig identies
+    // original:
+    //    const float THPIO4F =  2.35619449019234492885;    /* 3*pi/4 */
+    //    xn = q * polevl( w, PH1J1, 7) - THPIO4F;
+    //    p = p * cos(xn + x);
+    //    return( xx < 0. ? -p : p );
+    // expanding cos(a + b - 3 pi/4) is
+    //    [sin(a)sin(b) + sin(a)cos(b) + cos(a)sin(b)-cos(a)cos(b)] / sqrt(2)
+    xn = q * polevl( w, PH1J1, 7);
+    float cos_xn, sin_xn;
+    float cos_x, sin_x;
+    SINCOS(xn, sin_xn, cos_xn);  // about xn and 1
+    SINCOS(x, sin_x, cos_x);
+    p *= M_SQRT1_2*(sin_xn*(sin_x+cos_x) + cos_xn*(sin_x-cos_x));
+
+    return( xx < 0. ? -p : p );
+}
+#endif
+
+#if FLOAT_SIZE>4
+#define sas_J1 cephes_j1
+#else
+#define sas_J1 cephes_j1f
+#endif
+
+//Finally J1c function that equals 2*J1(x)/x
+    
+#pragma acc routine seq
+static
+double sas_2J1x_x(double x)
+{
+    return (x != 0.0 ) ? 2.0*sas_J1(x)/x : 1.0;
+}
+
+
+#line 1 ".././models/lib/gauss76.c"
+
+// Created by Andrew Jackson on 4/23/07
+
+ #ifdef GAUSS_N
+ # undef GAUSS_N
+ # undef GAUSS_Z
+ # undef GAUSS_W
+ #endif
+ #define GAUSS_N 76
+ #define GAUSS_Z Gauss76Z
+ #define GAUSS_W Gauss76Wt
+
+// Gaussians
+constant double Gauss76Wt[76] = {
+	.00126779163408536,		//0
+	.00294910295364247,
+	.00462793522803742,
+	.00629918049732845,
+	.00795984747723973,
+	.00960710541471375,
+	.0112381685696677,
+	.0128502838475101,
+	.0144407317482767,
+	.0160068299122486,
+	.0175459372914742,		//10
+	.0190554584671906,
+	.020532847967908,
+	.0219756145344162,
+	.0233813253070112,
+	.0247476099206597,
+	.026072164497986,
+	.0273527555318275,
+	.028587223650054,
+	.029773487255905,
+	.0309095460374916,		//20
+	.0319934843404216,
+	.0330234743977917,
+	.0339977794120564,
+	.0349147564835508,
+	.0357728593807139,
+	.0365706411473296,
+	.0373067565423816,
+	.0379799643084053,
+	.0385891292645067,
+	.0391332242205184,		//30
+	.0396113317090621,
+	.0400226455325968,
+	.040366472122844,
+	.0406422317102947,
+	.0408494593018285,
+	.040987805464794,
+	.0410570369162294,
+	.0410570369162294,
+	.040987805464794,
+	.0408494593018285,		//40
+	.0406422317102947,
+	.040366472122844,
+	.0400226455325968,
+	.0396113317090621,
+	.0391332242205184,
+	.0385891292645067,
+	.0379799643084053,
+	.0373067565423816,
+	.0365706411473296,
+	.0357728593807139,		//50
+	.0349147564835508,
+	.0339977794120564,
+	.0330234743977917,
+	.0319934843404216,
+	.0309095460374916,
+	.029773487255905,
+	.028587223650054,
+	.0273527555318275,
+	.026072164497986,
+	.0247476099206597,		//60
+	.0233813253070112,
+	.0219756145344162,
+	.020532847967908,
+	.0190554584671906,
+	.0175459372914742,
+	.0160068299122486,
+	.0144407317482767,
+	.0128502838475101,
+	.0112381685696677,
+	.00960710541471375,		//70
+	.00795984747723973,
+	.00629918049732845,
+	.00462793522803742,
+	.00294910295364247,
+	.00126779163408536		//75 (indexed from 0)
+};
+
+constant double Gauss76Z[76] = {
+	-.999505948362153,		//0
+	-.997397786355355,
+	-.993608772723527,
+	-.988144453359837,
+	-.981013938975656,
+	-.972229228520377,
+	-.961805126758768,
+	-.949759207710896,
+	-.936111781934811,
+	-.92088586125215,
+	-.904107119545567,		//10
+	-.885803849292083,
+	-.866006913771982,
+	-.844749694983342,
+	-.822068037328975,
+	-.7980001871612,
+	-.77258672828181,
+	-.74587051350361,
+	-.717896592387704,
+	-.688712135277641,
+	-.658366353758143,		//20
+	-.626910417672267,
+	-.594397368836793,
+	-.560882031601237,
+	-.526420920401243,
+	-.491072144462194,
+	-.454895309813726,
+	-.417951418780327,
+	-.380302767117504,
+	-.342012838966962,
+	-.303146199807908,		//30
+	-.263768387584994,
+	-.223945802196474,
+	-.183745593528914,
+	-.143235548227268,
+	-.102483975391227,
+	-.0615595913906112,
+	-.0205314039939986,
+	.0205314039939986,
+	.0615595913906112,
+	.102483975391227,			//40
+	.143235548227268,
+	.183745593528914,
+	.223945802196474,
+	.263768387584994,
+	.303146199807908,
+	.342012838966962,
+	.380302767117504,
+	.417951418780327,
+	.454895309813726,
+	.491072144462194,		//50
+	.526420920401243,
+	.560882031601237,
+	.594397368836793,
+	.626910417672267,
+	.658366353758143,
+	.688712135277641,
+	.717896592387704,
+	.74587051350361,
+	.77258672828181,
+	.7980001871612,	//60
+	.822068037328975,
+	.844749694983342,
+	.866006913771982,
+	.885803849292083,
+	.904107119545567,
+	.92088586125215,
+	.936111781934811,
+	.949759207710896,
+	.961805126758768,
+	.972229228520377,		//70
+	.981013938975656,
+	.988144453359837,
+	.993608772723527,
+	.997397786355355,
+	.999505948362153		//75
+};
+
+
+#pragma acc declare copyin(Gauss76Wt[0:76], Gauss76Z[0:76])
+
+#line 1 ".././models/elliptical_cylinder.c"
+
+static double
+form_volume(double radius_minor, double r_ratio, double length)
+{
+    return M_PI * radius_minor * radius_minor * r_ratio * length;
+}
+
+static double
+radius_from_excluded_volume(double radius_minor, double r_ratio, double length)
+{
+    const double r_equiv = sqrt(radius_minor*radius_minor*r_ratio);
+    return 0.5*cbrt(0.75*r_equiv*(2.0*r_equiv*length + (r_equiv + length)*(M_PI*r_equiv + length)));
+}
+
+static double
+radius_from_volume(double radius_minor, double r_ratio, double length)
+{
+    const double volume_ellcyl = form_volume(radius_minor,r_ratio,length);
+    return cbrt(volume_ellcyl/M_4PI_3);
+}
+
+static double
+radius_from_min_dimension(double radius_minor, double r_ratio, double hlength)
+{
+    const double rad_min = (r_ratio > 1.0 ? radius_minor : r_ratio*radius_minor);
+    return (rad_min < hlength ? rad_min : hlength);
+}
+
+static double
+radius_from_max_dimension(double radius_minor, double r_ratio, double hlength)
+{
+    const double rad_max = (r_ratio < 1.0 ? radius_minor : r_ratio*radius_minor);
+    return (rad_max > hlength ? rad_max : hlength);
+}
+
+static double
+radius_from_diagonal(double radius_minor, double r_ratio, double length)
+{
+    const double radius_max = (r_ratio > 1.0 ? radius_minor*r_ratio : radius_minor);
+    return sqrt(radius_max*radius_max + 0.25*length*length);
+}
+
+static double
+radius_effective(int mode, double radius_minor, double r_ratio, double length)
+{
+    switch (mode) {
+    default:
+    case 1: // equivalent cylinder excluded volume
+        return radius_from_excluded_volume(radius_minor, r_ratio, length);
+    case 2: // equivalent volume sphere
+        return radius_from_volume(radius_minor, r_ratio, length);
+    case 3: // average radius
+        return 0.5*radius_minor*(1.0 + r_ratio);
+    case 4: // min radius
+        return (r_ratio > 1.0 ? radius_minor : r_ratio*radius_minor);
+    case 5: // max radius
+        return (r_ratio < 1.0 ? radius_minor : r_ratio*radius_minor);
+    case 6: // equivalent circular cross-section
+        return sqrt(radius_minor*radius_minor*r_ratio);
+    case 7: // half length
+        return 0.5*length;
+    case 8: // half min dimension
+        return radius_from_min_dimension(radius_minor,r_ratio,0.5*length);
+    case 9: // half max dimension
+        return radius_from_max_dimension(radius_minor,r_ratio,0.5*length);
+    case 10: // half diagonal
+        return radius_from_diagonal(radius_minor,r_ratio,length);
+    }
+}
+
+static void
+Fq(double q, double *F1, double *F2, double radius_minor, double r_ratio, double length,
+   double sld, double solvent_sld)
+{
+    // orientational average limits
+    const double va = 0.0;
+    const double vb = 1.0;
+    // inner integral limits
+    const double vaj=0.0;
+    const double vbj=M_PI;
+
+    const double radius_major = r_ratio * radius_minor;
+    const double rA = 0.5*(square(radius_major) + square(radius_minor));
+    const double rB = 0.5*(square(radius_major) - square(radius_minor));
+
+    //initialize integral
+    double outer_sum_F1 = 0.0;
+    double outer_sum_F2 = 0.0;
+    for(int i=0;i<GAUSS_N;i++) {
+        //setup inner integral over the ellipsoidal cross-section
+        const double cos_val = ( GAUSS_Z[i]*(vb-va) + va + vb )/2.0;
+        const double sin_val = sqrt(1.0 - cos_val*cos_val);
+        //const double arg = radius_minor*sin_val;
+        double inner_sum_F1 = 0.0;
+        double inner_sum_F2 = 0.0;
+        for(int j=0;j<GAUSS_N;j++) {
+            const double theta = ( GAUSS_Z[j]*(vbj-vaj) + vaj + vbj )/2.0;
+            const double r = sin_val*sqrt(rA - rB*cos(theta));
+            const double be = sas_2J1x_x(q*r);
+            inner_sum_F1 += GAUSS_W[j] * be;
+            inner_sum_F2 += GAUSS_W[j] * be * be;
+        }
+        //now calculate the value of the inner integral
+        inner_sum_F1 *= 0.5*(vbj-vaj);
+        inner_sum_F2 *= 0.5*(vbj-vaj);
+
+        //now calculate outer integral
+        const double si = sas_sinx_x(q*0.5*length*cos_val);
+        outer_sum_F1 += GAUSS_W[i] * inner_sum_F1 * si;
+        outer_sum_F2 += GAUSS_W[i] * inner_sum_F2 * si * si;
+    }
+    // correct limits and divide integral by pi
+    outer_sum_F1 *= 0.5*(vb-va)/M_PI;
+    outer_sum_F2 *= 0.5*(vb-va)/M_PI;
+
+    // scale by contrast and volume, and convert to to 1/cm units
+    const double volume = form_volume(radius_minor, r_ratio, length);
+    const double contrast = sld - solvent_sld;
+    const double s = contrast*volume;
+    *F1 = 1.0e-2*s*outer_sum_F1;
+    *F2 = 1.0e-4*s*s*outer_sum_F2;
+}
+
+
+static double
+Iqabc(double qa, double qb, double qc,
+     double radius_minor, double r_ratio, double length,
+     double sld, double solvent_sld)
+{
+    // Compute:  r = sqrt((radius_major*cos_nu)^2 + (radius_minor*cos_mu)^2)
+    // Given:    radius_major = r_ratio * radius_minor
+    const double qr = radius_minor*sqrt(square(r_ratio*qb) + square(qa));
+    const double be = sas_2J1x_x(qr);
+    const double si = sas_sinx_x(qc*0.5*length);
+    const double fq = be * si;
+    const double contrast = sld - solvent_sld;
+    const double volume = form_volume(radius_minor, r_ratio, length);
+    return 1.0e-4 * square(contrast * volume * fq);
+}
+
+

--- a/mcstas-comps/share/sas_fcc_paracrystal.c
+++ b/mcstas-comps/share/sas_fcc_paracrystal.c
@@ -1,837 +1,891 @@
-// GENERATED CODE --- DO NOT EDIT ---
-// Code is produced by sasmodels.gen from sasmodels/models/MODEL.c
+#define HAS_Iqabc
+#define HAS_Iq
+#define FORM_VOL
+#line 1 "../kernel_header.c"
 
 #ifdef __OPENCL_VERSION__
 # define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
 #endif
 
-#define USE_KAHAN_SUMMATION 0
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
 
 // If opencl is not available, then we are compiling a C function
 // Note: if using a C++ compiler, then define kernel as extern "C"
-#ifndef USE_OPENCL
-#  ifdef __cplusplus
-     #include <cstdio>
-     #include <cmath>
-     using namespace std;
-     #if defined(_MSC_VER)
-     #   define kernel extern "C" __declspec( dllexport )
-         inline float trunc(float x) { return x>=0?floor(x):-floor(-x); }
-	 inline float fmin(float x, float y) { return x>y ? y : x; }
-	 inline float fmax(float x, float y) { return x<y ? y : x; }
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
      #else
-     #   define kernel extern "C"
+         #define kernel extern "C"
+         #include <cstdint>
      #endif
-     inline void SINCOS(float angle, float &svar, float &cvar) { svar=sin(angle); cvar=cos(angle); }
-#  else
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
      #include <stdio.h>
-     #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
      // MSVC doesn't support C99, so no need for dllexport on C99 branch
      #define kernel
-     #define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
-#  define global
-#  define local
-#  define constant const
-// OpenCL powr(a,b) = C99 pow(a,b), b >= 0
-// OpenCL pown(a,b) = C99 pow(a,b), b integer
-#  define powr(a,b) pow(a,b)
-#  define pown(a,b) pow(a,b)
-#else
-#  ifdef USE_SINCOS
-#    define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
-#  else
-#    define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
 #endif
 
 // Standard mathematical constants:
 //   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
 //   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
-// OpenCL defines M_constant_F for float constants, and nothing if float
+// OpenCL defines M_constant_F for float constants, and nothing if double
 // is not enabled on the card, which is why these constants may be missing
 #ifndef M_PI
-#  define M_PI 3.141592653589793f
+#  define M_PI 3.141592653589793
 #endif
 #ifndef M_PI_2
-#  define M_PI_2 1.570796326794897f
+#  define M_PI_2 1.570796326794897
 #endif
 #ifndef M_PI_4
-#  define M_PI_4 0.7853981633974483f
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
 #endif
 
-// Non-standard pi/180, used for converting between degrees and radians
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
 #ifndef M_PI_180
-#  define M_PI_180 0.017453292519943295f
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
 #endif
 
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
 
-#define VOLUME_PARAMETERS radius
-#define VOLUME_WEIGHT_PRODUCT radius_w
-#define IQ_KERNEL_NAME fcc_paracrystal_Iq
-#define IQ_PARAMETERS dnn, d_factor, radius, sld, solvent_sld
-#define IQ_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float dnn, \
-    const float d_factor, \
-    const float sld, \
-    const float solvent_sld
-#define IQ_WEIGHT_PRODUCT radius_w
-#define IQ_DISPERSION_LENGTH_DECLARATIONS const int Nradius
-#define IQ_DISPERSION_LENGTH_SUM Nradius
-#define IQ_OPEN_LOOPS     for (int radius_i=0; radius_i < Nradius; radius_i++) { \
-      const float radius = loops[2*(radius_i)]; \
-      const float radius_w = loops[2*(radius_i)+1];
-#define IQ_CLOSE_LOOPS     }
-#define IQXY_KERNEL_NAME fcc_paracrystal_Iqxy
-#define IQXY_PARAMETERS dnn, d_factor, radius, sld, solvent_sld, theta, phi, psi
-#define IQXY_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float dnn, \
-    const float d_factor, \
-    const float sld, \
-    const float solvent_sld
-#define IQXY_WEIGHT_PRODUCT radius_w*theta_w*phi_w*psi_w
-#define IQXY_DISPERSION_LENGTH_DECLARATIONS const int Nradius, \
-    const int Ntheta, \
-    const int Nphi, \
-    const int Npsi
-#define IQXY_DISPERSION_LENGTH_SUM Nradius+Ntheta+Nphi+Npsi
-#define IQXY_OPEN_LOOPS     for (int radius_i=0; radius_i < Nradius; radius_i++) { \
-      const float radius = loops[2*(radius_i)]; \
-      const float radius_w = loops[2*(radius_i)+1]; \
-      for (int theta_i=0; theta_i < Ntheta; theta_i++) { \
-        const float theta = loops[2*(theta_i+Nradius)]; \
-        const float theta_w = loops[2*(theta_i+Nradius)+1]; \
-        for (int phi_i=0; phi_i < Nphi; phi_i++) { \
-          const float phi = loops[2*(phi_i+Nradius+Ntheta)]; \
-          const float phi_w = loops[2*(phi_i+Nradius+Ntheta)+1]; \
-          for (int psi_i=0; psi_i < Npsi; psi_i++) { \
-            const float psi = loops[2*(psi_i+Nradius+Ntheta+Nphi)]; \
-            const float psi_w = loops[2*(psi_i+Nradius+Ntheta+Nphi)+1];
-#define IQXY_CLOSE_LOOPS           } \
-        } \
-      } \
-    }
-#define IQXY_HAS_THETA 1
+//# Beginning of rotational operation definitions
 
-float J1(float x);
-float J1(float x)
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
 {
-  const float ax = fabs(x);
-  if (ax < 8.0f) {
-    const float y = x*x;
-    const float ans1 = x*(72362614232.0f
-              + y*(-7895059235.0f
-              + y*(242396853.1f
-              + y*(-2972611.439f
-              + y*(15704.48260f
-              + y*(-30.16036606f))))));
-    const float ans2 = 144725228442.0f
-              + y*(2300535178.0f
-              + y*(18583304.74f
-              + y*(99447.43394f
-              + y*(376.9991397f
-              + y))));
-    return ans1/ans2;
-  } else {
-    const float y = 64.0f/(ax*ax);
-    const float xx = ax - 2.356194491f;
-    const float ans1 = 1.0f
-              + y*(0.183105e-2f
-              + y*(-0.3516396496e-4f
-              + y*(0.2457520174e-5f
-              + y*-0.240337019e-6f)));
-    const float ans2 = 0.04687499995f
-              + y*(-0.2002690873e-3f
-              + y*(0.8449199096e-5f
-              + y*(-0.88228987e-6f
-              + y*0.105787412e-6f)));
-    float sn,cn;
-    SINCOS(xx, sn, cn);
-    const float ans = sqrt(0.636619772f/ax) * (cn*ans1 - (8.0f/ax)*sn*ans2);
-    return (x < 0.0f) ? -ans : ans;
-  }
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
 }
 
-
-/*
- *  GaussWeights.c
- *  SANSAnalysis
- *
- *  Created by Andrew Jackson on 4/23/07.f
- *  Copyright 2007 __MyCompanyName__. All rights reserved.
- *
- */
-
-// Gaussians
-constant float Gauss150Z[]={
-  	-0.9998723404457334f,
-  	-0.9993274305065947f,
-  	-0.9983473449340834f,
-  	-0.9969322929775997f,
-  	-0.9950828645255290f,
-  	-0.9927998590434373f,
-  	-0.9900842691660192f,
-  	-0.9869372772712794f,
-  	-0.9833602541697529f,
-  	-0.9793547582425894f,
-  	-0.9749225346595943f,
-  	-0.9700655145738374f,
-  	-0.9647858142586956f,
-  	-0.9590857341746905f,
-  	-0.9529677579610971f,
-  	-0.9464345513503147f,
-  	-0.9394889610042837f,
-  	-0.9321340132728527f,
-  	-0.9243729128743136f,
-  	-0.9162090414984952f,
-  	-0.9076459563329236f,
-  	-0.8986873885126239f,
-  	-0.8893372414942055f,
-  	-0.8795995893549102f,
-  	-0.8694786750173527f,
-  	-0.8589789084007133f,
-  	-0.8481048644991847f,
-  	-0.8368612813885015f,
-  	-0.8252530581614230f,
-  	-0.8132852527930605f,
-  	-0.8009630799369827f,
-  	-0.7882919086530552f,
-  	-0.7752772600680049f,
-  	-0.7619248049697269f,
-  	-0.7482403613363824f,
-  	-0.7342298918013638f,
-  	-0.7198995010552305f,
-  	-0.7052554331857488f,
-  	-0.6903040689571928f,
-  	-0.6750519230300931f,
-  	-0.6595056411226444f,
-  	-0.6436719971150083f,
-  	-0.6275578900977726f,
-  	-0.6111703413658551f,
-  	-0.5945164913591590f,
-  	-0.5776035965513142f,
-  	-0.5604390262878617f,
-  	-0.5430302595752546f,
-  	-0.5253848818220803f,
-  	-0.5075105815339176f,
-  	-0.4894151469632753f,
-  	-0.4711064627160663f,
-  	-0.4525925063160997f,
-  	-0.4338813447290861f,
-  	-0.4149811308476706f,
-  	-0.3959000999390257f,
-  	-0.3766465660565522f,
-  	-0.3572289184172501f,
-  	-0.3376556177463400f,
-  	-0.3179351925907259f,
-  	-0.2980762356029071f,
-  	-0.2780873997969574f,
-  	-0.2579773947782034f,
-  	-0.2377549829482451f,
-  	-0.2174289756869712f,
-  	-0.1970082295132342f,
-  	-0.1765016422258567f,
-  	-0.1559181490266516f,
-  	-0.1352667186271445f,
-  	-0.1145563493406956f,
-  	-0.0937960651617229f,
-  	-0.0729949118337358f,
-  	-0.0521619529078925f,
-  	-0.0313062657937972f,
-  	-0.0104369378042598f,
-  	0.0104369378042598f,
-  	0.0313062657937972f,
-  	0.0521619529078925f,
-  	0.0729949118337358f,
-  	0.0937960651617229f,
-  	0.1145563493406956f,
-  	0.1352667186271445f,
-  	0.1559181490266516f,
-  	0.1765016422258567f,
-  	0.1970082295132342f,
-  	0.2174289756869712f,
-  	0.2377549829482451f,
-  	0.2579773947782034f,
-  	0.2780873997969574f,
-  	0.2980762356029071f,
-  	0.3179351925907259f,
-  	0.3376556177463400f,
-  	0.3572289184172501f,
-  	0.3766465660565522f,
-  	0.3959000999390257f,
-  	0.4149811308476706f,
-  	0.4338813447290861f,
-  	0.4525925063160997f,
-  	0.4711064627160663f,
-  	0.4894151469632753f,
-  	0.5075105815339176f,
-  	0.5253848818220803f,
-  	0.5430302595752546f,
-  	0.5604390262878617f,
-  	0.5776035965513142f,
-  	0.5945164913591590f,
-  	0.6111703413658551f,
-  	0.6275578900977726f,
-  	0.6436719971150083f,
-  	0.6595056411226444f,
-  	0.6750519230300931f,
-  	0.6903040689571928f,
-  	0.7052554331857488f,
-  	0.7198995010552305f,
-  	0.7342298918013638f,
-  	0.7482403613363824f,
-  	0.7619248049697269f,
-  	0.7752772600680049f,
-  	0.7882919086530552f,
-  	0.8009630799369827f,
-  	0.8132852527930605f,
-  	0.8252530581614230f,
-  	0.8368612813885015f,
-  	0.8481048644991847f,
-  	0.8589789084007133f,
-  	0.8694786750173527f,
-  	0.8795995893549102f,
-  	0.8893372414942055f,
-  	0.8986873885126239f,
-  	0.9076459563329236f,
-  	0.9162090414984952f,
-  	0.9243729128743136f,
-  	0.9321340132728527f,
-  	0.9394889610042837f,
-  	0.9464345513503147f,
-  	0.9529677579610971f,
-  	0.9590857341746905f,
-  	0.9647858142586956f,
-  	0.9700655145738374f,
-  	0.9749225346595943f,
-  	0.9793547582425894f,
-  	0.9833602541697529f,
-  	0.9869372772712794f,
-  	0.9900842691660192f,
-  	0.9927998590434373f,
-  	0.9950828645255290f,
-  	0.9969322929775997f,
-  	0.9983473449340834f,
-  	0.9993274305065947f,
-  	0.9998723404457334f
-};
-
-#pragma acc declare create ( Gauss150Z )
-
-constant float Gauss150Wt[]={
-  	0.0003276086705538f,
-  	0.0007624720924706f,
-  	0.0011976474864367f,
-  	0.0016323569986067f,
-  	0.0020663664924131f,
-  	0.0024994789888943f,
-  	0.0029315036836558f,
-  	0.0033622516236779f,
-  	0.0037915348363451f,
-  	0.0042191661429919f,
-  	0.0046449591497966f,
-  	0.0050687282939456f,
-  	0.0054902889094487f,
-  	0.0059094573005900f,
-  	0.0063260508184704f,
-  	0.0067398879387430f,
-  	0.0071507883396855f,
-  	0.0075585729801782f,
-  	0.0079630641773633f,
-  	0.0083640856838475f,
-  	0.0087614627643580f,
-  	0.0091550222717888f,
-  	0.0095445927225849f,
-  	0.0099300043714212f,
-  	0.0103110892851360f,
-  	0.0106876814158841f,
-  	0.0110596166734735f,
-  	0.0114267329968529f,
-  	0.0117888704247183f,
-  	0.0121458711652067f,
-  	0.0124975796646449f,
-  	0.0128438426753249f,
-  	0.0131845093222756f,
-  	0.0135194311690004f,
-  	0.0138484622795371f,
-  	0.0141714592928592f,
-  	0.0144882814685445f,
-  	0.0147987907597169f,
-  	0.0151028518701744f,
-  	0.0154003323133401f,
-  	0.0156911024699895f,
-  	0.0159750356447283f,
-  	0.0162520081211971f,
-  	0.0165218992159766f,
-  	0.0167845913311726f,
-  	0.0170399700056559f,
-  	0.0172879239649355f,
-  	0.0175283451696437f,
-  	0.0177611288626114f,
-  	0.0179861736145128f,
-  	0.0182033813680609f,
-  	0.0184126574807331f,
-  	0.0186139107660094f,
-  	0.0188070535331042f,
-  	0.0189920016251754f,
-  	0.0191686744559934f,
-  	0.0193369950450545f,
-  	0.0194968900511231f,
-  	0.0196482898041878f,
-  	0.0197911283358190f,
-  	0.0199253434079123f,
-  	0.0200508765398072f,
-  	0.0201676730337687f,
-  	0.0202756819988200f,
-  	0.0203748563729175f,
-  	0.0204651529434560f,
-  	0.0205465323660984f,
-  	0.0206189591819181f,
-  	0.0206824018328499f,
-  	0.0207368326754401f,
-  	0.0207822279928917f,
-  	0.0208185680053983f,
-  	0.0208458368787627f,
-  	0.0208640227312962f,
-  	0.0208731176389954f,
-  	0.0208731176389954f,
-  	0.0208640227312962f,
-  	0.0208458368787627f,
-  	0.0208185680053983f,
-  	0.0207822279928917f,
-  	0.0207368326754401f,
-  	0.0206824018328499f,
-  	0.0206189591819181f,
-  	0.0205465323660984f,
-  	0.0204651529434560f,
-  	0.0203748563729175f,
-  	0.0202756819988200f,
-  	0.0201676730337687f,
-  	0.0200508765398072f,
-  	0.0199253434079123f,
-  	0.0197911283358190f,
-  	0.0196482898041878f,
-  	0.0194968900511231f,
-  	0.0193369950450545f,
-  	0.0191686744559934f,
-  	0.0189920016251754f,
-  	0.0188070535331042f,
-  	0.0186139107660094f,
-  	0.0184126574807331f,
-  	0.0182033813680609f,
-  	0.0179861736145128f,
-  	0.0177611288626114f,
-  	0.0175283451696437f,
-  	0.0172879239649355f,
-  	0.0170399700056559f,
-  	0.0167845913311726f,
-  	0.0165218992159766f,
-  	0.0162520081211971f,
-  	0.0159750356447283f,
-  	0.0156911024699895f,
-  	0.0154003323133401f,
-  	0.0151028518701744f,
-  	0.0147987907597169f,
-  	0.0144882814685445f,
-  	0.0141714592928592f,
-  	0.0138484622795371f,
-  	0.0135194311690004f,
-  	0.0131845093222756f,
-  	0.0128438426753249f,
-  	0.0124975796646449f,
-  	0.0121458711652067f,
-  	0.0117888704247183f,
-  	0.0114267329968529f,
-  	0.0110596166734735f,
-  	0.0106876814158841f,
-  	0.0103110892851360f,
-  	0.0099300043714212f,
-  	0.0095445927225849f,
-  	0.0091550222717888f,
-  	0.0087614627643580f,
-  	0.0083640856838475f,
-  	0.0079630641773633f,
-  	0.0075585729801782f,
-  	0.0071507883396855f,
-  	0.0067398879387430f,
-  	0.0063260508184704f,
-  	0.0059094573005900f,
-  	0.0054902889094487f,
-  	0.0050687282939456f,
-  	0.0046449591497966f,
-  	0.0042191661429919f,
-  	0.0037915348363451f,
-  	0.0033622516236779f,
-  	0.0029315036836558f,
-  	0.0024994789888943f,
-  	0.0020663664924131f,
-  	0.0016323569986067f,
-  	0.0011976474864367f,
-  	0.0007624720924706f,
-  	0.0003276086705538f
-};
-
-#pragma acc declare create ( Gauss150Wt )
-
-float form_volume(float radius);
-float Iq(float q,float dnn,float d_factor, float radius,float sld, float solvent_sld);
-float Iqxy(float qx, float qy, float dnn,
-    float d_factor, float radius,float sld, float solvent_sld,
-    float theta, float phi, float psi);
-
-float _FCC_Integrand(float q, float dnn, float d_factor, float theta, float phi);
-float _FCCeval(float Theta, float Phi, float temp1, float temp3);
-float _sphereform(float q, float radius, float sld, float solvent_sld);
-
-
-float _FCC_Integrand(float q, float dnn, float d_factor, float theta, float phi) {
-
-	const float Da = d_factor*dnn;
-	const float temp1 = q*q*Da*Da;
-	const float temp3 = q*dnn;
-
-	float retVal = _FCCeval(theta,phi,temp1,temp3)/(4.0f*M_PI);
-	return(retVal);
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
 }
 
-float _FCCeval(float Theta, float Phi, float temp1, float temp3) {
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
 
-	float result;
-        float sin_theta,cos_theta,sin_phi,cos_phi;
-	SINCOS(Theta, sin_theta, cos_theta);
-	SINCOS(Phi, sin_phi, cos_phi);
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
 
-	const float temp6 =  sin_theta;
-	const float temp7 =  sin_theta*sin_phi + cos_theta;
-	const float temp8 = -sin_theta*cos_phi + cos_theta;
-	const float temp9 = -sin_theta*cos_phi + sin_theta*sin_phi;
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
 
-	const float temp10 = exp((-1.0f/8.0f)*temp1*((temp7*temp7)+(temp8*temp8)+(temp9*temp9)));
-	result = pow((1.0f-(temp10*temp10)),3)*temp6
-	    / ( (1.0f - 2.0f*temp10*cos(0.5f*temp3*temp7) + temp10*temp10)
-	      * (1.0f - 2.0f*temp10*cos(0.5f*temp3*temp8) + temp10*temp10)
-	      * (1.0f - 2.0f*temp10*cos(0.5f*temp3*temp9) + temp10*temp10));
-
-	return (result);
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
 }
 
-float _sphereform(float q, float radius, float sld, float solvent_sld){
-    const float qr = q*radius;
-    float sn, cn;
-    SINCOS(qr, sn, cn);
-    const float bes = (qr == 0.0f ? 1.0f : 3.0f*(sn-qr*cn)/(qr*qr*qr));
-    const float fq = bes * (sld - solvent_sld)*form_volume(radius);
-    return 1.0e-4f*fq*fq;
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
 }
 
-float form_volume(float radius){
-    return 1.333333333333333f*M_PI*radius*radius*radius;
-}
+// ##### End of rotation operation definitions ######
 
+#line 1 ".././models/lib/sas_3j1x_x.c"
 
-float Iq(float q, float dnn,
-  float d_factor, float radius,
-  float sld, float solvent_sld){
-
-	//Volume fraction calculated from lattice symmetry and sphere radius
-	const float s1 = dnn*sqrt(2.0f);
-	const float latticescale = 4.0f*(4.0f/3.0f)*M_PI*(radius*radius*radius)/(s1*s1*s1);
-
-    const float va = 0.0f;
-    const float vb = 2.0f*M_PI;
-    const float vaj = 0.0f;
-    const float vbj = M_PI;
-
-    float summ = 0.0f;
-    float answer = 0.0f;
-	for(int i=0; i<150; i++) {
-		//setup inner integral over the ellipsoidal cross-section
-		float summj=0.0f;
-		const float zphi = ( Gauss150Z[i]*(vb-va) + va + vb )/2.0f;		//the outer dummy is phi
-		for(int j=0;j<150;j++) {
-			//20 gauss points for the inner integral
-			float ztheta = ( Gauss150Z[j]*(vbj-vaj) + vaj + vbj )/2.0f;		//the inner dummy is theta
-			float yyy = Gauss150Wt[j] * _FCC_Integrand(q,dnn,d_factor,ztheta,zphi);
-			summj += yyy;
-		}
-		//now calculate the value of the inner integral
-		float answer = (vbj-vaj)/2.0f*summj;
-
-		//now calculate outer integral
-		summ = summ+(Gauss150Wt[i] * answer);
-	}		//final scaling is done at the end of the function, after the NT_FP64 case
-
-	answer = (vb-va)/2.0f*summ;
-	answer = answer*_sphereform(q,radius,sld,solvent_sld)*latticescale;
-
-    return answer;
-
-
-}
-
-
-float Iqxy(float qx, float qy, float dnn,
-    float d_factor, float radius,float sld, float solvent_sld,
-    float theta, float phi, float psi){
-
-  float b3_x, b3_y, b1_x, b1_y, b2_x, b2_y; //b3_z,
-  float q_z;
-  float cos_val_b3, cos_val_b2, cos_val_b1;
-  float a1_dot_q, a2_dot_q,a3_dot_q;
-  float answer;
-  float Zq, Fkq, Fkq_2;
-
-  //convert to q and make scaled values
-  float q = sqrt(qx*qx+qy*qy);
-  float q_x = qx/q;
-  float q_y = qy/q;
-
-  //convert angle degree to radian
-  theta = theta * M_PI_180;
-  phi = phi * M_PI_180;
-  psi = psi * M_PI_180;
-
-  const float Da = d_factor*dnn;
-  const float s1 = dnn/sqrt(0.75f);
-
-
-  //the occupied volume of the lattice
-  const float latticescale = 2.0f*(4.0f/3.0f)*M_PI*(radius*radius*radius)/(s1*s1*s1);
-  // q vector
-  q_z = 0.0f; // for SANS; assuming qz is negligible
-  /// Angles here are respect to detector coordinate
-  ///  instead of against q coordinate(PRB 36(46), 3(6), 1754(3854))
-    // b3 axis orientation
-    b3_x = cos(theta) * cos(phi);
-    b3_y = sin(theta);
-    //b3_z = -cos(theta) * sin(phi);
-    cos_val_b3 =  b3_x*q_x + b3_y*q_y;// + b3_z*q_z;
-
-    //alpha = acos(cos_val_b3);
-    // b1 axis orientation
-    b1_x = -cos(phi)*sin(psi) * sin(theta)+sin(phi)*cos(psi);
-    b1_y = sin(psi)*cos(theta);
-    cos_val_b1 = b1_x*q_x + b1_y*q_y;
-    // b2 axis orientation
-    b2_x = -sin(theta)*cos(psi)*cos(phi)-sin(psi)*sin(phi);
-  	b2_y = cos(theta)*cos(psi);
-    cos_val_b2 = b2_x*q_x + b2_y*q_y;
-
-    // The following test should always pass
-    if (fabs(cos_val_b3)>1.0f) {
-      //printf("FCC_ana_2D: Unexpected error: cos()>1\n");
-      cos_val_b3 = 1.0f;
-    }
-    if (fabs(cos_val_b2)>1.0f) {
-      //printf("FCC_ana_2D: Unexpected error: cos()>1\n");
-      cos_val_b2 = 1.0f;
-    }
-    if (fabs(cos_val_b1)>1.0f) {
-      //printf("FCC_ana_2D: Unexpected error: cos()>1\n");
-      cos_val_b1 = 1.0f;
-    }
-    // Compute the angle btw vector q and the a3 axis
-    a3_dot_q = 0.5f*dnn*q*(cos_val_b2+cos_val_b1-cos_val_b3);
-
-    // a1 axis
-    a1_dot_q = 0.5f*dnn*q*(cos_val_b3+cos_val_b2-cos_val_b1);
-
-    // a2 axis
-    a2_dot_q = 0.5f*dnn*q*(cos_val_b3+cos_val_b1-cos_val_b2);
-
-
-    // Get Fkq and Fkq_2
-    Fkq = exp(-0.5f*pow(Da/dnn,2.0f)*(a1_dot_q*a1_dot_q+a2_dot_q*a2_dot_q+a3_dot_q*a3_dot_q));
-    Fkq_2 = Fkq*Fkq;
-    // Call Zq=Z1*Z2*Z3
-    Zq = (1.0f-Fkq_2)/(1.0f-2.0f*Fkq*cos(a1_dot_q)+Fkq_2);
-    Zq *= (1.0f-Fkq_2)/(1.0f-2.0f*Fkq*cos(a2_dot_q)+Fkq_2);
-    Zq *= (1.0f-Fkq_2)/(1.0f-2.0f*Fkq*cos(a3_dot_q)+Fkq_2);
-
-  // Use SphereForm directly from libigor
-  answer = _sphereform(q,radius,sld,solvent_sld)*Zq*latticescale;
-
-  return answer;
- }
-
-/*
-    ##########################################################
-    #                                                        #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #   !!                                              !!   #
-    #   !!  KEEP THIS CODE CONSISTENT WITH KERNELPY.PY  !!   #
-    #   !!                                              !!   #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #                                                        #
-    ##########################################################
+/**
+* Spherical Bessel function 3*j1(x)/x
+*
+* Used for low q to avoid cancellation error.
+* Note that the values differ from sasview ~ 5e-12 rather than 5e-14, but
+* in this case it is likely cancellation errors in the original expression
+* using double precision that are the source.
 */
+double sas_3j1x_x(double q);
 
-#ifdef IQ_KERNEL_NAME
-kernel void IQ_KERNEL_NAME(
-    global const float *q,
-    global float *result,
-    const int Nq,
-#ifdef IQ_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQ_DISPERSION_LENGTH_DECLARATIONS,
+// The choice of the number of terms in the series and the cutoff value for
+// switching between series and direct calculation depends on the numeric
+// precision.
+//
+// Point where direct calculation reaches machine precision:
+//
+//   single machine precision eps 3e-8 at qr=1.1 **
+//   double machine precision eps 4e-16 at qr=1.1
+//
+// Point where Taylor series reaches machine precision (eps), where taylor
+// series matches direct calculation (cross) and the error at that point:
+//
+//   prec   n eps  cross  error
+//   single 3 0.28  0.4   6.2e-7
+//   single 4 0.68  0.7   2.3e-7
+//   single 5 1.18  1.2   7.5e-8
+//   double 3 0.01  0.03  2.3e-13
+//   double 4 0.06  0.1   3.1e-14
+//   double 5 0.16  0.2   5.0e-15
+//
+// ** Note: relative error on single precision starts increase on the direct
+// method at qr=1.1, rising from 3e-8 to 5e-5 by qr=1e3.  This should be
+// safe for the sans range, with objects of 100 nm supported to a q of 0.1
+// while maintaining 5 digits of precision.  For usans/sesans, the objects
+// are larger but the q is smaller, so again it should be fine.
+//
+// See explore/sph_j1c.py for code to explore these ranges.
+
+// Use 4th order series
+#if FLOAT_SIZE>4
+#define SPH_J1C_CUTOFF 0.1
+#else
+#define SPH_J1C_CUTOFF 0.7
 #endif
-    IQ_FIXED_PARAMETER_DECLARATIONS
-    )
+#pragma acc routine seq
+double sas_3j1x_x(double q)
 {
-#ifdef USE_OPENCL
-  #ifdef IQ_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQ_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
-
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qi = q[i];
-#ifdef IQ_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-  #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-  #endif
-    IQ_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
-
-    const float weight = IQ_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-      const float scattering = Iq(qi, IQ_PARAMETERS);
-      // allow kernels to exclude invalid regions by returning NaN
-      if (!isnan(scattering)) {
-        ret += weight*scattering;
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-        norm_vol += vol_weight;
-      #endif
-      }
-    //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
+    // 2017-05-18 PAK - support negative q
+    if (fabs(q) < SPH_J1C_CUTOFF) {
+        const double q2 = q*q;
+        return (1.0 + q2*(-3./30. + q2*(3./840. + q2*(-3./45360.))));// + q2*(3./3991680.)))));
+    } else {
+        double sin_q, cos_q;
+        SINCOS(q, sin_q, cos_q);
+        return 3.0*(sin_q/q - cos_q)/(q*q);
     }
-    IQ_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iq(qi, IQ_PARAMETERS) + background;
-#endif
-  }
 }
-#endif
 
 
-#ifdef IQXY_KERNEL_NAME
-kernel void IQXY_KERNEL_NAME(
-    global const float *qx,
-    global const float *qy,
-    global float *result,
-    const int Nq,
-#ifdef IQXY_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQXY_DISPERSION_LENGTH_DECLARATIONS,
-#endif
-    IQXY_FIXED_PARAMETER_DECLARATIONS
-    )
+#line 1 ".././models/lib/gauss150.c"
+
+// Created by Andrew Jackson on 4/23/07
+
+ #ifdef GAUSS_N
+ # undef GAUSS_N
+ # undef GAUSS_Z
+ # undef GAUSS_W
+ #endif
+ #define GAUSS_N 150
+ #define GAUSS_Z Gauss150Z
+ #define GAUSS_W Gauss150Wt
+
+
+// Note: using array size 152 rather than 150 so that it is a multiple of 4.
+// Some OpenCL devices prefer that vectors start and end on nice boundaries.
+constant double Gauss150Z[152]={
+  	-0.9998723404457334,
+  	-0.9993274305065947,
+  	-0.9983473449340834,
+  	-0.9969322929775997,
+  	-0.9950828645255290,
+  	-0.9927998590434373,
+  	-0.9900842691660192,
+  	-0.9869372772712794,
+  	-0.9833602541697529,
+  	-0.9793547582425894,
+  	-0.9749225346595943,
+  	-0.9700655145738374,
+  	-0.9647858142586956,
+  	-0.9590857341746905,
+  	-0.9529677579610971,
+  	-0.9464345513503147,
+  	-0.9394889610042837,
+  	-0.9321340132728527,
+  	-0.9243729128743136,
+  	-0.9162090414984952,
+  	-0.9076459563329236,
+  	-0.8986873885126239,
+  	-0.8893372414942055,
+  	-0.8795995893549102,
+  	-0.8694786750173527,
+  	-0.8589789084007133,
+  	-0.8481048644991847,
+  	-0.8368612813885015,
+  	-0.8252530581614230,
+  	-0.8132852527930605,
+  	-0.8009630799369827,
+  	-0.7882919086530552,
+  	-0.7752772600680049,
+  	-0.7619248049697269,
+  	-0.7482403613363824,
+  	-0.7342298918013638,
+  	-0.7198995010552305,
+  	-0.7052554331857488,
+  	-0.6903040689571928,
+  	-0.6750519230300931,
+  	-0.6595056411226444,
+  	-0.6436719971150083,
+  	-0.6275578900977726,
+  	-0.6111703413658551,
+  	-0.5945164913591590,
+  	-0.5776035965513142,
+  	-0.5604390262878617,
+  	-0.5430302595752546,
+  	-0.5253848818220803,
+  	-0.5075105815339176,
+  	-0.4894151469632753,
+  	-0.4711064627160663,
+  	-0.4525925063160997,
+  	-0.4338813447290861,
+  	-0.4149811308476706,
+  	-0.3959000999390257,
+  	-0.3766465660565522,
+  	-0.3572289184172501,
+  	-0.3376556177463400,
+  	-0.3179351925907259,
+  	-0.2980762356029071,
+  	-0.2780873997969574,
+  	-0.2579773947782034,
+  	-0.2377549829482451,
+  	-0.2174289756869712,
+  	-0.1970082295132342,
+  	-0.1765016422258567,
+  	-0.1559181490266516,
+  	-0.1352667186271445,
+  	-0.1145563493406956,
+  	-0.0937960651617229,
+  	-0.0729949118337358,
+  	-0.0521619529078925,
+  	-0.0313062657937972,
+  	-0.0104369378042598,
+  	0.0104369378042598,
+  	0.0313062657937972,
+  	0.0521619529078925,
+  	0.0729949118337358,
+  	0.0937960651617229,
+  	0.1145563493406956,
+  	0.1352667186271445,
+  	0.1559181490266516,
+  	0.1765016422258567,
+  	0.1970082295132342,
+  	0.2174289756869712,
+  	0.2377549829482451,
+  	0.2579773947782034,
+  	0.2780873997969574,
+  	0.2980762356029071,
+  	0.3179351925907259,
+  	0.3376556177463400,
+  	0.3572289184172501,
+  	0.3766465660565522,
+  	0.3959000999390257,
+  	0.4149811308476706,
+  	0.4338813447290861,
+  	0.4525925063160997,
+  	0.4711064627160663,
+  	0.4894151469632753,
+  	0.5075105815339176,
+  	0.5253848818220803,
+  	0.5430302595752546,
+  	0.5604390262878617,
+  	0.5776035965513142,
+  	0.5945164913591590,
+  	0.6111703413658551,
+  	0.6275578900977726,
+  	0.6436719971150083,
+  	0.6595056411226444,
+  	0.6750519230300931,
+  	0.6903040689571928,
+  	0.7052554331857488,
+  	0.7198995010552305,
+  	0.7342298918013638,
+  	0.7482403613363824,
+  	0.7619248049697269,
+  	0.7752772600680049,
+  	0.7882919086530552,
+  	0.8009630799369827,
+  	0.8132852527930605,
+  	0.8252530581614230,
+  	0.8368612813885015,
+  	0.8481048644991847,
+  	0.8589789084007133,
+  	0.8694786750173527,
+  	0.8795995893549102,
+  	0.8893372414942055,
+  	0.8986873885126239,
+  	0.9076459563329236,
+  	0.9162090414984952,
+  	0.9243729128743136,
+  	0.9321340132728527,
+  	0.9394889610042837,
+  	0.9464345513503147,
+  	0.9529677579610971,
+  	0.9590857341746905,
+  	0.9647858142586956,
+  	0.9700655145738374,
+  	0.9749225346595943,
+  	0.9793547582425894,
+  	0.9833602541697529,
+  	0.9869372772712794,
+  	0.9900842691660192,
+  	0.9927998590434373,
+  	0.9950828645255290,
+  	0.9969322929775997,
+  	0.9983473449340834,
+  	0.9993274305065947,
+  	0.9998723404457334,
+  	0., // zero padding is ignored
+  	0.  // zero padding is ignored
+};
+
+constant double Gauss150Wt[152]={
+  	0.0003276086705538,
+  	0.0007624720924706,
+  	0.0011976474864367,
+  	0.0016323569986067,
+  	0.0020663664924131,
+  	0.0024994789888943,
+  	0.0029315036836558,
+  	0.0033622516236779,
+  	0.0037915348363451,
+  	0.0042191661429919,
+  	0.0046449591497966,
+  	0.0050687282939456,
+  	0.0054902889094487,
+  	0.0059094573005900,
+  	0.0063260508184704,
+  	0.0067398879387430,
+  	0.0071507883396855,
+  	0.0075585729801782,
+  	0.0079630641773633,
+  	0.0083640856838475,
+  	0.0087614627643580,
+  	0.0091550222717888,
+  	0.0095445927225849,
+  	0.0099300043714212,
+  	0.0103110892851360,
+  	0.0106876814158841,
+  	0.0110596166734735,
+  	0.0114267329968529,
+  	0.0117888704247183,
+  	0.0121458711652067,
+  	0.0124975796646449,
+  	0.0128438426753249,
+  	0.0131845093222756,
+  	0.0135194311690004,
+  	0.0138484622795371,
+  	0.0141714592928592,
+  	0.0144882814685445,
+  	0.0147987907597169,
+  	0.0151028518701744,
+  	0.0154003323133401,
+  	0.0156911024699895,
+  	0.0159750356447283,
+  	0.0162520081211971,
+  	0.0165218992159766,
+  	0.0167845913311726,
+  	0.0170399700056559,
+  	0.0172879239649355,
+  	0.0175283451696437,
+  	0.0177611288626114,
+  	0.0179861736145128,
+  	0.0182033813680609,
+  	0.0184126574807331,
+  	0.0186139107660094,
+  	0.0188070535331042,
+  	0.0189920016251754,
+  	0.0191686744559934,
+  	0.0193369950450545,
+  	0.0194968900511231,
+  	0.0196482898041878,
+  	0.0197911283358190,
+  	0.0199253434079123,
+  	0.0200508765398072,
+  	0.0201676730337687,
+  	0.0202756819988200,
+  	0.0203748563729175,
+  	0.0204651529434560,
+  	0.0205465323660984,
+  	0.0206189591819181,
+  	0.0206824018328499,
+  	0.0207368326754401,
+  	0.0207822279928917,
+  	0.0208185680053983,
+  	0.0208458368787627,
+  	0.0208640227312962,
+  	0.0208731176389954,
+  	0.0208731176389954,
+  	0.0208640227312962,
+  	0.0208458368787627,
+  	0.0208185680053983,
+  	0.0207822279928917,
+  	0.0207368326754401,
+  	0.0206824018328499,
+  	0.0206189591819181,
+  	0.0205465323660984,
+  	0.0204651529434560,
+  	0.0203748563729175,
+  	0.0202756819988200,
+  	0.0201676730337687,
+  	0.0200508765398072,
+  	0.0199253434079123,
+  	0.0197911283358190,
+  	0.0196482898041878,
+  	0.0194968900511231,
+  	0.0193369950450545,
+  	0.0191686744559934,
+  	0.0189920016251754,
+  	0.0188070535331042,
+  	0.0186139107660094,
+  	0.0184126574807331,
+  	0.0182033813680609,
+  	0.0179861736145128,
+  	0.0177611288626114,
+  	0.0175283451696437,
+  	0.0172879239649355,
+  	0.0170399700056559,
+  	0.0167845913311726,
+  	0.0165218992159766,
+  	0.0162520081211971,
+  	0.0159750356447283,
+  	0.0156911024699895,
+  	0.0154003323133401,
+  	0.0151028518701744,
+  	0.0147987907597169,
+  	0.0144882814685445,
+  	0.0141714592928592,
+  	0.0138484622795371,
+  	0.0135194311690004,
+  	0.0131845093222756,
+  	0.0128438426753249,
+  	0.0124975796646449,
+  	0.0121458711652067,
+  	0.0117888704247183,
+  	0.0114267329968529,
+  	0.0110596166734735,
+  	0.0106876814158841,
+  	0.0103110892851360,
+  	0.0099300043714212,
+  	0.0095445927225849,
+  	0.0091550222717888,
+  	0.0087614627643580,
+  	0.0083640856838475,
+  	0.0079630641773633,
+  	0.0075585729801782,
+  	0.0071507883396855,
+  	0.0067398879387430,
+  	0.0063260508184704,
+  	0.0059094573005900,
+  	0.0054902889094487,
+  	0.0050687282939456,
+  	0.0046449591497966,
+  	0.0042191661429919,
+  	0.0037915348363451,
+  	0.0033622516236779,
+  	0.0029315036836558,
+  	0.0024994789888943,
+  	0.0020663664924131,
+  	0.0016323569986067,
+  	0.0011976474864367,
+  	0.0007624720924706,
+  	0.0003276086705538,
+  	0., // zero padding is ignored
+  	0.  // zero padding is ignored
+};
+
+#pragma acc declare copyin( Gauss150Wt[0:150], Gauss150Z[0:150] )
+
+#line 1 ".././models/lib/sphere_form.c"
+
+double sphere_volume(double radius);
+double sphere_form(double q, double radius, double sld, double solvent_sld);
+
+    
+#pragma acc routine seq
+double sphere_volume(double radius)
 {
-#ifdef USE_OPENCL
-  #ifdef IQXY_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQXY_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
-
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qxi = qx[i];
-    const float qyi = qy[i];
-    #if USE_KAHAN_SUMMATION
-    float accumulated_error = 0.0f;
-    #endif
-#ifdef IQXY_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-    #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-    #endif
-    IQXY_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
-
-    const float weight = IQXY_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-
-      const float scattering = Iqxy(qxi, qyi, IQXY_PARAMETERS);
-      if (!isnan(scattering)) { // if scattering is bad, exclude it from sum
-      //if (scattering >= 0.0f) { // scattering cannot be negative
-        // TODO: use correct angle for spherical correction
-        // Definition of theta and phi are probably reversed relative to the
-        // equation which gave rise to this correction, leading to an
-        // attenuation of the pattern as theta moves through pi/2.f  Either
-        // reverse the meanings of phi and theta in the forms, or use phi
-        // rather than theta in this correction.  Current code uses cos(theta)
-        // so that values match those of sasview.
-      #if defined(IQXY_HAS_THETA) // && 0
-        const float spherical_correction
-          = (Ntheta>1 ? fabs(cos(M_PI_180*theta))*M_PI_2:1.0f);
-        const float next = spherical_correction * weight * scattering;
-      #else
-        const float next = weight * scattering;
-      #endif
-      #if USE_KAHAN_SUMMATION
-        const float y = next - accumulated_error;
-        const float t = ret + y;
-        accumulated_error = (t - ret) - y;
-        ret = t;
-      #else
-        ret += next;
-      #endif
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-      #endif
-        norm_vol += vol_weight;
-      }
-      //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
-    }
-    IQXY_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iqxy(qxi, qyi, IQXY_PARAMETERS) + background;
-#endif
-  }
+    return M_4PI_3*cube(radius);
 }
-#endif
+    
+#pragma acc routine seq
+double sphere_form(double q, double radius, double sld, double solvent_sld)
+{
+    const double fq = sphere_volume(radius) * sas_3j1x_x(q*radius);
+    const double contrast = (sld - solvent_sld);
+    return 1.0e-4*square(contrast * fq);
+}
+
+
+
+#line 1 ".././models/fcc_paracrystal.c"
+
+static double
+fcc_Zq(double qa, double qb, double qc, double dnn, double d_factor)
+{
+    // Equations from Matsuoka 17-18-19, multiplied by |q|
+    const double a1 = ( qa + qb)/2.0;
+    const double a2 = ( qa + qc)/2.0;
+    const double a3 = ( qb + qc)/2.0;
+    const double d_a = dnn/sqrt(2);
+
+    // Matsuoka 23-24-25
+    //     Z_k numerator: 1 - exp(a)^2
+    //     Z_k denominator: 1 - 2 cos(d a_k) exp(a) + exp(2a)
+    // Rewriting numerator
+    //         => -(exp(2a) - 1)
+    //         => -expm1(2a)
+    // Rewriting denominator
+    //         => exp(a)^2 - 2 cos(d ak) exp(a) + 1)
+    //         => (exp(a) - 2 cos(d ak)) * exp(a) + 1
+    const double arg = -0.5*square(dnn*d_factor)*(a1*a1 + a2*a2 + a3*a3);
+    const double exp_arg = exp(arg);
+    const double Zq = -cube(expm1(2.0*arg))
+        / ( ((exp_arg - 2.0*cos(d_a*a1))*exp_arg + 1.0)
+          * ((exp_arg - 2.0*cos(d_a*a2))*exp_arg + 1.0)
+          * ((exp_arg - 2.0*cos(d_a*a3))*exp_arg + 1.0));
+
+    return Zq;
+}
+
+
+// occupied volume fraction calculated from lattice symmetry and sphere radius
+static double
+fcc_volume_fraction(double radius, double dnn)
+{
+    return 4.0*sphere_volume(M_SQRT1_2*radius/dnn);
+}
+
+static double
+form_volume(double radius)
+{
+    return sphere_volume(radius);
+}
+
+
+static double Iq(double q, double dnn,
+  double d_factor, double radius,
+  double sld, double solvent_sld)
+{
+    // translate a point in [-1,1] to a point in [0, 2 pi]
+    const double phi_m = M_PI;
+    const double phi_b = M_PI;
+    // translate a point in [-1,1] to a point in [0, pi]
+    const double theta_m = M_PI_2;
+    const double theta_b = M_PI_2;
+
+    double outer_sum = 0.0;
+    for(int i=0; i<GAUSS_N; i++) {
+        double inner_sum = 0.0;
+        const double theta = GAUSS_Z[i]*theta_m + theta_b;
+        double sin_theta, cos_theta;
+        SINCOS(theta, sin_theta, cos_theta);
+        const double qc = q*cos_theta;
+        const double qab = q*sin_theta;
+        for(int j=0;j<GAUSS_N;j++) {
+            const double phi = GAUSS_Z[j]*phi_m + phi_b;
+            double sin_phi, cos_phi;
+            SINCOS(phi, sin_phi, cos_phi);
+            const double qa = qab*cos_phi;
+            const double qb = qab*sin_phi;
+            const double form = fcc_Zq(qa, qb, qc, dnn, d_factor);
+            inner_sum += GAUSS_W[j] * form;
+        }
+        inner_sum *= phi_m;  // sum(f(x)dx) = sum(f(x)) dx
+        outer_sum += GAUSS_W[i] * inner_sum * sin_theta;
+    }
+    outer_sum *= theta_m;
+    const double Zq = outer_sum/(4.0*M_PI);
+    const double Pq = sphere_form(q, radius, sld, solvent_sld);
+
+    return fcc_volume_fraction(radius, dnn) * Pq * Zq;
+}
+
+static double Iqabc(double qa, double qb, double qc,
+    double dnn, double d_factor, double radius,
+    double sld, double solvent_sld)
+{
+    const double q = sqrt(qa*qa + qb*qb + qc*qc);
+    const double Pq = sphere_form(q, radius, sld, solvent_sld);
+    const double Zq = fcc_Zq(qa, qb, qc, dnn, d_factor);
+    return fcc_volume_fraction(radius, dnn) * Pq * Zq;
+}
+

--- a/mcstas-comps/share/sas_flexible_cylinder.c
+++ b/mcstas-comps/share/sas_flexible_cylinder.c
@@ -1,0 +1,994 @@
+#define HAS_Iq
+#define FORM_VOL
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/polevl.c"
+
+/*							polevl.c
+ *							p1evl.c
+ *
+ *	Evaluate polynomial
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * int N;
+ * double x, y, coef[N+1], polevl[];
+ *
+ * y = polevl( x, coef, N );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Evaluates polynomial of degree N:
+ *
+ *                     2          N
+ * y  =  C  + C x + C x  +...+ C x
+ *        0    1     2          N
+ *
+ * Coefficients are stored in reverse order:
+ *
+ * coef[0] = C  , ..., coef[N] = C  .
+ *            N                   0
+ *
+ * The function p1evl() assumes that C_N = 1.0 and is
+ * omitted from the array.  Its calling arguments are
+ * otherwise the same as polevl().
+ *
+ *
+ * SPEED:
+ *
+ * In the interest of speed, there are no checks for out
+ * of bounds arithmetic.  This routine is used by most of
+ * the functions in the library.  Depending on available
+ * equipment features, the user may wish to rewrite the
+ * program in microcode or assembly language.
+ *
+ */
+
+
+/*
+Cephes Math Library Release 2.1:  December, 1988
+Copyright 1984, 1987, 1988 by Stephen L. Moshier
+Direct inquiries to 30 Frost Street, Cambridge, MA 02140
+*/
+#pragma acc routine seq
+static
+double polevl( double x, pconstant double *coef, int N )
+{
+
+    int i = 0;
+    double ans = coef[i];
+
+    while (i < N) {
+        i++;
+        ans = ans * x + coef[i];
+    }
+
+    return ans;
+}
+
+/*							p1evl()	*/
+/*                                          N
+ * Evaluate polynomial when coefficient of x  is 1.0.
+ * Otherwise same as polevl.
+ */
+#pragma acc routine seq
+static
+double p1evl( double x, pconstant double *coef, int N )
+{
+    int i=0;
+    double ans = x+coef[i];
+
+    while (i < N-1) {
+        i++;
+        ans = ans*x + coef[i];
+    }
+
+    return ans;
+}
+
+
+#line 1 ".././models/lib/sas_J1.c"
+
+/*							j1.c
+ *
+ *	Bessel function of order one
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * double x, y, j1();
+ *
+ * y = j1( x );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Returns Bessel function of order one of the argument.
+ *
+ * The domain is divided into the intervals [0, 8] and
+ * (8, infinity). In the first interval a 24 term Chebyshev
+ * expansion is used. In the second, the asymptotic
+ * trigonometric representation is employed using two
+ * rational functions of degree 5/5.
+ *
+ *
+ *
+ * ACCURACY:
+ *
+ *                      Absolute error:
+ * arithmetic   domain      # trials      peak         rms
+ *    DEC       0, 30       10000       4.0e-17     1.1e-17
+ *    IEEE      0, 30       30000       2.6e-16     1.1e-16
+ *
+ *
+ */
+
+/*
+Cephes Math Library Release 2.8:  June, 2000
+Copyright 1984, 1987, 1989, 2000 by Stephen L. Moshier
+*/
+
+#if FLOAT_SIZE>4
+//Cephes double pression function
+
+constant double RPJ1[8] = {
+    -8.99971225705559398224E8,
+    4.52228297998194034323E11,
+    -7.27494245221818276015E13,
+    3.68295732863852883286E15,
+    0.0,
+    0.0,
+    0.0,
+    0.0 };
+
+constant double RQJ1[8] = {
+    6.20836478118054335476E2,
+    2.56987256757748830383E5,
+    8.35146791431949253037E7,
+    2.21511595479792499675E10,
+    4.74914122079991414898E12,
+    7.84369607876235854894E14,
+    8.95222336184627338078E16,
+    5.32278620332680085395E18
+    };
+
+constant double PPJ1[8] = {
+    7.62125616208173112003E-4,
+    7.31397056940917570436E-2,
+    1.12719608129684925192E0,
+    5.11207951146807644818E0,
+    8.42404590141772420927E0,
+    5.21451598682361504063E0,
+    1.00000000000000000254E0,
+    0.0} ;
+
+
+constant double PQJ1[8] = {
+    5.71323128072548699714E-4,
+    6.88455908754495404082E-2,
+    1.10514232634061696926E0,
+    5.07386386128601488557E0,
+    8.39985554327604159757E0,
+    5.20982848682361821619E0,
+    9.99999999999999997461E-1,
+    0.0 };
+
+constant double QPJ1[8] = {
+    5.10862594750176621635E-2,
+    4.98213872951233449420E0,
+    7.58238284132545283818E1,
+    3.66779609360150777800E2,
+    7.10856304998926107277E2,
+    5.97489612400613639965E2,
+    2.11688757100572135698E2,
+    2.52070205858023719784E1 };
+
+constant double QQJ1[8] = {
+    7.42373277035675149943E1,
+    1.05644886038262816351E3,
+    4.98641058337653607651E3,
+    9.56231892404756170795E3,
+    7.99704160447350683650E3,
+    2.82619278517639096600E3,
+    3.36093607810698293419E2,
+    0.0 };
+
+#pragma acc declare copyin( RPJ1[0:8], RQJ1[0:8], PPJ1[0:8], PQJ1[0:8], QPJ1[0:8], QQJ1[0:8])
+
+#pragma acc routine seq
+static
+double cephes_j1(double x)
+{
+
+    double w, z, p, q, abs_x, sign_x;
+
+    const double Z1 = 1.46819706421238932572E1;
+    const double Z2 = 4.92184563216946036703E1;
+
+    // 2017-05-18 PAK - mathematica and mpmath use J1(-x) = -J1(x)
+    if (x < 0) {
+        abs_x = -x;
+        sign_x = -1.0;
+    } else {
+        abs_x = x;
+        sign_x = 1.0;
+    }
+
+    if( abs_x <= 5.0 ) {
+        z = abs_x * abs_x;
+        w = polevl( z, RPJ1, 3 ) / p1evl( z, RQJ1, 8 );
+        w = w * abs_x * (z - Z1) * (z - Z2);
+        return( sign_x * w );
+    }
+
+    w = 5.0/abs_x;
+    z = w * w;
+    p = polevl( z, PPJ1, 6)/polevl( z, PQJ1, 6 );
+    q = polevl( z, QPJ1, 7)/p1evl( z, QQJ1, 7 );
+
+    // 2017-05-19 PAK improve accuracy using trig identies
+    // original:
+    //    const double THPIO4 =  2.35619449019234492885;
+    //    const double SQ2OPI = 0.79788456080286535588;
+    //    double sin_xn, cos_xn;
+    //    SINCOS(abs_x - THPIO4, sin_xn, cos_xn);
+    //    p = p * cos_xn - w * q * sin_xn;
+    //    return( sign_x * p * SQ2OPI / sqrt(abs_x) );
+    // expanding p*cos(a - 3 pi/4) - wq sin(a - 3 pi/4)
+    //    [ p(sin(a) - cos(a)) + wq(sin(a) + cos(a)) / sqrt(2)
+    // note that sqrt(1/2) * sqrt(2/pi) = sqrt(1/pi)
+    const double SQRT1_PI = 0.56418958354775628;
+    double sin_x, cos_x;
+    SINCOS(abs_x, sin_x, cos_x);
+    p = p*(sin_x - cos_x) + w*q*(sin_x + cos_x);
+    return( sign_x * p * SQRT1_PI / sqrt(abs_x) );
+}
+
+#else
+//Single precission version of cephes
+
+constant float JPJ1[8] = {
+    -4.878788132172128E-009,
+    6.009061827883699E-007,
+    -4.541343896997497E-005,
+    1.937383947804541E-003,
+    -3.405537384615824E-002,
+    0.0,
+    0.0,
+    0.0
+    };
+
+constant float MO1J1[8] = {
+    6.913942741265801E-002,
+    -2.284801500053359E-001,
+    3.138238455499697E-001,
+    -2.102302420403875E-001,
+    5.435364690523026E-003,
+    1.493389585089498E-001,
+    4.976029650847191E-006,
+    7.978845453073848E-001
+    };
+
+constant float PH1J1[8] = {
+    -4.497014141919556E+001,
+    5.073465654089319E+001,
+    -2.485774108720340E+001,
+    7.222973196770240E+000,
+    -1.544842782180211E+000,
+    3.503787691653334E-001,
+    -1.637986776941202E-001,
+    3.749989509080821E-001
+    };
+
+#pragma acc declare copyin( JPJ1[0:8], MO1J1[0:8], PH1J1[0:8])
+
+#pragma acc routine seq
+static
+float cephes_j1f(float xx)
+{
+
+    float x, w, z, p, q, xn;
+
+    const float Z1 = 1.46819706421238932572E1;
+
+
+    // 2017-05-18 PAK - mathematica and mpmath use J1(-x) = -J1(x)
+    x = xx;
+    if( x < 0 )
+        x = -xx;
+
+    if( x <= 2.0 ) {
+        z = x * x;
+        p = (z-Z1) * x * polevl( z, JPJ1, 4 );
+        return( xx < 0. ? -p : p );
+    }
+
+    q = 1.0/x;
+    w = sqrt(q);
+
+    p = w * polevl( q, MO1J1, 7);
+    w = q*q;
+    // 2017-05-19 PAK improve accuracy using trig identies
+    // original:
+    //    const float THPIO4F =  2.35619449019234492885;    /* 3*pi/4 */
+    //    xn = q * polevl( w, PH1J1, 7) - THPIO4F;
+    //    p = p * cos(xn + x);
+    //    return( xx < 0. ? -p : p );
+    // expanding cos(a + b - 3 pi/4) is
+    //    [sin(a)sin(b) + sin(a)cos(b) + cos(a)sin(b)-cos(a)cos(b)] / sqrt(2)
+    xn = q * polevl( w, PH1J1, 7);
+    float cos_xn, sin_xn;
+    float cos_x, sin_x;
+    SINCOS(xn, sin_xn, cos_xn);  // about xn and 1
+    SINCOS(x, sin_x, cos_x);
+    p *= M_SQRT1_2*(sin_xn*(sin_x+cos_x) + cos_xn*(sin_x-cos_x));
+
+    return( xx < 0. ? -p : p );
+}
+#endif
+
+#if FLOAT_SIZE>4
+#define sas_J1 cephes_j1
+#else
+#define sas_J1 cephes_j1f
+#endif
+
+//Finally J1c function that equals 2*J1(x)/x
+    
+#pragma acc routine seq
+static
+double sas_2J1x_x(double x)
+{
+    return (x != 0.0 ) ? 2.0*sas_J1(x)/x : 1.0;
+}
+
+
+#line 1 ".././models/lib/wrc_cyl.c"
+
+/*
+    Functions for WRC implementation of flexible cylinders. See
+    W R Chen, P D Butler and L J Magid,
+    Incorporating Intermicellar Interactions in the Fitting of
+    SANS Data from Cationic Wormlike Micelles.
+    Langmuir, 22(15) 2006 6539-6548
+*/
+    
+#pragma acc routine seq
+static double
+Rgsquare(double L, double b)
+{
+    const double x = L/b;
+    // Use Horner's method to evaluate Pedersen eq 15:
+    //     alpha^2 = [1.0 + (x/3.12)^2 + (x/8.67)^3] ^ (0.176/3)
+    const double alphasq =
+        pow(1.0 + x*x*(1.027284681130835e-01 + 1.534414548417740e-03*x),
+            5.866666666666667e-02);
+    return alphasq*L*b/6.0;
+}
+    
+#pragma acc routine seq
+static double
+Rgsquareshort(double L, double b)
+{
+    const double r = b/L;  // = 1/n_b in Pedersen ref.
+    return Rgsquare(L, b) * (1.0 + r*(-1.5 + r*(1.5 + r*0.75*expm1(-2.0/r))));
+}
+    
+#pragma acc routine seq
+static double
+w_WR(double x)
+{
+    // Pedersen eq. 16:
+    //    w = [1 + tanh((x-C4)/C5)]/2
+    const double C4 = 1.523;
+    const double C5 = 0.1477;
+    return 0.5 + 0.5*tanh((x - C4)/C5);
+}
+    
+#pragma acc routine seq
+static double
+Sdebye(double qsq)
+{
+#if FLOAT_SIZE>4
+#  define DEBYE_CUTOFF 0.25  // 1e-15 error
+#else
+#  define DEBYE_CUTOFF 1.0  // 4e-7 error
+#endif
+
+    if (qsq < DEBYE_CUTOFF) {
+        const double x = qsq;
+        // mathematica: PadeApproximant[2*Exp[-x^2] + x^2-1)/x^4, {x, 0, 8}]
+        const double A1=1./15., A2=1./60, A3=0., A4=1./75600.;
+        const double B1=2./5., B2=1./15., B3=1./180., B4=1./5040.;
+        return ((((A4*x + A3)*x + A2)*x + A1)*x + 1.)
+             / ((((B4*x + B3)*x + B2)*x + B1)*x + 1.);
+    } else {
+        return 2.*(expm1(-qsq) + qsq)/(qsq*qsq);
+    }
+}
+    
+#pragma acc routine seq
+static double
+a_long(double q, double L, double b/*, double p1, double p2, double q0*/)
+{
+    const double p1 = 4.12;
+    const double p2 = 4.42;
+    const double q0 = 3.1;
+
+    // Constants C1, ..., C5 derived from least squares fit (Pedersen, eq 13,16)
+    const double C1 = 1.22;
+    const double C2 = 0.4288;
+    const double C3 = -1.651;
+    const double C4 = 1.523;
+    const double C5 = 0.1477;
+    const double miu = 0.585;
+
+    const double C = (L/b>10.0 ? 3.06*pow(L/b, -0.44) : 1.0);
+    //printf("branch B-%d q=%g L=%g b=%g\n", C==1.0, q, L, b);
+    const double r2 = Rgsquare(L,b);
+    const double r = sqrt(r2);
+    const double qr_b = q0*r/b;
+    const double qr_b_sq = qr_b*qr_b;
+    const double qr_b_4 = qr_b_sq*qr_b_sq;
+    const double qr_b_miu = pow(qr_b, -1.0/miu);
+    const double em1_qr_b_sq = expm1(-qr_b_sq);
+    const double sech2 = 1.0/square(cosh((qr_b-C4)/C5));
+    const double w = w_WR(qr_b);
+
+    const double t1 = pow(q0, 1.0 + p1 + p2)/(b*(p1-p2));
+    const double t2 = C/(15.0*L) * (
+        + 14.0*b*b*em1_qr_b_sq/(q0*qr_b_sq)
+        + 2.0*q0*r2*exp(-qr_b_sq)*(11.0 + 7.0/qr_b_sq));
+    const double t11 = ((C3*qr_b_miu + C2)*qr_b_miu + C1)*qr_b_miu;
+    const double t3 = r*sech2/(2.*C5)*t11;
+    const double t4 = r*(em1_qr_b_sq + qr_b_sq)*sech2 / (C5*qr_b_4);
+    const double t5 = -4.0*r*qr_b*em1_qr_b_sq/qr_b_4 * (1.0 - w);
+    const double t10 = 2.0*(em1_qr_b_sq + qr_b_sq)/qr_b_4 * (1.0 - w); //=Sdebye*(1-w)
+    const double t6 = 4.0*b/q0 * t10;
+    const double t7 = r*((-3.0*C3*qr_b_miu -2.0*C2)*qr_b_miu -1.0*C1)*qr_b_miu/(miu*qr_b);
+    const double t9 = C*b/L * (4.0 - exp(-qr_b_sq) * (11.0 + 7.0/qr_b_sq) + 7.0/qr_b_sq)/15.0;
+    const double t12 = b*b*M_PI/(L*q0*q0) + t2 + t3 - t4 + t5 - t6 + t7*w;
+    const double t13 = -b*M_PI/(L*q0) + t9 + t10 + t11*w;
+
+    const double a1 = pow(q0,p1)*t13 - t1*pow(q0,-p2)*(t12 + b*p1/q0*t13);
+    const double a2 = t1*pow(q0,-p1)*(t12 + b*p1/q0*t13);
+
+    const double ans = a1*pow(q*b, -p1) + a2*pow(q*b, -p2) + M_PI/(q*L);
+    return ans;
+}
+    
+#pragma acc routine seq
+static double
+_short(double r2, double exp_qr_b, double L, double b, double p1short,
+        double p2short, double q0)
+{
+    const double qr2 = q0*q0 * r2;
+    const double b3 = b*b*b;
+    const double q0p = pow(q0, -4.0 + p1short);
+
+    double yy = 1.0/(L*r2*r2) * b/exp_qr_b*q0p
+        * (8.0*b3*L
+           - 8.0*b3*exp_qr_b*L
+           + 2.0*b3*exp_qr_b*L*p2short
+           - 2.0*b*exp_qr_b*L*p2short*qr2
+           + 4.0*b*exp_qr_b*L*qr2
+           - 2.0*b3*L*p2short
+           + 4.0*b*L*qr2
+           - M_PI*exp_qr_b*qr2*q0*r2
+           + M_PI*exp_qr_b*p2short*qr2*q0*r2);
+
+    return yy;
+}
+    
+#pragma acc routine seq
+static double
+a_short(double qp, double L, double b
+        /*double p1short, double p2short*/, double q0)
+{
+    const double p1short = 5.36;
+    const double p2short = 5.62;
+
+    const double r2 = Rgsquareshort(L,b);
+    const double exp_qr_b = exp(r2*square(q0/b));
+    const double pdiff = p1short - p2short;
+    const double a1 = _short(r2,exp_qr_b,L,b,p1short,p2short,q0)/pdiff;
+    const double a2= -_short(r2,exp_qr_b,L,b,p2short,p1short,q0)/pdiff;
+    const double ans = a1*pow(qp*b, -p1short) + a2*pow(qp*b, -p2short) + M_PI/(qp*L);
+    return ans;
+}
+    
+#pragma acc routine seq
+static double
+Sexv(double q, double L, double b)
+{
+    // Pedersen eq 13, corrected by Chen eq A.5, swapping w and 1-w
+    const double C1=1.22;
+    const double C2=0.4288;
+    const double C3=-1.651;
+    const double miu = 0.585;
+    const double qr = q*sqrt(Rgsquare(L,b));
+    const double qr_miu = pow(qr, -1.0/miu);
+    const double w = w_WR(qr);
+    const double t10 = Sdebye(qr*qr)*(1.0 - w);
+    const double t11 = ((C3*qr_miu + C2)*qr_miu + C1)*qr_miu;
+
+    return t10 + w*t11;
+}
+    
+#pragma acc routine seq
+// Modified by Yun on Oct. 15,
+static double
+Sexv_new(double q, double L, double b)
+{
+    const double qr = q*sqrt(Rgsquare(L,b));
+    const double qr2 = qr*qr;
+    const double C = (L/b > 10.0) ? 3.06*pow(L/b, -0.44) : 1.0;
+    const double t9 = C*b/L * (4.0 - exp(-qr2) * (11.0 + 7.0/qr2) + 7.0/qr2)/15.0;
+
+    const double Sexv_orig = Sexv(q, L, b);
+
+    // calculating the derivative to decide on the correction (cutoff) term?
+    // Note: this is modified from WRs original code
+    const double del=1.05;
+    const double qdel = (Sexv(q*del,L,b) - Sexv_orig)/(q*(del - 1.0));
+
+    if (qdel < 0) {
+        //printf("branch A1-%d q=%g L=%g b=%g\n", C==1.0, q, L, b);
+        return t9 + Sexv_orig;
+    } else {
+        //printf("branch A2-%d q=%g L=%g b=%g\n", C==1.0, q, L, b);
+        const double w = w_WR(qr);
+        const double t10 = Sdebye(qr*qr)*(1.0 - w);
+        return t9 + t10;
+    }
+}
+
+    
+#pragma acc routine seq
+static double
+Sk_WR(double q, double L, double b)
+{
+    const double Rg_short = sqrt(Rgsquareshort(L, b));
+    double q0short = fmax(1.9/Rg_short, 3.0);
+    double ans;
+
+
+    if( L > 4*b ) { // L > 4*b : Longer Chains
+        if (q*b <= 3.1) {
+            ans = Sexv_new(q, L, b);
+        } else { //q(i)*b > 3.1
+            ans = a_long(q, L, b /*, p1, p2, q0*/);
+        }
+    } else { // L <= 4*b : Shorter Chains
+        if (q*b <= q0short) { // q*b <= fmax(1.9/Rg_short, 3)
+            //printf("branch C-%d q=%g L=%g b=%g\n", square(q*Rg_short)<DEBYE_CUTOFF, q, L, b);
+            // Note that q0short is usually 3, but it will be greater than 3
+            // small enough b, depending on the L/b ratio:
+            //     L/b == 1 => b < 2.37
+            //     L/b == 2 => b < 1.36
+            //     L/b == 3 => b < 1.00
+            //     L/b == 4 => b < 0.816
+            // 2017-10-01 pkienzle: moved low q approximation into Sdebye()
+            ans = Sdebye(square(q*Rg_short));
+        } else {  // q*b > max(1.9/Rg_short, 3)
+            //printf("branch D q=%g L=%g b=%g\n", q, L, b);
+            ans = a_short(q, L, b /*, p1short, p2short*/, q0short);
+        }
+    }
+
+    return ans;
+}
+
+
+#line 1 ".././models/flexible_cylinder.c"
+
+static double
+form_volume(double length, double kuhn_length, double radius)
+{
+    return 1.0;
+}
+
+static double
+Iq(double q,
+   double length,
+   double kuhn_length,
+   double radius,
+   double sld,
+   double solvent_sld)
+{
+    const double contrast = sld - solvent_sld;
+    const double cross_section = sas_2J1x_x(q*radius);
+    const double volume = M_PI*radius*radius*length;
+    const double flex = Sk_WR(q, length, kuhn_length);
+    return 1.0e-4 * volume * square(contrast*cross_section) * flex;
+}
+
+

--- a/mcstas-comps/share/sas_flexible_cylinder_elliptical.c
+++ b/mcstas-comps/share/sas_flexible_cylinder_elliptical.c
@@ -1,0 +1,1222 @@
+#define HAS_Iq
+#define FORM_VOL
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/polevl.c"
+
+/*							polevl.c
+ *							p1evl.c
+ *
+ *	Evaluate polynomial
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * int N;
+ * double x, y, coef[N+1], polevl[];
+ *
+ * y = polevl( x, coef, N );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Evaluates polynomial of degree N:
+ *
+ *                     2          N
+ * y  =  C  + C x + C x  +...+ C x
+ *        0    1     2          N
+ *
+ * Coefficients are stored in reverse order:
+ *
+ * coef[0] = C  , ..., coef[N] = C  .
+ *            N                   0
+ *
+ * The function p1evl() assumes that C_N = 1.0 and is
+ * omitted from the array.  Its calling arguments are
+ * otherwise the same as polevl().
+ *
+ *
+ * SPEED:
+ *
+ * In the interest of speed, there are no checks for out
+ * of bounds arithmetic.  This routine is used by most of
+ * the functions in the library.  Depending on available
+ * equipment features, the user may wish to rewrite the
+ * program in microcode or assembly language.
+ *
+ */
+
+
+/*
+Cephes Math Library Release 2.1:  December, 1988
+Copyright 1984, 1987, 1988 by Stephen L. Moshier
+Direct inquiries to 30 Frost Street, Cambridge, MA 02140
+*/
+#pragma acc routine seq
+static
+double polevl( double x, pconstant double *coef, int N )
+{
+
+    int i = 0;
+    double ans = coef[i];
+
+    while (i < N) {
+        i++;
+        ans = ans * x + coef[i];
+    }
+
+    return ans;
+}
+
+/*							p1evl()	*/
+/*                                          N
+ * Evaluate polynomial when coefficient of x  is 1.0.
+ * Otherwise same as polevl.
+ */
+#pragma acc routine seq
+static
+double p1evl( double x, pconstant double *coef, int N )
+{
+    int i=0;
+    double ans = x+coef[i];
+
+    while (i < N-1) {
+        i++;
+        ans = ans*x + coef[i];
+    }
+
+    return ans;
+}
+
+
+#line 1 ".././models/lib/sas_J1.c"
+
+/*							j1.c
+ *
+ *	Bessel function of order one
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * double x, y, j1();
+ *
+ * y = j1( x );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Returns Bessel function of order one of the argument.
+ *
+ * The domain is divided into the intervals [0, 8] and
+ * (8, infinity). In the first interval a 24 term Chebyshev
+ * expansion is used. In the second, the asymptotic
+ * trigonometric representation is employed using two
+ * rational functions of degree 5/5.
+ *
+ *
+ *
+ * ACCURACY:
+ *
+ *                      Absolute error:
+ * arithmetic   domain      # trials      peak         rms
+ *    DEC       0, 30       10000       4.0e-17     1.1e-17
+ *    IEEE      0, 30       30000       2.6e-16     1.1e-16
+ *
+ *
+ */
+
+/*
+Cephes Math Library Release 2.8:  June, 2000
+Copyright 1984, 1987, 1989, 2000 by Stephen L. Moshier
+*/
+
+#if FLOAT_SIZE>4
+//Cephes double pression function
+
+constant double RPJ1[8] = {
+    -8.99971225705559398224E8,
+    4.52228297998194034323E11,
+    -7.27494245221818276015E13,
+    3.68295732863852883286E15,
+    0.0,
+    0.0,
+    0.0,
+    0.0 };
+
+constant double RQJ1[8] = {
+    6.20836478118054335476E2,
+    2.56987256757748830383E5,
+    8.35146791431949253037E7,
+    2.21511595479792499675E10,
+    4.74914122079991414898E12,
+    7.84369607876235854894E14,
+    8.95222336184627338078E16,
+    5.32278620332680085395E18
+    };
+
+constant double PPJ1[8] = {
+    7.62125616208173112003E-4,
+    7.31397056940917570436E-2,
+    1.12719608129684925192E0,
+    5.11207951146807644818E0,
+    8.42404590141772420927E0,
+    5.21451598682361504063E0,
+    1.00000000000000000254E0,
+    0.0} ;
+
+
+constant double PQJ1[8] = {
+    5.71323128072548699714E-4,
+    6.88455908754495404082E-2,
+    1.10514232634061696926E0,
+    5.07386386128601488557E0,
+    8.39985554327604159757E0,
+    5.20982848682361821619E0,
+    9.99999999999999997461E-1,
+    0.0 };
+
+constant double QPJ1[8] = {
+    5.10862594750176621635E-2,
+    4.98213872951233449420E0,
+    7.58238284132545283818E1,
+    3.66779609360150777800E2,
+    7.10856304998926107277E2,
+    5.97489612400613639965E2,
+    2.11688757100572135698E2,
+    2.52070205858023719784E1 };
+
+constant double QQJ1[8] = {
+    7.42373277035675149943E1,
+    1.05644886038262816351E3,
+    4.98641058337653607651E3,
+    9.56231892404756170795E3,
+    7.99704160447350683650E3,
+    2.82619278517639096600E3,
+    3.36093607810698293419E2,
+    0.0 };
+
+#pragma acc declare copyin( RPJ1[0:8], RQJ1[0:8], PPJ1[0:8], PQJ1[0:8], QPJ1[0:8], QQJ1[0:8])
+
+#pragma acc routine seq
+static
+double cephes_j1(double x)
+{
+
+    double w, z, p, q, abs_x, sign_x;
+
+    const double Z1 = 1.46819706421238932572E1;
+    const double Z2 = 4.92184563216946036703E1;
+
+    // 2017-05-18 PAK - mathematica and mpmath use J1(-x) = -J1(x)
+    if (x < 0) {
+        abs_x = -x;
+        sign_x = -1.0;
+    } else {
+        abs_x = x;
+        sign_x = 1.0;
+    }
+
+    if( abs_x <= 5.0 ) {
+        z = abs_x * abs_x;
+        w = polevl( z, RPJ1, 3 ) / p1evl( z, RQJ1, 8 );
+        w = w * abs_x * (z - Z1) * (z - Z2);
+        return( sign_x * w );
+    }
+
+    w = 5.0/abs_x;
+    z = w * w;
+    p = polevl( z, PPJ1, 6)/polevl( z, PQJ1, 6 );
+    q = polevl( z, QPJ1, 7)/p1evl( z, QQJ1, 7 );
+
+    // 2017-05-19 PAK improve accuracy using trig identies
+    // original:
+    //    const double THPIO4 =  2.35619449019234492885;
+    //    const double SQ2OPI = 0.79788456080286535588;
+    //    double sin_xn, cos_xn;
+    //    SINCOS(abs_x - THPIO4, sin_xn, cos_xn);
+    //    p = p * cos_xn - w * q * sin_xn;
+    //    return( sign_x * p * SQ2OPI / sqrt(abs_x) );
+    // expanding p*cos(a - 3 pi/4) - wq sin(a - 3 pi/4)
+    //    [ p(sin(a) - cos(a)) + wq(sin(a) + cos(a)) / sqrt(2)
+    // note that sqrt(1/2) * sqrt(2/pi) = sqrt(1/pi)
+    const double SQRT1_PI = 0.56418958354775628;
+    double sin_x, cos_x;
+    SINCOS(abs_x, sin_x, cos_x);
+    p = p*(sin_x - cos_x) + w*q*(sin_x + cos_x);
+    return( sign_x * p * SQRT1_PI / sqrt(abs_x) );
+}
+
+#else
+//Single precission version of cephes
+
+constant float JPJ1[8] = {
+    -4.878788132172128E-009,
+    6.009061827883699E-007,
+    -4.541343896997497E-005,
+    1.937383947804541E-003,
+    -3.405537384615824E-002,
+    0.0,
+    0.0,
+    0.0
+    };
+
+constant float MO1J1[8] = {
+    6.913942741265801E-002,
+    -2.284801500053359E-001,
+    3.138238455499697E-001,
+    -2.102302420403875E-001,
+    5.435364690523026E-003,
+    1.493389585089498E-001,
+    4.976029650847191E-006,
+    7.978845453073848E-001
+    };
+
+constant float PH1J1[8] = {
+    -4.497014141919556E+001,
+    5.073465654089319E+001,
+    -2.485774108720340E+001,
+    7.222973196770240E+000,
+    -1.544842782180211E+000,
+    3.503787691653334E-001,
+    -1.637986776941202E-001,
+    3.749989509080821E-001
+    };
+
+#pragma acc declare copyin( JPJ1[0:8], MO1J1[0:8], PH1J1[0:8])
+
+#pragma acc routine seq
+static
+float cephes_j1f(float xx)
+{
+
+    float x, w, z, p, q, xn;
+
+    const float Z1 = 1.46819706421238932572E1;
+
+
+    // 2017-05-18 PAK - mathematica and mpmath use J1(-x) = -J1(x)
+    x = xx;
+    if( x < 0 )
+        x = -xx;
+
+    if( x <= 2.0 ) {
+        z = x * x;
+        p = (z-Z1) * x * polevl( z, JPJ1, 4 );
+        return( xx < 0. ? -p : p );
+    }
+
+    q = 1.0/x;
+    w = sqrt(q);
+
+    p = w * polevl( q, MO1J1, 7);
+    w = q*q;
+    // 2017-05-19 PAK improve accuracy using trig identies
+    // original:
+    //    const float THPIO4F =  2.35619449019234492885;    /* 3*pi/4 */
+    //    xn = q * polevl( w, PH1J1, 7) - THPIO4F;
+    //    p = p * cos(xn + x);
+    //    return( xx < 0. ? -p : p );
+    // expanding cos(a + b - 3 pi/4) is
+    //    [sin(a)sin(b) + sin(a)cos(b) + cos(a)sin(b)-cos(a)cos(b)] / sqrt(2)
+    xn = q * polevl( w, PH1J1, 7);
+    float cos_xn, sin_xn;
+    float cos_x, sin_x;
+    SINCOS(xn, sin_xn, cos_xn);  // about xn and 1
+    SINCOS(x, sin_x, cos_x);
+    p *= M_SQRT1_2*(sin_xn*(sin_x+cos_x) + cos_xn*(sin_x-cos_x));
+
+    return( xx < 0. ? -p : p );
+}
+#endif
+
+#if FLOAT_SIZE>4
+#define sas_J1 cephes_j1
+#else
+#define sas_J1 cephes_j1f
+#endif
+
+//Finally J1c function that equals 2*J1(x)/x
+    
+#pragma acc routine seq
+static
+double sas_2J1x_x(double x)
+{
+    return (x != 0.0 ) ? 2.0*sas_J1(x)/x : 1.0;
+}
+
+
+#line 1 ".././models/lib/gauss76.c"
+
+// Created by Andrew Jackson on 4/23/07
+
+ #ifdef GAUSS_N
+ # undef GAUSS_N
+ # undef GAUSS_Z
+ # undef GAUSS_W
+ #endif
+ #define GAUSS_N 76
+ #define GAUSS_Z Gauss76Z
+ #define GAUSS_W Gauss76Wt
+
+// Gaussians
+constant double Gauss76Wt[76] = {
+	.00126779163408536,		//0
+	.00294910295364247,
+	.00462793522803742,
+	.00629918049732845,
+	.00795984747723973,
+	.00960710541471375,
+	.0112381685696677,
+	.0128502838475101,
+	.0144407317482767,
+	.0160068299122486,
+	.0175459372914742,		//10
+	.0190554584671906,
+	.020532847967908,
+	.0219756145344162,
+	.0233813253070112,
+	.0247476099206597,
+	.026072164497986,
+	.0273527555318275,
+	.028587223650054,
+	.029773487255905,
+	.0309095460374916,		//20
+	.0319934843404216,
+	.0330234743977917,
+	.0339977794120564,
+	.0349147564835508,
+	.0357728593807139,
+	.0365706411473296,
+	.0373067565423816,
+	.0379799643084053,
+	.0385891292645067,
+	.0391332242205184,		//30
+	.0396113317090621,
+	.0400226455325968,
+	.040366472122844,
+	.0406422317102947,
+	.0408494593018285,
+	.040987805464794,
+	.0410570369162294,
+	.0410570369162294,
+	.040987805464794,
+	.0408494593018285,		//40
+	.0406422317102947,
+	.040366472122844,
+	.0400226455325968,
+	.0396113317090621,
+	.0391332242205184,
+	.0385891292645067,
+	.0379799643084053,
+	.0373067565423816,
+	.0365706411473296,
+	.0357728593807139,		//50
+	.0349147564835508,
+	.0339977794120564,
+	.0330234743977917,
+	.0319934843404216,
+	.0309095460374916,
+	.029773487255905,
+	.028587223650054,
+	.0273527555318275,
+	.026072164497986,
+	.0247476099206597,		//60
+	.0233813253070112,
+	.0219756145344162,
+	.020532847967908,
+	.0190554584671906,
+	.0175459372914742,
+	.0160068299122486,
+	.0144407317482767,
+	.0128502838475101,
+	.0112381685696677,
+	.00960710541471375,		//70
+	.00795984747723973,
+	.00629918049732845,
+	.00462793522803742,
+	.00294910295364247,
+	.00126779163408536		//75 (indexed from 0)
+};
+
+constant double Gauss76Z[76] = {
+	-.999505948362153,		//0
+	-.997397786355355,
+	-.993608772723527,
+	-.988144453359837,
+	-.981013938975656,
+	-.972229228520377,
+	-.961805126758768,
+	-.949759207710896,
+	-.936111781934811,
+	-.92088586125215,
+	-.904107119545567,		//10
+	-.885803849292083,
+	-.866006913771982,
+	-.844749694983342,
+	-.822068037328975,
+	-.7980001871612,
+	-.77258672828181,
+	-.74587051350361,
+	-.717896592387704,
+	-.688712135277641,
+	-.658366353758143,		//20
+	-.626910417672267,
+	-.594397368836793,
+	-.560882031601237,
+	-.526420920401243,
+	-.491072144462194,
+	-.454895309813726,
+	-.417951418780327,
+	-.380302767117504,
+	-.342012838966962,
+	-.303146199807908,		//30
+	-.263768387584994,
+	-.223945802196474,
+	-.183745593528914,
+	-.143235548227268,
+	-.102483975391227,
+	-.0615595913906112,
+	-.0205314039939986,
+	.0205314039939986,
+	.0615595913906112,
+	.102483975391227,			//40
+	.143235548227268,
+	.183745593528914,
+	.223945802196474,
+	.263768387584994,
+	.303146199807908,
+	.342012838966962,
+	.380302767117504,
+	.417951418780327,
+	.454895309813726,
+	.491072144462194,		//50
+	.526420920401243,
+	.560882031601237,
+	.594397368836793,
+	.626910417672267,
+	.658366353758143,
+	.688712135277641,
+	.717896592387704,
+	.74587051350361,
+	.77258672828181,
+	.7980001871612,	//60
+	.822068037328975,
+	.844749694983342,
+	.866006913771982,
+	.885803849292083,
+	.904107119545567,
+	.92088586125215,
+	.936111781934811,
+	.949759207710896,
+	.961805126758768,
+	.972229228520377,		//70
+	.981013938975656,
+	.988144453359837,
+	.993608772723527,
+	.997397786355355,
+	.999505948362153		//75
+};
+
+
+#pragma acc declare copyin(Gauss76Wt[0:76], Gauss76Z[0:76])
+
+#line 1 ".././models/lib/wrc_cyl.c"
+
+/*
+    Functions for WRC implementation of flexible cylinders. See
+    W R Chen, P D Butler and L J Magid,
+    Incorporating Intermicellar Interactions in the Fitting of
+    SANS Data from Cationic Wormlike Micelles.
+    Langmuir, 22(15) 2006 6539-6548
+*/
+    
+#pragma acc routine seq
+static double
+Rgsquare(double L, double b)
+{
+    const double x = L/b;
+    // Use Horner's method to evaluate Pedersen eq 15:
+    //     alpha^2 = [1.0 + (x/3.12)^2 + (x/8.67)^3] ^ (0.176/3)
+    const double alphasq =
+        pow(1.0 + x*x*(1.027284681130835e-01 + 1.534414548417740e-03*x),
+            5.866666666666667e-02);
+    return alphasq*L*b/6.0;
+}
+    
+#pragma acc routine seq
+static double
+Rgsquareshort(double L, double b)
+{
+    const double r = b/L;  // = 1/n_b in Pedersen ref.
+    return Rgsquare(L, b) * (1.0 + r*(-1.5 + r*(1.5 + r*0.75*expm1(-2.0/r))));
+}
+    
+#pragma acc routine seq
+static double
+w_WR(double x)
+{
+    // Pedersen eq. 16:
+    //    w = [1 + tanh((x-C4)/C5)]/2
+    const double C4 = 1.523;
+    const double C5 = 0.1477;
+    return 0.5 + 0.5*tanh((x - C4)/C5);
+}
+    
+#pragma acc routine seq
+static double
+Sdebye(double qsq)
+{
+#if FLOAT_SIZE>4
+#  define DEBYE_CUTOFF 0.25  // 1e-15 error
+#else
+#  define DEBYE_CUTOFF 1.0  // 4e-7 error
+#endif
+
+    if (qsq < DEBYE_CUTOFF) {
+        const double x = qsq;
+        // mathematica: PadeApproximant[2*Exp[-x^2] + x^2-1)/x^4, {x, 0, 8}]
+        const double A1=1./15., A2=1./60, A3=0., A4=1./75600.;
+        const double B1=2./5., B2=1./15., B3=1./180., B4=1./5040.;
+        return ((((A4*x + A3)*x + A2)*x + A1)*x + 1.)
+             / ((((B4*x + B3)*x + B2)*x + B1)*x + 1.);
+    } else {
+        return 2.*(expm1(-qsq) + qsq)/(qsq*qsq);
+    }
+}
+    
+#pragma acc routine seq
+static double
+a_long(double q, double L, double b/*, double p1, double p2, double q0*/)
+{
+    const double p1 = 4.12;
+    const double p2 = 4.42;
+    const double q0 = 3.1;
+
+    // Constants C1, ..., C5 derived from least squares fit (Pedersen, eq 13,16)
+    const double C1 = 1.22;
+    const double C2 = 0.4288;
+    const double C3 = -1.651;
+    const double C4 = 1.523;
+    const double C5 = 0.1477;
+    const double miu = 0.585;
+
+    const double C = (L/b>10.0 ? 3.06*pow(L/b, -0.44) : 1.0);
+    //printf("branch B-%d q=%g L=%g b=%g\n", C==1.0, q, L, b);
+    const double r2 = Rgsquare(L,b);
+    const double r = sqrt(r2);
+    const double qr_b = q0*r/b;
+    const double qr_b_sq = qr_b*qr_b;
+    const double qr_b_4 = qr_b_sq*qr_b_sq;
+    const double qr_b_miu = pow(qr_b, -1.0/miu);
+    const double em1_qr_b_sq = expm1(-qr_b_sq);
+    const double sech2 = 1.0/square(cosh((qr_b-C4)/C5));
+    const double w = w_WR(qr_b);
+
+    const double t1 = pow(q0, 1.0 + p1 + p2)/(b*(p1-p2));
+    const double t2 = C/(15.0*L) * (
+        + 14.0*b*b*em1_qr_b_sq/(q0*qr_b_sq)
+        + 2.0*q0*r2*exp(-qr_b_sq)*(11.0 + 7.0/qr_b_sq));
+    const double t11 = ((C3*qr_b_miu + C2)*qr_b_miu + C1)*qr_b_miu;
+    const double t3 = r*sech2/(2.*C5)*t11;
+    const double t4 = r*(em1_qr_b_sq + qr_b_sq)*sech2 / (C5*qr_b_4);
+    const double t5 = -4.0*r*qr_b*em1_qr_b_sq/qr_b_4 * (1.0 - w);
+    const double t10 = 2.0*(em1_qr_b_sq + qr_b_sq)/qr_b_4 * (1.0 - w); //=Sdebye*(1-w)
+    const double t6 = 4.0*b/q0 * t10;
+    const double t7 = r*((-3.0*C3*qr_b_miu -2.0*C2)*qr_b_miu -1.0*C1)*qr_b_miu/(miu*qr_b);
+    const double t9 = C*b/L * (4.0 - exp(-qr_b_sq) * (11.0 + 7.0/qr_b_sq) + 7.0/qr_b_sq)/15.0;
+    const double t12 = b*b*M_PI/(L*q0*q0) + t2 + t3 - t4 + t5 - t6 + t7*w;
+    const double t13 = -b*M_PI/(L*q0) + t9 + t10 + t11*w;
+
+    const double a1 = pow(q0,p1)*t13 - t1*pow(q0,-p2)*(t12 + b*p1/q0*t13);
+    const double a2 = t1*pow(q0,-p1)*(t12 + b*p1/q0*t13);
+
+    const double ans = a1*pow(q*b, -p1) + a2*pow(q*b, -p2) + M_PI/(q*L);
+    return ans;
+}
+    
+#pragma acc routine seq
+static double
+_short(double r2, double exp_qr_b, double L, double b, double p1short,
+        double p2short, double q0)
+{
+    const double qr2 = q0*q0 * r2;
+    const double b3 = b*b*b;
+    const double q0p = pow(q0, -4.0 + p1short);
+
+    double yy = 1.0/(L*r2*r2) * b/exp_qr_b*q0p
+        * (8.0*b3*L
+           - 8.0*b3*exp_qr_b*L
+           + 2.0*b3*exp_qr_b*L*p2short
+           - 2.0*b*exp_qr_b*L*p2short*qr2
+           + 4.0*b*exp_qr_b*L*qr2
+           - 2.0*b3*L*p2short
+           + 4.0*b*L*qr2
+           - M_PI*exp_qr_b*qr2*q0*r2
+           + M_PI*exp_qr_b*p2short*qr2*q0*r2);
+
+    return yy;
+}
+    
+#pragma acc routine seq
+static double
+a_short(double qp, double L, double b
+        /*double p1short, double p2short*/, double q0)
+{
+    const double p1short = 5.36;
+    const double p2short = 5.62;
+
+    const double r2 = Rgsquareshort(L,b);
+    const double exp_qr_b = exp(r2*square(q0/b));
+    const double pdiff = p1short - p2short;
+    const double a1 = _short(r2,exp_qr_b,L,b,p1short,p2short,q0)/pdiff;
+    const double a2= -_short(r2,exp_qr_b,L,b,p2short,p1short,q0)/pdiff;
+    const double ans = a1*pow(qp*b, -p1short) + a2*pow(qp*b, -p2short) + M_PI/(qp*L);
+    return ans;
+}
+    
+#pragma acc routine seq
+static double
+Sexv(double q, double L, double b)
+{
+    // Pedersen eq 13, corrected by Chen eq A.5, swapping w and 1-w
+    const double C1=1.22;
+    const double C2=0.4288;
+    const double C3=-1.651;
+    const double miu = 0.585;
+    const double qr = q*sqrt(Rgsquare(L,b));
+    const double qr_miu = pow(qr, -1.0/miu);
+    const double w = w_WR(qr);
+    const double t10 = Sdebye(qr*qr)*(1.0 - w);
+    const double t11 = ((C3*qr_miu + C2)*qr_miu + C1)*qr_miu;
+
+    return t10 + w*t11;
+}
+    
+#pragma acc routine seq
+// Modified by Yun on Oct. 15,
+static double
+Sexv_new(double q, double L, double b)
+{
+    const double qr = q*sqrt(Rgsquare(L,b));
+    const double qr2 = qr*qr;
+    const double C = (L/b > 10.0) ? 3.06*pow(L/b, -0.44) : 1.0;
+    const double t9 = C*b/L * (4.0 - exp(-qr2) * (11.0 + 7.0/qr2) + 7.0/qr2)/15.0;
+
+    const double Sexv_orig = Sexv(q, L, b);
+
+    // calculating the derivative to decide on the correction (cutoff) term?
+    // Note: this is modified from WRs original code
+    const double del=1.05;
+    const double qdel = (Sexv(q*del,L,b) - Sexv_orig)/(q*(del - 1.0));
+
+    if (qdel < 0) {
+        //printf("branch A1-%d q=%g L=%g b=%g\n", C==1.0, q, L, b);
+        return t9 + Sexv_orig;
+    } else {
+        //printf("branch A2-%d q=%g L=%g b=%g\n", C==1.0, q, L, b);
+        const double w = w_WR(qr);
+        const double t10 = Sdebye(qr*qr)*(1.0 - w);
+        return t9 + t10;
+    }
+}
+
+    
+#pragma acc routine seq
+static double
+Sk_WR(double q, double L, double b)
+{
+    const double Rg_short = sqrt(Rgsquareshort(L, b));
+    double q0short = fmax(1.9/Rg_short, 3.0);
+    double ans;
+
+
+    if( L > 4*b ) { // L > 4*b : Longer Chains
+        if (q*b <= 3.1) {
+            ans = Sexv_new(q, L, b);
+        } else { //q(i)*b > 3.1
+            ans = a_long(q, L, b /*, p1, p2, q0*/);
+        }
+    } else { // L <= 4*b : Shorter Chains
+        if (q*b <= q0short) { // q*b <= fmax(1.9/Rg_short, 3)
+            //printf("branch C-%d q=%g L=%g b=%g\n", square(q*Rg_short)<DEBYE_CUTOFF, q, L, b);
+            // Note that q0short is usually 3, but it will be greater than 3
+            // small enough b, depending on the L/b ratio:
+            //     L/b == 1 => b < 2.37
+            //     L/b == 2 => b < 1.36
+            //     L/b == 3 => b < 1.00
+            //     L/b == 4 => b < 0.816
+            // 2017-10-01 pkienzle: moved low q approximation into Sdebye()
+            ans = Sdebye(square(q*Rg_short));
+        } else {  // q*b > max(1.9/Rg_short, 3)
+            //printf("branch D q=%g L=%g b=%g\n", q, L, b);
+            ans = a_short(q, L, b /*, p1short, p2short*/, q0short);
+        }
+    }
+
+    return ans;
+}
+
+
+#line 1 ".././models/flexible_cylinder_elliptical.c"
+
+double form_volume(double length, double kuhn_length, double radius);
+double Iq(double q, double length, double kuhn_length, double radius,
+          double axis_ratio, double sld, double solvent_sld);
+double flexible_cylinder_ex_kernel(double q, double length, double kuhn_length,
+                                double radius, double axis_ratio, double sld,
+                                double solvent_sld);
+double elliptical_crosssection(double q, double a, double b);
+
+double form_volume(double length, double kuhn_length, double radius)
+{
+    return 1.0;
+}
+
+double
+elliptical_crosssection(double q, double a, double b)
+{
+    double sum=0.0;
+
+    for(int i=0;i<GAUSS_N;i++) {
+        const double zi = ( GAUSS_Z[i] + 1.0 )*M_PI_4;
+        double sn, cn;
+        SINCOS(zi, sn, cn);
+        const double arg = q*sqrt(a*a*sn*sn + b*b*cn*cn);
+        const double yyy = sas_2J1x_x(arg);
+        sum += GAUSS_W[i] * yyy * yyy;
+    }
+    sum *= 0.5;
+    return(sum);
+
+}
+
+double flexible_cylinder_ex_kernel(double q,
+          double length,
+          double kuhn_length,
+          double radius,
+          double axis_ratio,
+          double sld,
+          double solvent_sld)
+{
+
+    double flex,crossSect, cont;
+
+    cont = sld - solvent_sld;
+    crossSect = elliptical_crosssection(q,radius,(radius*axis_ratio));
+
+    flex = Sk_WR(q,length,kuhn_length);
+    flex *= crossSect;
+    flex *= M_PI*radius*radius*axis_ratio*axis_ratio*length;
+    flex *= cont*cont;
+    flex *= 1.0e-4;
+
+    return flex;
+}
+
+double Iq(double q,
+          double length,
+          double kuhn_length,
+          double radius,
+          double axis_ratio,
+          double sld,
+          double solvent_sld)
+{
+
+    double result = flexible_cylinder_ex_kernel(q,
+                    length,
+                    kuhn_length,
+                    radius,
+                    axis_ratio,
+                    sld,
+                    solvent_sld);
+
+    return result;
+}
+
+

--- a/mcstas-comps/share/sas_fractal.c
+++ b/mcstas-comps/share/sas_fractal.c
@@ -1,0 +1,670 @@
+#define HAS_Iq
+#define FORM_VOL
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/sas_3j1x_x.c"
+
+/**
+* Spherical Bessel function 3*j1(x)/x
+*
+* Used for low q to avoid cancellation error.
+* Note that the values differ from sasview ~ 5e-12 rather than 5e-14, but
+* in this case it is likely cancellation errors in the original expression
+* using double precision that are the source.
+*/
+double sas_3j1x_x(double q);
+
+// The choice of the number of terms in the series and the cutoff value for
+// switching between series and direct calculation depends on the numeric
+// precision.
+//
+// Point where direct calculation reaches machine precision:
+//
+//   single machine precision eps 3e-8 at qr=1.1 **
+//   double machine precision eps 4e-16 at qr=1.1
+//
+// Point where Taylor series reaches machine precision (eps), where taylor
+// series matches direct calculation (cross) and the error at that point:
+//
+//   prec   n eps  cross  error
+//   single 3 0.28  0.4   6.2e-7
+//   single 4 0.68  0.7   2.3e-7
+//   single 5 1.18  1.2   7.5e-8
+//   double 3 0.01  0.03  2.3e-13
+//   double 4 0.06  0.1   3.1e-14
+//   double 5 0.16  0.2   5.0e-15
+//
+// ** Note: relative error on single precision starts increase on the direct
+// method at qr=1.1, rising from 3e-8 to 5e-5 by qr=1e3.  This should be
+// safe for the sans range, with objects of 100 nm supported to a q of 0.1
+// while maintaining 5 digits of precision.  For usans/sesans, the objects
+// are larger but the q is smaller, so again it should be fine.
+//
+// See explore/sph_j1c.py for code to explore these ranges.
+
+// Use 4th order series
+#if FLOAT_SIZE>4
+#define SPH_J1C_CUTOFF 0.1
+#else
+#define SPH_J1C_CUTOFF 0.7
+#endif
+#pragma acc routine seq
+double sas_3j1x_x(double q)
+{
+    // 2017-05-18 PAK - support negative q
+    if (fabs(q) < SPH_J1C_CUTOFF) {
+        const double q2 = q*q;
+        return (1.0 + q2*(-3./30. + q2*(3./840. + q2*(-3./45360.))));// + q2*(3./3991680.)))));
+    } else {
+        double sin_q, cos_q;
+        SINCOS(q, sin_q, cos_q);
+        return 3.0*(sin_q/q - cos_q)/(q*q);
+    }
+}
+
+
+#line 1 ".././models/lib/sas_gamma.c"
+
+/*
+The wrapper for gamma function from OpenCL and standard libraries
+The OpenCL gamma function fails miserably on values lower than 1.0
+while works fine on larger values.
+We use gamma definition Gamma(t + 1) = t * Gamma(t) to compute
+to function for values lower than 1.0. Namely Gamma(t) = 1/t * Gamma(t + 1)
+For t < 0, we use Gamma(t) = pi / ( Gamma(1 - t) * sin(pi * t) )
+*/
+
+#if defined(NEED_TGAMMA)
+#pragma acc routine seq
+static double cephes_stirf(double x)
+{
+	const double MAXSTIR=143.01608;
+	const double SQTPI=2.50662827463100050242E0;
+	double y, w, v;
+
+	w = 1.0 / x;
+
+	w = ((((
+		7.87311395793093628397E-4*w
+		- 2.29549961613378126380E-4)*w
+		- 2.68132617805781232825E-3)*w
+		+ 3.47222221605458667310E-3)*w
+		+ 8.33333333333482257126E-2)*w
+		+ 1.0;
+	y = exp(x);
+	if (x > MAXSTIR)
+	{ /* Avoid overflow in pow() */
+		v = pow(x, 0.5 * x - 0.25);
+		y = v * (v / y);
+	}
+	else
+	{
+		y = pow(x, x - 0.5) / y;
+	}
+	y = SQTPI * y * w;
+	return(y);
+}
+
+#pragma acc routine seq
+static double tgamma(double x) {
+	double p, q, z;
+	int sgngam;
+	int i;
+
+	sgngam = 1;
+	if (isnan(x))
+		return(x);
+	q = fabs(x);
+
+	if (q > 33.0)
+	{
+		if (x < 0.0)
+		{
+			p = floor(q);
+			if (p == q)
+			{
+				return (NAN);
+			}
+			i = p;
+			if ((i & 1) == 0)
+				sgngam = -1;
+			z = q - p;
+			if (z > 0.5)
+			{
+				p += 1.0;
+				z = q - p;
+			}
+			z = q * sin(M_PI * z);
+			if (z == 0.0)
+			{
+				return(NAN);
+			}
+			z = fabs(z);
+			z = M_PI / (z * cephes_stirf(q));
+		}
+		else
+		{
+			z = cephes_stirf(x);
+		}
+		return(sgngam * z);
+	}
+
+	z = 1.0;
+	while (x >= 3.0)
+	{
+		x -= 1.0;
+		z *= x;
+	}
+
+	while (x < 0.0)
+	{
+		if (x > -1.E-9)
+			goto small;
+		z /= x;
+		x += 1.0;
+	}
+
+	while (x < 2.0)
+	{
+		if (x < 1.e-9)
+			goto small;
+		z /= x;
+		x += 1.0;
+	}
+
+	if (x == 2.0)
+		return(z);
+
+	x -= 2.0;
+	p = (((((
+		+1.60119522476751861407E-4*x
+		+ 1.19135147006586384913E-3)*x
+		+ 1.04213797561761569935E-2)*x
+		+ 4.76367800457137231464E-2)*x
+		+ 2.07448227648435975150E-1)*x
+		+ 4.94214826801497100753E-1)*x
+		+ 9.99999999999999996796E-1;
+	q = ((((((
+		-2.31581873324120129819E-5*x
+		+ 5.39605580493303397842E-4)*x
+		- 4.45641913851797240494E-3)*x
+		+ 1.18139785222060435552E-2)*x
+		+ 3.58236398605498653373E-2)*x
+		- 2.34591795718243348568E-1)*x
+		+ 7.14304917030273074085E-2)*x
+		+ 1.00000000000000000320E0;
+	return(z * p / q);
+
+small:
+	if (x == 0.0)
+	{
+		return (NAN);
+	}
+	else
+		return(z / ((1.0 + 0.5772156649015329 * x) * x));
+}
+#endif // NEED_TGAMMA
+
+#pragma acc routine seq
+inline double sas_gamma(double x)
+{
+    // Note: the builtin tgamma can give slow and unreliable results for x<1.
+    // The following transform extends it to zero and to negative values.
+    // It should return NaN for zero and negative integers but doesn't.
+    // The accuracy is okay but not wonderful for negative numbers, maybe
+    // one or two digits lost in the calculation. If higher accuracy is
+    // needed, you could test the following loop:
+    //    double norm = 1.;
+    //    while (x<1.) { norm*=x; x+=1.; }
+    //    return tgamma(x)/norm;
+    return (x<0. ? M_PI/tgamma(1.-x)/sin(M_PI*x) : tgamma(x+1)/x);
+}
+
+
+#line 1 ".././models/lib/fractal_sq.c"
+
+#pragma acc routine seq
+static double
+fractal_sq(double q, double radius, double fractal_dim, double cor_length)
+{
+    //calculate S(q),  using Teixeira, Eq(15)
+    // mathematica query to check limiting conditions:
+    //    lim x->0 of [ x gamma(x-1) sin(arctan(q c (x-1))) (q r)^(-x) (1 + 1/(q c)^2)^((1-x)/2) ]
+    // Note: gamma(x) may be unreliable for x<0, so the gamma(D-1) is risky.
+    // We instead transform D*gamma(D-1) into gamma(D+1)/(D-1).
+    double term;
+    if (q == 0.) {
+        const double D = fractal_dim;
+        term = pow(cor_length/radius, D)*sas_gamma(D+1.);
+    } else if (fractal_dim == 0.) {
+        term = 1.0;
+    } else if (fractal_dim == 1.) {
+        term = atan(q*cor_length)/(q*radius);
+    } else {
+        // q>0, D>0
+        const double D = fractal_dim;
+        const double Dm1 = fractal_dim - 1.0;
+        // Note: for large Dm1, sin(Dm1*atan(q*cor_length) can go negative
+        const double t1 = sas_gamma(D+1.)/Dm1*sin(Dm1*atan(q*cor_length));
+        const double t2 = pow(q*radius, -D);
+        const double t3 = pow(1.0 + 1.0/square(q*cor_length), -0.5*Dm1);
+        term = t1 * t2 * t3;
+    }
+    return 1.0 + term;
+}
+
+
+#line 1 ".././models/fractal.c"
+
+ static double
+ form_volume(double radius)
+ {
+     return M_4PI_3 * cube(radius);
+ }
+
+static double
+Iq(double q,
+   double volfraction,
+   double radius,
+   double fractal_dim,
+   double cor_length,
+   double sld_block,
+   double sld_solvent)
+{
+    const double sq = fractal_sq(q, radius, fractal_dim, cor_length);
+
+    //calculate P(q) for the spherical subunits
+    const double fq = form_volume(radius) * (sld_block-sld_solvent)
+                      *sas_3j1x_x(q*radius);
+
+    // scale to units cm-1 sr-1 (assuming data on absolute scale)
+    //    convert I(1/A) to (1/cm)  => 1e8 * I(q)
+    //    convert rho^2 in 10^-6 1/A to 1/A  => 1e-12 * I(q)
+    //    combined: 1e-4 * I(q)
+
+    return 1.e-4 * volfraction * sq * fq * fq;
+}
+
+

--- a/mcstas-comps/share/sas_fractal_core_shell.c
+++ b/mcstas-comps/share/sas_fractal_core_shell.c
@@ -1,0 +1,717 @@
+#define HAS_Iq
+#define FORM_VOL
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/sas_3j1x_x.c"
+
+/**
+* Spherical Bessel function 3*j1(x)/x
+*
+* Used for low q to avoid cancellation error.
+* Note that the values differ from sasview ~ 5e-12 rather than 5e-14, but
+* in this case it is likely cancellation errors in the original expression
+* using double precision that are the source.
+*/
+double sas_3j1x_x(double q);
+
+// The choice of the number of terms in the series and the cutoff value for
+// switching between series and direct calculation depends on the numeric
+// precision.
+//
+// Point where direct calculation reaches machine precision:
+//
+//   single machine precision eps 3e-8 at qr=1.1 **
+//   double machine precision eps 4e-16 at qr=1.1
+//
+// Point where Taylor series reaches machine precision (eps), where taylor
+// series matches direct calculation (cross) and the error at that point:
+//
+//   prec   n eps  cross  error
+//   single 3 0.28  0.4   6.2e-7
+//   single 4 0.68  0.7   2.3e-7
+//   single 5 1.18  1.2   7.5e-8
+//   double 3 0.01  0.03  2.3e-13
+//   double 4 0.06  0.1   3.1e-14
+//   double 5 0.16  0.2   5.0e-15
+//
+// ** Note: relative error on single precision starts increase on the direct
+// method at qr=1.1, rising from 3e-8 to 5e-5 by qr=1e3.  This should be
+// safe for the sans range, with objects of 100 nm supported to a q of 0.1
+// while maintaining 5 digits of precision.  For usans/sesans, the objects
+// are larger but the q is smaller, so again it should be fine.
+//
+// See explore/sph_j1c.py for code to explore these ranges.
+
+// Use 4th order series
+#if FLOAT_SIZE>4
+#define SPH_J1C_CUTOFF 0.1
+#else
+#define SPH_J1C_CUTOFF 0.7
+#endif
+#pragma acc routine seq
+double sas_3j1x_x(double q)
+{
+    // 2017-05-18 PAK - support negative q
+    if (fabs(q) < SPH_J1C_CUTOFF) {
+        const double q2 = q*q;
+        return (1.0 + q2*(-3./30. + q2*(3./840. + q2*(-3./45360.))));// + q2*(3./3991680.)))));
+    } else {
+        double sin_q, cos_q;
+        SINCOS(q, sin_q, cos_q);
+        return 3.0*(sin_q/q - cos_q)/(q*q);
+    }
+}
+
+
+#line 1 ".././models/lib/sas_gamma.c"
+
+/*
+The wrapper for gamma function from OpenCL and standard libraries
+The OpenCL gamma function fails miserably on values lower than 1.0
+while works fine on larger values.
+We use gamma definition Gamma(t + 1) = t * Gamma(t) to compute
+to function for values lower than 1.0. Namely Gamma(t) = 1/t * Gamma(t + 1)
+For t < 0, we use Gamma(t) = pi / ( Gamma(1 - t) * sin(pi * t) )
+*/
+
+#if defined(NEED_TGAMMA)
+#pragma acc routine seq
+static double cephes_stirf(double x)
+{
+	const double MAXSTIR=143.01608;
+	const double SQTPI=2.50662827463100050242E0;
+	double y, w, v;
+
+	w = 1.0 / x;
+
+	w = ((((
+		7.87311395793093628397E-4*w
+		- 2.29549961613378126380E-4)*w
+		- 2.68132617805781232825E-3)*w
+		+ 3.47222221605458667310E-3)*w
+		+ 8.33333333333482257126E-2)*w
+		+ 1.0;
+	y = exp(x);
+	if (x > MAXSTIR)
+	{ /* Avoid overflow in pow() */
+		v = pow(x, 0.5 * x - 0.25);
+		y = v * (v / y);
+	}
+	else
+	{
+		y = pow(x, x - 0.5) / y;
+	}
+	y = SQTPI * y * w;
+	return(y);
+}
+
+#pragma acc routine seq
+static double tgamma(double x) {
+	double p, q, z;
+	int sgngam;
+	int i;
+
+	sgngam = 1;
+	if (isnan(x))
+		return(x);
+	q = fabs(x);
+
+	if (q > 33.0)
+	{
+		if (x < 0.0)
+		{
+			p = floor(q);
+			if (p == q)
+			{
+				return (NAN);
+			}
+			i = p;
+			if ((i & 1) == 0)
+				sgngam = -1;
+			z = q - p;
+			if (z > 0.5)
+			{
+				p += 1.0;
+				z = q - p;
+			}
+			z = q * sin(M_PI * z);
+			if (z == 0.0)
+			{
+				return(NAN);
+			}
+			z = fabs(z);
+			z = M_PI / (z * cephes_stirf(q));
+		}
+		else
+		{
+			z = cephes_stirf(x);
+		}
+		return(sgngam * z);
+	}
+
+	z = 1.0;
+	while (x >= 3.0)
+	{
+		x -= 1.0;
+		z *= x;
+	}
+
+	while (x < 0.0)
+	{
+		if (x > -1.E-9)
+			goto small;
+		z /= x;
+		x += 1.0;
+	}
+
+	while (x < 2.0)
+	{
+		if (x < 1.e-9)
+			goto small;
+		z /= x;
+		x += 1.0;
+	}
+
+	if (x == 2.0)
+		return(z);
+
+	x -= 2.0;
+	p = (((((
+		+1.60119522476751861407E-4*x
+		+ 1.19135147006586384913E-3)*x
+		+ 1.04213797561761569935E-2)*x
+		+ 4.76367800457137231464E-2)*x
+		+ 2.07448227648435975150E-1)*x
+		+ 4.94214826801497100753E-1)*x
+		+ 9.99999999999999996796E-1;
+	q = ((((((
+		-2.31581873324120129819E-5*x
+		+ 5.39605580493303397842E-4)*x
+		- 4.45641913851797240494E-3)*x
+		+ 1.18139785222060435552E-2)*x
+		+ 3.58236398605498653373E-2)*x
+		- 2.34591795718243348568E-1)*x
+		+ 7.14304917030273074085E-2)*x
+		+ 1.00000000000000000320E0;
+	return(z * p / q);
+
+small:
+	if (x == 0.0)
+	{
+		return (NAN);
+	}
+	else
+		return(z / ((1.0 + 0.5772156649015329 * x) * x));
+}
+#endif // NEED_TGAMMA
+
+#pragma acc routine seq
+inline double sas_gamma(double x)
+{
+    // Note: the builtin tgamma can give slow and unreliable results for x<1.
+    // The following transform extends it to zero and to negative values.
+    // It should return NaN for zero and negative integers but doesn't.
+    // The accuracy is okay but not wonderful for negative numbers, maybe
+    // one or two digits lost in the calculation. If higher accuracy is
+    // needed, you could test the following loop:
+    //    double norm = 1.;
+    //    while (x<1.) { norm*=x; x+=1.; }
+    //    return tgamma(x)/norm;
+    return (x<0. ? M_PI/tgamma(1.-x)/sin(M_PI*x) : tgamma(x+1)/x);
+}
+
+
+#line 1 ".././models/lib/core_shell.c"
+
+/*******************************************************************
+
+core_shell_kernel
+
+Form factor used in core_shell and fractal_core_shell
+
+********************************************************************/
+#pragma acc routine seq
+static
+double core_shell_fq(double q,
+                         double radius,
+                         double thickness,
+                         double core_sld,
+                         double shell_sld,
+                         double solvent_sld)
+{
+    // Core first, then add in shell
+    const double core_qr = q * radius;
+    const double core_contrast = core_sld - shell_sld;
+    const double core_bes = sas_3j1x_x(core_qr);
+    const double core_volume = M_4PI_3 * cube(radius);
+    double f = core_volume * core_bes * core_contrast;
+
+    // Now the shell
+    const double shell_qr = q * (radius + thickness);
+    const double shell_contrast = shell_sld - solvent_sld;
+    const double shell_bes = sas_3j1x_x(shell_qr);
+    const double shell_volume = M_4PI_3 * cube(radius + thickness);
+    f += shell_volume * shell_bes * shell_contrast;
+    return f;
+}
+
+// Deprecated function: use core_shell_fq instead.
+#pragma acc routine seq
+static
+double core_shell_kernel(double q,
+                         double radius,
+                         double thickness,
+                         double core_sld,
+                         double shell_sld,
+                         double solvent_sld)
+{
+    const double fq = core_shell_fq(q, radius, thickness, core_sld, shell_sld, solvent_sld);
+    return 1.0e-4 * fq*fq;
+}
+
+
+#line 1 ".././models/lib/fractal_sq.c"
+
+#pragma acc routine seq
+static double
+fractal_sq(double q, double radius, double fractal_dim, double cor_length)
+{
+    //calculate S(q),  using Teixeira, Eq(15)
+    // mathematica query to check limiting conditions:
+    //    lim x->0 of [ x gamma(x-1) sin(arctan(q c (x-1))) (q r)^(-x) (1 + 1/(q c)^2)^((1-x)/2) ]
+    // Note: gamma(x) may be unreliable for x<0, so the gamma(D-1) is risky.
+    // We instead transform D*gamma(D-1) into gamma(D+1)/(D-1).
+    double term;
+    if (q == 0.) {
+        const double D = fractal_dim;
+        term = pow(cor_length/radius, D)*sas_gamma(D+1.);
+    } else if (fractal_dim == 0.) {
+        term = 1.0;
+    } else if (fractal_dim == 1.) {
+        term = atan(q*cor_length)/(q*radius);
+    } else {
+        // q>0, D>0
+        const double D = fractal_dim;
+        const double Dm1 = fractal_dim - 1.0;
+        // Note: for large Dm1, sin(Dm1*atan(q*cor_length) can go negative
+        const double t1 = sas_gamma(D+1.)/Dm1*sin(Dm1*atan(q*cor_length));
+        const double t2 = pow(q*radius, -D);
+        const double t3 = pow(1.0 + 1.0/square(q*cor_length), -0.5*Dm1);
+        term = t1 * t2 * t3;
+    }
+    return 1.0 + term;
+}
+
+
+#line 1 ".././models/fractal_core_shell.c"
+
+static double
+form_volume(double radius, double thickness)
+{
+    return M_4PI_3 * cube(radius + thickness);
+}
+
+static double
+Iq(double q,
+   double radius,
+   double thickness,
+   double core_sld,
+   double shell_sld,
+   double solvent_sld,
+   double volfraction,
+   double fractal_dim,
+   double cor_length)
+{
+    //The radius for the building block of the core shell particle that is
+    //needed by the Teixeira fractal S(q) is the radius of the whole particle.
+    const double cs_radius = radius + thickness;
+    const double sq = fractal_sq(q, cs_radius, fractal_dim, cor_length);
+    const double fq = core_shell_fq(q, radius, thickness,
+                                    core_sld, shell_sld, solvent_sld);
+
+    return 1.0e-4 * volfraction * sq * fq * fq;
+}
+
+

--- a/mcstas-comps/share/sas_fuzzy_sphere.c
+++ b/mcstas-comps/share/sas_fuzzy_sphere.c
@@ -1,0 +1,479 @@
+#define HAS_FQ
+#define FORM_VOL
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/sas_3j1x_x.c"
+
+/**
+* Spherical Bessel function 3*j1(x)/x
+*
+* Used for low q to avoid cancellation error.
+* Note that the values differ from sasview ~ 5e-12 rather than 5e-14, but
+* in this case it is likely cancellation errors in the original expression
+* using double precision that are the source.
+*/
+double sas_3j1x_x(double q);
+
+// The choice of the number of terms in the series and the cutoff value for
+// switching between series and direct calculation depends on the numeric
+// precision.
+//
+// Point where direct calculation reaches machine precision:
+//
+//   single machine precision eps 3e-8 at qr=1.1 **
+//   double machine precision eps 4e-16 at qr=1.1
+//
+// Point where Taylor series reaches machine precision (eps), where taylor
+// series matches direct calculation (cross) and the error at that point:
+//
+//   prec   n eps  cross  error
+//   single 3 0.28  0.4   6.2e-7
+//   single 4 0.68  0.7   2.3e-7
+//   single 5 1.18  1.2   7.5e-8
+//   double 3 0.01  0.03  2.3e-13
+//   double 4 0.06  0.1   3.1e-14
+//   double 5 0.16  0.2   5.0e-15
+//
+// ** Note: relative error on single precision starts increase on the direct
+// method at qr=1.1, rising from 3e-8 to 5e-5 by qr=1e3.  This should be
+// safe for the sans range, with objects of 100 nm supported to a q of 0.1
+// while maintaining 5 digits of precision.  For usans/sesans, the objects
+// are larger but the q is smaller, so again it should be fine.
+//
+// See explore/sph_j1c.py for code to explore these ranges.
+
+// Use 4th order series
+#if FLOAT_SIZE>4
+#define SPH_J1C_CUTOFF 0.1
+#else
+#define SPH_J1C_CUTOFF 0.7
+#endif
+#pragma acc routine seq
+double sas_3j1x_x(double q)
+{
+    // 2017-05-18 PAK - support negative q
+    if (fabs(q) < SPH_J1C_CUTOFF) {
+        const double q2 = q*q;
+        return (1.0 + q2*(-3./30. + q2*(3./840. + q2*(-3./45360.))));// + q2*(3./3991680.)))));
+    } else {
+        double sin_q, cos_q;
+        SINCOS(q, sin_q, cos_q);
+        return 3.0*(sin_q/q - cos_q)/(q*q);
+    }
+}
+
+
+#line 1 ".././models/fuzzy_sphere.c"
+
+static double form_volume(double radius, double fuzziness)
+{
+    return M_4PI_3*cube(radius);
+}
+
+static double
+radius_effective(int mode, double radius, double fuzziness)
+{
+    switch (mode) {
+    default:
+    case 1: // radius
+        return radius;
+    case 2: // radius + fuzziness
+        return radius + fuzziness;
+    }
+}
+
+static void Fq(double q, double *F1, double *F2, double sld, double sld_solvent,
+               double radius, double fuzziness)
+{
+    const double qr = q*radius;
+    const double bes = sas_3j1x_x(qr);
+    const double qf = exp(-0.5*square(q*fuzziness));
+    const double contrast = (sld - sld_solvent);
+    const double form = contrast * form_volume(radius,fuzziness) * bes * qf;
+    *F1 = 1.0e-2*form;
+    *F2 = 1.0e-4*form*form;
+}
+
+

--- a/mcstas-comps/share/sas_gauss_lorentz_gel.c
+++ b/mcstas-comps/share/sas_gauss_lorentz_gel.c
@@ -1,0 +1,404 @@
+#define HAS_Iq
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/gauss_lorentz_gel.c"
+
+    
+double Iq(double q, double gauss_scale, double cor_length_static, double lorentz_scale, double cor_length_dynamic);
+
+#pragma acc routine seq
+double Iq(double q, double gauss_scale, double cor_length_static, double lorentz_scale, double cor_length_dynamic) {
+    // Calculate the Gaussian and Lorentzian terms separately
+    double term1 = gauss_scale * exp(-q * q * cor_length_static * cor_length_static / 2.0);
+    double term2 = lorentz_scale / (1.0 + q * q * cor_length_dynamic * cor_length_dynamic);
+
+    // Return the sum of the two terms
+    return term1 + term2;
+}
+
+
+
+
+

--- a/mcstas-comps/share/sas_gaussian_peak.c
+++ b/mcstas-comps/share/sas_gaussian_peak.c
@@ -1,290 +1,393 @@
-// GENERATED CODE --- DO NOT EDIT ---
-// Code is produced by sasmodels.gen from sasmodels/models/MODEL.c
+#define HAS_Iq
+#line 1 "../kernel_header.c"
 
 #ifdef __OPENCL_VERSION__
 # define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
 #endif
 
-#define USE_KAHAN_SUMMATION 0
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
 
 // If opencl is not available, then we are compiling a C function
 // Note: if using a C++ compiler, then define kernel as extern "C"
-#ifndef USE_OPENCL
-#  ifdef __cplusplus
-     #include <cstdio>
-     #include <cmath>
-     using namespace std;
-     #if defined(_MSC_VER)
-     #   define kernel extern "C" __declspec( dllexport )
-         inline float trunc(float x) { return x>=0?floor(x):-floor(-x); }
-	 inline float fmin(float x, float y) { return x>y ? y : x; }
-	 inline float fmax(float x, float y) { return x<y ? y : x; }
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
      #else
-     #   define kernel extern "C"
+         #define kernel extern "C"
+         #include <cstdint>
      #endif
-     inline void SINCOS(float angle, float &svar, float &cvar) { svar=sin(angle); cvar=cos(angle); }
-#  else
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
      #include <stdio.h>
-     #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
      // MSVC doesn't support C99, so no need for dllexport on C99 branch
      #define kernel
-     #define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
-#  define global
-#  define local
-#  define constant const
-// OpenCL powr(a,b) = C99 pow(a,b), b >= 0
-// OpenCL pown(a,b) = C99 pow(a,b), b integer
-#  define powr(a,b) pow(a,b)
-#  define pown(a,b) pow(a,b)
-#else
-#  ifdef USE_SINCOS
-#    define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
-#  else
-#    define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
 #endif
 
 // Standard mathematical constants:
 //   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
 //   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
-// OpenCL defines M_constant_F for float constants, and nothing if float
+// OpenCL defines M_constant_F for float constants, and nothing if double
 // is not enabled on the card, which is why these constants may be missing
 #ifndef M_PI
-#  define M_PI 3.141592653589793f
+#  define M_PI 3.141592653589793
 #endif
 #ifndef M_PI_2
-#  define M_PI_2 1.570796326794897f
+#  define M_PI_2 1.570796326794897
 #endif
 #ifndef M_PI_4
-#  define M_PI_4 0.7853981633974483f
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
 #endif
 
-// Non-standard pi/180, used for converting between degrees and radians
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
 #ifndef M_PI_180
-#  define M_PI_180 0.017453292519943295f
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
 #endif
 
-
-#define VOLUME_PARAMETER_DECLARATIONS void
-#define IQ_KERNEL_NAME gaussian_peak_Iq
-#define IQ_PARAMETERS q0, sigma
-#define IQ_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float q0, \
-    const float sigma
-#define IQ_PARAMETER_DECLARATIONS float q0, float sigma
-#define IQXY_KERNEL_NAME gaussian_peak_Iqxy
-#define IQXY_PARAMETERS q0, sigma
-#define IQXY_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float q0, \
-    const float sigma
-#define IQXY_PARAMETER_DECLARATIONS float q0, float sigma
-
-float form_volume(VOLUME_PARAMETER_DECLARATIONS);
-float form_volume(VOLUME_PARAMETER_DECLARATIONS) {
-    
-    return 1.0f;
-    
-}
-
-
-float Iq(float q, IQ_PARAMETER_DECLARATIONS);
-float Iq(float q, IQ_PARAMETER_DECLARATIONS) {
-    
-    float scaled_dq = (q - q0)/sigma;
-    return exp(-0.5f*scaled_dq*scaled_dq); //sqrt(2*M_PI*sigma*sigma);
-    
-}
-
-
-float Iqxy(float qx, float qy, IQXY_PARAMETER_DECLARATIONS);
-float Iqxy(float qx, float qy, IQXY_PARAMETER_DECLARATIONS) {
-    
-    // never called since no orientation or magnetic parameters.
-    //return -1.0f;
-    return Iq(sqrt(qx*qx + qy*qy), q0, sigma);
-    
-}
-
-
-/*
-    ##########################################################
-    #                                                        #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #   !!                                              !!   #
-    #   !!  KEEP THIS CODE CONSISTENT WITH KERNELPY.PY  !!   #
-    #   !!                                              !!   #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #                                                        #
-    ##########################################################
-*/
-
-#ifdef IQ_KERNEL_NAME
-kernel void IQ_KERNEL_NAME(
-    global const float *q,
-    global float *result,
-    const int Nq,
-#ifdef IQ_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQ_DISPERSION_LENGTH_DECLARATIONS,
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
 #endif
-    IQ_FIXED_PARAMETER_DECLARATIONS
-    )
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
 {
-#ifdef USE_OPENCL
-  #ifdef IQ_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQ_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
 
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qi = q[i];
-#ifdef IQ_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-  #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-  #endif
-    IQ_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
 
-    const float weight = IQ_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-      const float scattering = Iq(qi, IQ_PARAMETERS);
-      // allow kernels to exclude invalid regions by returning NaN
-      if (!isnan(scattering)) {
-        ret += weight*scattering;
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-        norm_vol += vol_weight;
-      #endif
-      }
-    //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
-    }
-    IQ_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iq(qi, IQ_PARAMETERS) + background;
-#endif
-  }
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
 }
-#endif
 
-
-#ifdef IQXY_KERNEL_NAME
-kernel void IQXY_KERNEL_NAME(
-    global const float *qx,
-    global const float *qy,
-    global float *result,
-    const int Nq,
-#ifdef IQXY_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQXY_DISPERSION_LENGTH_DECLARATIONS,
-#endif
-    IQXY_FIXED_PARAMETER_DECLARATIONS
-    )
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
 {
-#ifdef USE_OPENCL
-  #ifdef IQXY_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQXY_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
-
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qxi = qx[i];
-    const float qyi = qy[i];
-    #if USE_KAHAN_SUMMATION
-    float accumulated_error = 0.0f;
-    #endif
-#ifdef IQXY_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-    #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-    #endif
-    IQXY_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
-
-    const float weight = IQXY_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-
-      const float scattering = Iqxy(qxi, qyi, IQXY_PARAMETERS);
-      if (!isnan(scattering)) { // if scattering is bad, exclude it from sum
-      //if (scattering >= 0.0f) { // scattering cannot be negative
-        // TODO: use correct angle for spherical correction
-        // Definition of theta and phi are probably reversed relative to the
-        // equation which gave rise to this correction, leading to an
-        // attenuation of the pattern as theta moves through pi/2.f  Either
-        // reverse the meanings of phi and theta in the forms, or use phi
-        // rather than theta in this correction.  Current code uses cos(theta)
-        // so that values match those of sasview.
-      #if defined(IQXY_HAS_THETA) // && 0
-        const float spherical_correction
-          = (Ntheta>1 ? fabs(cos(M_PI_180*theta))*M_PI_2:1.0f);
-        const float next = spherical_correction * weight * scattering;
-      #else
-        const float next = weight * scattering;
-      #endif
-      #if USE_KAHAN_SUMMATION
-        const float y = next - accumulated_error;
-        const float t = ret + y;
-        accumulated_error = (t - ret) - y;
-        ret = t;
-      #else
-        ret += next;
-      #endif
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-      #endif
-        norm_vol += vol_weight;
-      }
-      //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
-    }
-    IQXY_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iqxy(qxi, qyi, IQXY_PARAMETERS) + background;
-#endif
-  }
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
 }
-#endif
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/gaussian_peak.c"
+
+double Iq(double q, double peak_pos, double sigma)
+{
+    double scaled_dq = (q - peak_pos)/sigma;
+    return exp(-0.5*scaled_dq*scaled_dq); //sqrt(2*M_PI*sigma*sigma);
+}
+

--- a/mcstas-comps/share/sas_gel_fit.c
+++ b/mcstas-comps/share/sas_gel_fit.c
@@ -1,0 +1,411 @@
+#define HAS_Iq
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/gel_fit.c"
+
+static double Iq(double q,
+          double guinier_scale,
+          double lorentz_scale,
+          double rg,
+          double fractal_dim,
+          double cor_length)
+{
+    // Lorentzian Term
+    ////////////////////////double a(x[i]*x[i]*zeta*zeta);
+    double lorentzian_term = square(q*cor_length);
+    lorentzian_term = 1.0 + ((fractal_dim + 1.0)/3.0)*lorentzian_term;
+    lorentzian_term = pow(lorentzian_term, fractal_dim/2.0 );
+
+    // Exponential Term
+    ////////////////////////double d(x[i]*x[i]*rg*rg);
+    double exp_term = square(q*rg);
+    exp_term = exp(-exp_term/3.0);
+
+    // Scattering Law
+    double result = lorentz_scale/lorentzian_term + guinier_scale*exp_term;
+    return result;
+}
+
+

--- a/mcstas-comps/share/sas_guinier.c
+++ b/mcstas-comps/share/sas_guinier.c
@@ -1,278 +1,394 @@
-// GENERATED CODE --- DO NOT EDIT ---
-// Code is produced by sasmodels.gen from sasmodels/models/MODEL.c
+#define HAS_Iq
+#line 1 "../kernel_header.c"
 
 #ifdef __OPENCL_VERSION__
 # define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
 #endif
 
-#define USE_KAHAN_SUMMATION 0
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
 
 // If opencl is not available, then we are compiling a C function
 // Note: if using a C++ compiler, then define kernel as extern "C"
-#ifndef USE_OPENCL
-#  ifdef __cplusplus
-     #include <cstdio>
-     #include <cmath>
-     using namespace std;
-     #if defined(_MSC_VER)
-     #   define kernel extern "C" __declspec( dllexport )
-         inline float trunc(float x) { return x>=0?floor(x):-floor(-x); }
-	 inline float fmin(float x, float y) { return x>y ? y : x; }
-	 inline float fmax(float x, float y) { return x<y ? y : x; }
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
      #else
-     #   define kernel extern "C"
+         #define kernel extern "C"
+         #include <cstdint>
      #endif
-     inline void SINCOS(float angle, float &svar, float &cvar) { svar=sin(angle); cvar=cos(angle); }
-#  else
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
      #include <stdio.h>
-     #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
      // MSVC doesn't support C99, so no need for dllexport on C99 branch
      #define kernel
-     #define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
-#  define global
-#  define local
-#  define constant const
-// OpenCL powr(a,b) = C99 pow(a,b), b >= 0
-// OpenCL pown(a,b) = C99 pow(a,b), b integer
-#  define powr(a,b) pow(a,b)
-#  define pown(a,b) pow(a,b)
-#else
-#  ifdef USE_SINCOS
-#    define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
-#  else
-#    define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
 #endif
 
 // Standard mathematical constants:
 //   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
 //   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
-// OpenCL defines M_constant_F for float constants, and nothing if float
+// OpenCL defines M_constant_F for float constants, and nothing if double
 // is not enabled on the card, which is why these constants may be missing
 #ifndef M_PI
-#  define M_PI 3.141592653589793f
+#  define M_PI 3.141592653589793
 #endif
 #ifndef M_PI_2
-#  define M_PI_2 1.570796326794897f
+#  define M_PI_2 1.570796326794897
 #endif
 #ifndef M_PI_4
-#  define M_PI_4 0.7853981633974483f
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
 #endif
 
-// Non-standard pi/180, used for converting between degrees and radians
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
 #ifndef M_PI_180
-#  define M_PI_180 0.017453292519943295f
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
 #endif
 
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
 
-#define IQ_KERNEL_NAME guinier_Iq
-#define IQ_PARAMETERS rg
-#define IQ_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float rg
-#define IQ_PARAMETER_DECLARATIONS float rg
-#define IQXY_KERNEL_NAME guinier_Iqxy
-#define IQXY_PARAMETERS rg
-#define IQXY_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float rg
-#define IQXY_PARAMETER_DECLARATIONS float rg
+//# Beginning of rotational operation definitions
 
-float Iq(float q, IQ_PARAMETER_DECLARATIONS);
-float Iq(float q, IQ_PARAMETER_DECLARATIONS) {
-    
-    float exponent = rg*rg*q*q/3.0f;
-    float value = exp(-exponent);
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/guinier.c"
+
+double Iq(double q, double rg)
+{
+    double exponent = fabs(rg)*rg*q*q/3.0;
+    double value = exp(-exponent);
     return value;
-
 }
 
-
-float Iqxy(float qx, float qy, IQXY_PARAMETER_DECLARATIONS);
-float Iqxy(float qx, float qy, IQXY_PARAMETER_DECLARATIONS) {
-    
-    return Iq(sqrt(qx*qx + qy*qy), rg);
-    
-}
-
-
-/*
-    ##########################################################
-    #                                                        #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #   !!                                              !!   #
-    #   !!  KEEP THIS CODE CONSISTENT WITH KERNELPY.PY  !!   #
-    #   !!                                              !!   #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #                                                        #
-    ##########################################################
-*/
-
-#ifdef IQ_KERNEL_NAME
-kernel void IQ_KERNEL_NAME(
-    global const float *q,
-    global float *result,
-    const int Nq,
-#ifdef IQ_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQ_DISPERSION_LENGTH_DECLARATIONS,
-#endif
-    IQ_FIXED_PARAMETER_DECLARATIONS
-    )
-{
-#ifdef USE_OPENCL
-  #ifdef IQ_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQ_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
-
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qi = q[i];
-#ifdef IQ_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-  #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-  #endif
-    IQ_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
-
-    const float weight = IQ_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-      const float scattering = Iq(qi, IQ_PARAMETERS);
-      // allow kernels to exclude invalid regions by returning NaN
-      if (!isnan(scattering)) {
-        ret += weight*scattering;
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-        norm_vol += vol_weight;
-      #endif
-      }
-    //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
-    }
-    IQ_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iq(qi, IQ_PARAMETERS) + background;
-#endif
-  }
-}
-#endif
-
-
-#ifdef IQXY_KERNEL_NAME
-kernel void IQXY_KERNEL_NAME(
-    global const float *qx,
-    global const float *qy,
-    global float *result,
-    const int Nq,
-#ifdef IQXY_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQXY_DISPERSION_LENGTH_DECLARATIONS,
-#endif
-    IQXY_FIXED_PARAMETER_DECLARATIONS
-    )
-{
-#ifdef USE_OPENCL
-  #ifdef IQXY_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQXY_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
-
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qxi = qx[i];
-    const float qyi = qy[i];
-    #if USE_KAHAN_SUMMATION
-    float accumulated_error = 0.0f;
-    #endif
-#ifdef IQXY_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-    #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-    #endif
-    IQXY_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
-
-    const float weight = IQXY_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-
-      const float scattering = Iqxy(qxi, qyi, IQXY_PARAMETERS);
-      if (!isnan(scattering)) { // if scattering is bad, exclude it from sum
-      //if (scattering >= 0.0f) { // scattering cannot be negative
-        // TODO: use correct angle for spherical correction
-        // Definition of theta and phi are probably reversed relative to the
-        // equation which gave rise to this correction, leading to an
-        // attenuation of the pattern as theta moves through pi/2.f  Either
-        // reverse the meanings of phi and theta in the forms, or use phi
-        // rather than theta in this correction.  Current code uses cos(theta)
-        // so that values match those of sasview.
-      #if defined(IQXY_HAS_THETA) // && 0
-        const float spherical_correction
-          = (Ntheta>1 ? fabs(cos(M_PI_180*theta))*M_PI_2:1.0f);
-        const float next = spherical_correction * weight * scattering;
-      #else
-        const float next = weight * scattering;
-      #endif
-      #if USE_KAHAN_SUMMATION
-        const float y = next - accumulated_error;
-        const float t = ret + y;
-        accumulated_error = (t - ret) - y;
-        ret = t;
-      #else
-        ret += next;
-      #endif
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-      #endif
-        norm_vol += vol_weight;
-      }
-      //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
-    }
-    IQXY_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iqxy(qxi, qyi, IQXY_PARAMETERS) + background;
-#endif
-  }
-}
-#endif

--- a/mcstas-comps/share/sas_guinier_porod.c
+++ b/mcstas-comps/share/sas_guinier_porod.c
@@ -1,0 +1,414 @@
+#define HAS_Iq
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/guinier_porod.c"
+
+#include <math.h>
+
+double Iq(double q, double rg, double s, double porod_exp);
+
+#pragma acc routine seq
+double Iq(double q, double rg, double s, double porod_exp) {
+    double n = 3.0 - s;
+    double ms = 0.5 * (porod_exp - s);  // =(n-3+porod_exp)/2
+    double iq = 0.0;
+
+    // Take care of the singular points
+    if (rg <= 0.0 || ms <= 0.0) {
+        return iq;
+    }
+
+    // Do the calculation and return the function value
+    if (q < sqrt(n * ms) / rg) {
+        iq = pow(q, -s) * exp(-pow(q * rg, 2) / n);
+    } else {
+        iq = pow(q, -porod_exp) * (exp(-ms) * pow(n * ms / pow(rg, 2), ms));
+    }
+
+    return iq;
+}
+
+
+

--- a/mcstas-comps/share/sas_hardsphere.c
+++ b/mcstas-comps/share/sas_hardsphere.c
@@ -1,330 +1,474 @@
-// GENERATED CODE --- DO NOT EDIT ---
-// Code is produced by sasmodels.gen from sasmodels/models/MODEL.c
+#define HAS_Iq
+#line 1 "../kernel_header.c"
 
 #ifdef __OPENCL_VERSION__
 # define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
 #endif
 
-#define USE_KAHAN_SUMMATION 0
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
 
 // If opencl is not available, then we are compiling a C function
 // Note: if using a C++ compiler, then define kernel as extern "C"
-#ifndef USE_OPENCL
-#  ifdef __cplusplus
-     #include <cstdio>
-     #include <cmath>
-     using namespace std;
-     #if defined(_MSC_VER)
-     #   define kernel extern "C" __declspec( dllexport )
-         inline float trunc(float x) { return x>=0?floor(x):-floor(-x); }
-	 inline float fmin(float x, float y) { return x>y ? y : x; }
-	 inline float fmax(float x, float y) { return x<y ? y : x; }
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
      #else
-     #   define kernel extern "C"
+         #define kernel extern "C"
+         #include <cstdint>
      #endif
-     inline void SINCOS(float angle, float &svar, float &cvar) { svar=sin(angle); cvar=cos(angle); }
-#  else
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
      #include <stdio.h>
-     #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
      // MSVC doesn't support C99, so no need for dllexport on C99 branch
      #define kernel
-     #define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
-#  define global
-#  define local
-#  define constant const
-// OpenCL powr(a,b) = C99 pow(a,b), b >= 0
-// OpenCL pown(a,b) = C99 pow(a,b), b integer
-#  define powr(a,b) pow(a,b)
-#  define pown(a,b) pow(a,b)
-#else
-#  ifdef USE_SINCOS
-#    define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
-#  else
-#    define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
 #endif
 
 // Standard mathematical constants:
 //   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
 //   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
-// OpenCL defines M_constant_F for float constants, and nothing if float
+// OpenCL defines M_constant_F for float constants, and nothing if double
 // is not enabled on the card, which is why these constants may be missing
 #ifndef M_PI
-#  define M_PI 3.141592653589793f
+#  define M_PI 3.141592653589793
 #endif
 #ifndef M_PI_2
-#  define M_PI_2 1.570796326794897f
+#  define M_PI_2 1.570796326794897
 #endif
 #ifndef M_PI_4
-#  define M_PI_4 0.7853981633974483f
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
 #endif
 
-// Non-standard pi/180, used for converting between degrees and radians
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
 #ifndef M_PI_180
-#  define M_PI_180 0.017453292519943295f
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
 #endif
 
-
-#define VOLUME_PARAMETERS effect_radius
-#define VOLUME_WEIGHT_PRODUCT effect_radius_w
-#define VOLUME_PARAMETER_DECLARATIONS float effect_radius
-#define IQ_KERNEL_NAME hardsphere_Iq
-#define IQ_PARAMETERS effect_radius, volfraction
-#define IQ_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float volfraction
-#define IQ_WEIGHT_PRODUCT effect_radius_w
-#define IQ_DISPERSION_LENGTH_DECLARATIONS const int Neffect_radius
-#define IQ_DISPERSION_LENGTH_SUM Neffect_radius
-#define IQ_OPEN_LOOPS     for (int effect_radius_i=0; effect_radius_i < Neffect_radius; effect_radius_i++) { \
-      const float effect_radius = loops[2*(effect_radius_i)]; \
-      const float effect_radius_w = loops[2*(effect_radius_i)+1];
-#define IQ_CLOSE_LOOPS     }
-#define IQ_PARAMETER_DECLARATIONS float effect_radius, float volfraction
-#define IQXY_KERNEL_NAME hardsphere_Iqxy
-#define IQXY_PARAMETERS effect_radius, volfraction
-#define IQXY_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float volfraction
-#define IQXY_WEIGHT_PRODUCT effect_radius_w
-#define IQXY_DISPERSION_LENGTH_DECLARATIONS const int Neffect_radius
-#define IQXY_DISPERSION_LENGTH_SUM Neffect_radius
-#define IQXY_OPEN_LOOPS     for (int effect_radius_i=0; effect_radius_i < Neffect_radius; effect_radius_i++) { \
-      const float effect_radius = loops[2*(effect_radius_i)]; \
-      const float effect_radius_w = loops[2*(effect_radius_i)+1];
-#define IQXY_CLOSE_LOOPS     }
-#define IQXY_PARAMETER_DECLARATIONS float effect_radius, float volfraction
-
-float form_volume(VOLUME_PARAMETER_DECLARATIONS);
-float form_volume(VOLUME_PARAMETER_DECLARATIONS) {
-    
-    return 1.0f;
-    
-}
-
-
-float Iq(float q, IQ_PARAMETER_DECLARATIONS);
-float Iq(float q, IQ_PARAMETER_DECLARATIONS) {
-    
-    float denom,dnum,alpha,beta,gamm,a,asq,ath,afor,rca,rsa;
-    float calp,cbeta,cgam,prefac,c,vstruc;
-    float struc;
-
-    //  compute constants
-    denom = pow((1.0f-volfraction),4);
-    dnum = pow((1.0f + 2.0f*volfraction),2);
-    alpha = dnum/denom;
-    beta = -6.0f*volfraction*pow((1.0f + volfraction/2.0f),2)/denom;
-    gamm = 0.50f*volfraction*dnum/denom;
-    //
-    //  calculate the structure factor
-    //
-    a = 2.0f*q*effect_radius;
-    asq = a*a;
-    ath = asq*a;
-    afor = ath*a;
-    SINCOS(a,rsa,rca);
-    //rca = cos(a);
-    //rsa = sin(a);
-    calp = alpha*(rsa/asq - rca/a);
-    cbeta = beta*(2.0f*rsa/asq - (asq - 2.0f)*rca/ath - 2.0f/ath);
-    cgam = gamm*(-rca/a + (4.0f/a)*((3.0f*asq - 6.0f)*rca/afor + (asq - 6.0f)*rsa/ath + 6.0f/afor));
-    prefac = -24.0f*volfraction/a;
-    c = prefac*(calp + cbeta + cgam);
-    vstruc = 1.0f/(1.0f-c);
-    struc = vstruc;
-
-    return(struc);
-   
-}
-
-
-float Iqxy(float qx, float qy, IQXY_PARAMETER_DECLARATIONS);
-float Iqxy(float qx, float qy, IQXY_PARAMETER_DECLARATIONS) {
-    
-    // never called since no orientation or magnetic parameters.
-    return Iq(sqrt(qx*qx+qy*qy), IQ_PARAMETERS);
-    
-}
-
-
-/*
-    ##########################################################
-    #                                                        #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #   !!                                              !!   #
-    #   !!  KEEP THIS CODE CONSISTENT WITH KERNELPY.PY  !!   #
-    #   !!                                              !!   #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #                                                        #
-    ##########################################################
-*/
-
-#ifdef IQ_KERNEL_NAME
-kernel void IQ_KERNEL_NAME(
-    global const float *q,
-    global float *result,
-    const int Nq,
-#ifdef IQ_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQ_DISPERSION_LENGTH_DECLARATIONS,
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
 #endif
-    IQ_FIXED_PARAMETER_DECLARATIONS
-    )
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
 {
-#ifdef USE_OPENCL
-  #ifdef IQ_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQ_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
 
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qi = q[i];
-#ifdef IQ_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-  #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-  #endif
-    IQ_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
 
-    const float weight = IQ_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-      const float scattering = Iq(qi, IQ_PARAMETERS);
-      // allow kernels to exclude invalid regions by returning NaN
-      if (!isnan(scattering)) {
-        ret += weight*scattering;
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-        norm_vol += vol_weight;
-      #endif
-      }
-    //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
-    }
-    IQ_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iq(qi, IQ_PARAMETERS) + background;
-#endif
-  }
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
 }
-#endif
 
-
-#ifdef IQXY_KERNEL_NAME
-kernel void IQXY_KERNEL_NAME(
-    global const float *qx,
-    global const float *qy,
-    global float *result,
-    const int Nq,
-#ifdef IQXY_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQXY_DISPERSION_LENGTH_DECLARATIONS,
-#endif
-    IQXY_FIXED_PARAMETER_DECLARATIONS
-    )
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
 {
-#ifdef USE_OPENCL
-  #ifdef IQXY_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQXY_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
-
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qxi = qx[i];
-    const float qyi = qy[i];
-    #if USE_KAHAN_SUMMATION
-    float accumulated_error = 0.0f;
-    #endif
-#ifdef IQXY_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-    #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-    #endif
-    IQXY_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
-
-    const float weight = IQXY_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-
-      const float scattering = Iqxy(qxi, qyi, IQXY_PARAMETERS);
-      if (!isnan(scattering)) { // if scattering is bad, exclude it from sum
-      //if (scattering >= 0.0f) { // scattering cannot be negative
-        // TODO: use correct angle for spherical correction
-        // Definition of theta and phi are probably reversed relative to the
-        // equation which gave rise to this correction, leading to an
-        // attenuation of the pattern as theta moves through pi/2.f  Either
-        // reverse the meanings of phi and theta in the forms, or use phi
-        // rather than theta in this correction.  Current code uses cos(theta)
-        // so that values match those of sasview.
-      #if defined(IQXY_HAS_THETA) // && 0
-        const float spherical_correction
-          = (Ntheta>1 ? fabs(cos(M_PI_180*theta))*M_PI_2:1.0f);
-        const float next = spherical_correction * weight * scattering;
-      #else
-        const float next = weight * scattering;
-      #endif
-      #if USE_KAHAN_SUMMATION
-        const float y = next - accumulated_error;
-        const float t = ret + y;
-        accumulated_error = (t - ret) - y;
-        ret = t;
-      #else
-        ret += next;
-      #endif
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-      #endif
-        norm_vol += vol_weight;
-      }
-      //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
-    }
-    IQXY_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iqxy(qxi, qyi, IQXY_PARAMETERS) + background;
-#endif
-  }
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
 }
-#endif
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/hardsphere.c"
+
+double Iq(double q, double radius_effective, double volfraction)
+{
+      double D,A,B,G,X,X2,X4,S,C,FF,HARDSPH;
+      // these are c compiler instructions, can also put normal code inside the "if else" structure
+      #if FLOAT_SIZE > 4
+      // double precision
+      // orig had 0.2, don't call the variable cutoff as PAK already has one called that!
+      // Must use UPPERCASE name please.
+      // 0.05 better, 0.1 OK
+      #define CUTOFFHS 0.05
+      #else
+      // 0.1 bad, 0.2 OK, 0.3 good, 0.4 better, 0.8 no good
+      #define CUTOFFHS 0.4
+      #endif
+
+      if(fabs(radius_effective) < 1.E-12) {
+               HARDSPH=1.0;
+//printf("HS1 %g: %g\n",q,HARDSPH);
+               return(HARDSPH);
+      }
+      // removing use of pow(xxx,2) and rearranging the calcs
+      // of A, B & G cut ~40% off execution time ( 0.5 to 0.3 msec)
+      X = 1.0/( 1.0 -volfraction);
+      D= X*X;
+      A= (1.+2.*volfraction)*D;
+      A *=A;
+      X=fabs(q*radius_effective*2.0);
+
+      if(X < 5.E-06) {
+                 HARDSPH=1./A;
+//printf("HS2 %g: %g\n",q,HARDSPH);
+                 return(HARDSPH);
+      }
+      X2 =X*X;
+      B = (1.0 +0.5*volfraction)*D;
+      B *= B;
+      B *= -6.*volfraction;
+      G=0.5*volfraction*A;
+
+      if(X < CUTOFFHS) {
+      // RKH Feb 2016, use Taylor series expansion for small X
+      // else no obvious way to rearrange the equations to avoid
+      // needing a very high number of significant figures.
+      // Series expansion found using Mathematica software. Numerical test
+      // in .xls showed terms to X^2 are sufficient
+      // for 5 or 6 significant figures, but I put the X^4 one in anyway
+            //FF = 8*A +6*B + 4*G - (0.8*A +2.0*B/3.0 +0.5*G)*X2 +(A/35. +B/40. +G/50.)*X4;
+            // refactoring the polynomial makes it very slightly faster (0.5 not 0.6 msec)
+            //FF = 8*A +6*B + 4*G + ( -0.8*A -2.0*B/3.0 -0.5*G +(A/35. +B/40. +G/50.)*X2)*X2;
+
+            FF = 8.0*A +6.0*B + 4.0*G + ( -0.8*A -B/1.5 -0.5*G +(A/35. +0.0125*B +0.02*G)*X2)*X2;
+
+            // combining the terms makes things worse at smallest Q in single precision
+            //FF = (8-0.8*X2)*A +(3.0-X2/3.)*2*B + (4+0.5*X2)*G +(A/35. +B/40. +G/50.)*X4;
+            // note that G = -volfraction*A/2, combining this makes no further difference at smallest Q
+            //FF = (8 +2.*volfraction + ( volfraction/4. -0.8 +(volfraction/100. -1./35.)*X2 )*X2 )*A  + (3.0 -X2/3. +X4/40.)*2.*B;
+            HARDSPH= 1./(1. + volfraction*FF );
+//printf("HS3 %g: %g\n",q,HARDSPH);
+            return(HARDSPH);
+      }
+      X4=X2*X2;
+      SINCOS(X,S,C);
+
+// RKH Feb 2016, use version FISH code as is better than original sasview one
+// at small Q in single precision, and more than twice as fast in double.
+      //FF=A*(S-X*C)/X + B*(2.*X*S -(X2-2.)*C -2.)/X2 + G*( (4.*X2*X -24.*X)*S -(X4 -12.*X2 +24.)*C +24. )/X4;
+      // refactoring the polynomial here & above makes it slightly faster
+
+      FF=  (( G*( (4.*X2 -24.)*X*S -(X4 -12.*X2 +24.)*C +24. )/X2 + B*(2.*X*S -(X2-2.)*C -2.) )/X + A*(S-X*C))/X ;
+      HARDSPH= 1./(1. + 24.*volfraction*FF/X2 );
+
+      // changing /X and /X2 to *MX1 and *MX2, no significantg difference?
+      //MX=1.0/X;
+      //MX2=MX*MX;
+      //FF=  (( G*( (4.*X2 -24.)*X*S -(X4 -12.*X2 +24.)*C +24. )*MX2 + B*(2.*X*S -(X2-2.)*C -2.) )*MX + A*(S-X*C)) ;
+      //HARDSPH= 1./(1. + 24.*volfraction*FF*MX2*MX );
+
+// grouping the terms, was about same as sasmodels for single precision issues
+//     FF=A*(S/X-C) + B*(2.*S/X - C +2.0*(C-1.0)/X2) + G*( (4./X -24./X3)*S -(1.0 -12./X2 +24./X4)*C +24./X4 );
+//     HARDSPH= 1./(1. + 24.*volfraction*FF/X2 );
+// remove 1/X2 from final line, take more powers of X inside the brackets, stil bad
+//      FF=A*(S/X3-C/X2) + B*(2.*S/X3 - C/X2 +2.0*(C-1.0)/X4) + G*( (4./X -24./X3)*S -(1.0 -12./X2 +24./X4)*C +24./X4 )/X2;
+//      HARDSPH= 1./(1. + 24.*volfraction*FF );
+//printf("HS4 %g: %g\n",q,HARDSPH);
+      return(HARDSPH);
+}
+

--- a/mcstas-comps/share/sas_hayter_msa.c
+++ b/mcstas-comps/share/sas_hayter_msa.c
@@ -1,0 +1,930 @@
+#define HAS_Iq
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/hayter_msa.c"
+
+// Hayter-Penfold (rescaled) MSA structure factor for screened Coulomb interactions 
+//
+// C99 needs declarations of routines here
+double Iq(double QQ,
+      double radius_effective, double zz, double VolFrac, double Temp, double csalt, double dialec);
+int
+sqcoef(int ir, double gMSAWave[]);
+
+int
+sqfun(int ix, int ir, double gMSAWave[]);
+
+double
+sqhcal(double qq, double gMSAWave[]);
+  
+double Iq(double QQ,
+      double radius_effective, double VolFrac, double zz, double Temp, double csalt, double dialec)
+{
+    double gMSAWave[17]={1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17};
+	double Elcharge=1.602189e-19;		// electron charge in Coulombs (C)
+	double kB=1.380662e-23;				// Boltzman constant in J/K
+	double FrSpPerm=8.85418782E-12;	//Permittivity of free space in C^2/(N m^2)
+	double SofQ, Qdiam, Vp, ss;
+	double SIdiam, diam, Kappa, cs, IonSt;
+	double  Perm, Beta;
+	double charge;
+	int ierr;
+	
+	diam=2*radius_effective;		//in A
+
+						////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+						//////////////////////////// convert to USEFUL inputs in SI units                                                //
+						////////////////////////////    NOTE: easiest to do EVERYTHING in SI units                               //
+						////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	Beta=1.0/(kB*Temp);		// in Joules^-1
+	Perm=dialec*FrSpPerm;	//in C^2/(N  m^2)
+	charge=zz*Elcharge;		//in Coulomb (C)
+	SIdiam = diam*1.0E-10;		//in m
+	Vp=M_4PI_3*cube(SIdiam/2.0);	//in m^3
+	cs=csalt*6.022E23*1.0E3;	//# salt molecules/m^3
+	
+	//         Compute the derived values of :
+	//			 Ionic strength IonSt (in C^2/m^3)  
+	// 			Kappa (Debye-Huckel screening length in m)
+	//	and		gamma Exp(-k)
+	
+	// the zz*VolFrac/Vp is for the counterions from the micelle, assumed monovalent, the 2.0*cs if for added salt, assumed 1:1 electolyte 
+	IonSt=0.5 * Elcharge*Elcharge*(zz*VolFrac/Vp+2.0*cs);
+	Kappa=sqrt(2*Beta*IonSt/Perm);     //Kappa calc from Ionic strength
+									   //	Kappa=2/SIdiam					// Use to compare with HP paper
+	gMSAWave[5]=Beta*charge*charge/(M_PI*Perm*SIdiam*square(2.0+Kappa*SIdiam));
+	
+	//         Finally set up dimensionless parameters 
+	Qdiam=QQ*diam;
+	gMSAWave[6] = Kappa*SIdiam;
+	gMSAWave[4] = VolFrac;
+	
+	//Function sqhpa(qq)  {this is where Hayter-Penfold program began}
+	
+	//       FIRST CALCULATE COUPLING
+	
+	ss=pow(gMSAWave[4],(1.0/3.0));
+	gMSAWave[9] = 2.0*ss*gMSAWave[5]*exp(gMSAWave[6]-gMSAWave[6]/ss);
+	
+	//        CALCULATE COEFFICIENTS, CHECK ALL IS WELL
+	//        AND IF SO CALCULATE S(Q*SIG)
+	
+	ierr=0;
+	ierr=sqcoef(ierr, gMSAWave);
+	if (ierr>=0) {
+		SofQ=sqhcal(Qdiam, gMSAWave);
+	}else{
+       	SofQ=NAN;
+		//	print "Error Level = ",ierr
+		//      print "Please report HPMSA problem with above error code"
+	}
+	
+	return(SofQ);
+}
+
+
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+//
+//
+//      CALCULATES RESCALED VOLUME FRACTION AND CORRESPONDING
+//      COEFFICIENTS FOR "SQHPA"
+//
+//      JOHN B. HAYTER   (I.L.L.)    14-SEP-81
+//
+//      ON EXIT:
+//
+//      SETA IS THE RESCALED VOLUME FRACTION
+//      SGEK IS THE RESCALED CONTACT POTENTIAL
+//      SAK IS THE RESCALED SCREENING CONSTANT
+//      A,B,C,F,U,V ARE THE MSA COEFFICIENTS
+//      G1= G(1+) IS THE CONTACT VALUE OF G(R/SIG):
+//      FOR THE GILLAN CONDITION, THE DIFFERENCE FROM
+//      ZERO INDICATES THE COMPUTATIONAL ACCURACY.
+//
+//      IR > 0:    NORMAL EXIT,  IR IS THE NUMBER OF ITERATIONS.
+//         < 0:    FAILED TO CONVERGE
+//
+int
+sqcoef(int ir, double gMSAWave[])
+{	
+	int itm=40,ix,ig,ii;
+	double acc=5.0E-6,del,e1,e2,f1,f2;
+
+	//      WAVE gMSAWave = $"root:HayPenMSA:gMSAWave"
+	f1=0;		//these were never properly initialized...
+	f2=0;
+	
+	ig=1;
+	if (gMSAWave[6]>=(1.0+8.0*gMSAWave[4])) {
+		ig=0;
+		gMSAWave[15]=gMSAWave[14];
+		gMSAWave[16]=gMSAWave[4];
+		ix=1;
+		ir = sqfun(ix,ir,gMSAWave);
+		gMSAWave[14]=gMSAWave[15];
+		gMSAWave[4]=gMSAWave[16];
+		if((ir<0.0) || (gMSAWave[14]>=0.0)) {
+			return ir;
+		}
+	}
+	gMSAWave[10]=fmin(gMSAWave[4],0.20);
+	if ((ig!=1) || ( gMSAWave[9]>=0.15)) {
+		ii=0;                             
+		do {
+			ii=ii+1;
+			if(ii>itm) {
+				ir=-1;
+				return ir;		
+			}
+			if (gMSAWave[10]<=0.0) {
+			    gMSAWave[10]=gMSAWave[4]/ii;
+			}
+			if(gMSAWave[10]>0.6) {
+			    gMSAWave[10] = 0.35/ii;
+			}
+			e1=gMSAWave[10];
+			gMSAWave[15]=f1;
+			gMSAWave[16]=e1;
+			ix=2;
+			ir = sqfun(ix,ir,gMSAWave);
+			f1=gMSAWave[15];
+			e1=gMSAWave[16];
+			e2=gMSAWave[10]*1.01;
+			gMSAWave[15]=f2;
+			gMSAWave[16]=e2;
+			ix=2;
+			ir = sqfun(ix,ir,gMSAWave);
+			f2=gMSAWave[15];
+			e2=gMSAWave[16];
+			e2=e1-(e2-e1)*f1/(f2-f1);
+			gMSAWave[10] = e2;
+			del = fabs((e2-e1)/e1);
+		} while (del>acc);
+		gMSAWave[15]=gMSAWave[14];
+		gMSAWave[16]=e2;
+		ix=4;
+		ir = sqfun(ix,ir,gMSAWave);
+		gMSAWave[14]=gMSAWave[15];
+		e2=gMSAWave[16];
+		ir=ii;
+		if ((ig!=1) || (gMSAWave[10]>=gMSAWave[4])) {
+		    return ir;
+		}
+	}
+	gMSAWave[15]=gMSAWave[14];
+	gMSAWave[16]=gMSAWave[4];
+	ix=3;
+	ir = sqfun(ix,ir,gMSAWave);
+	gMSAWave[14]=gMSAWave[15];
+	gMSAWave[4]=gMSAWave[16];
+	if ((ir>=0) && (gMSAWave[14]<0.0)) {
+		ir=-3;
+	}
+	return ir;
+}
+
+
+int
+sqfun(int ix, int ir, double gMSAWave[])
+{	
+	double acc=1.0e-6;
+	double reta,eta2,eta21,eta22,eta3,eta32,eta2d,eta2d2,eta3d,eta6d,e12,e24,rgek;
+	double rak,ak1,ak2,dak,dak2,dak4,d,d2,dd2,dd4,dd45,ex1,ex2,sk,ck,ckma,skma;
+	double al1,al2,al3,al4,al5,al6,be1,be2,be3,vu1,vu2,vu3,vu4,vu5,ph1,ph2,ta1,ta2,ta3,ta4,ta5;
+	double a1,a2,a3,b1,b2,b3,v1,v2,v3,p1,p2,p3,pp,pp1,pp2,p1p2,t1,t2,t3,um1,um2,um3,um4,um5,um6;
+	double w0,w1,w2,w3,w4,w12,w13,w14,w15,w16,w24,w25,w26,w32,w34,w3425,w35,w3526,w36,w46,w56;
+	double fa,fap,ca,e24g,pwk,qpw,pg,del,fun,fund,g24;
+	int ii,ibig,itm=40;
+	//      WAVE gMSAWave = $"root:HayPenMSA:gMSAWave"
+	a2=0;
+	a3=0;
+	b2=0;
+	b3=0;
+	v2=0;
+	v3=0;
+	p2=0;
+	p3=0;
+	
+	//     CALCULATE CONSTANTS; NOTATION IS HAYTER PENFOLD (1981)
+	
+	reta = gMSAWave[16];                                                
+	eta2 = reta*reta;
+	eta3 = eta2*reta;
+	e12 = 12.0*reta;
+	e24 = e12+e12;
+	gMSAWave[13] = pow( (gMSAWave[4]/gMSAWave[16]),(1.0/3.0));
+	gMSAWave[12]=gMSAWave[6]/gMSAWave[13];
+	ibig=0;
+	if (( gMSAWave[12]>15.0) && (ix==1)) {
+		ibig=1;
+	}
+    
+	gMSAWave[11] = gMSAWave[5]*gMSAWave[13]*exp(gMSAWave[6]- gMSAWave[12]);
+	rgek =  gMSAWave[11];
+	rak =  gMSAWave[12];
+	ak2 = rak*rak;
+	ak1 = 1.0+rak;
+	dak2 = 1.0/ak2;
+	dak4 = dak2*dak2;
+	d = 1.0-reta;
+	d2 = d*d;
+	dak = d/rak;
+	dd2 = 1.0/d2;
+	dd4 = dd2*dd2;
+	dd45 = dd4*2.0e-1;
+	eta3d=3.0*reta;
+	eta6d = eta3d+eta3d;
+	eta32 = eta3+ eta3;
+	eta2d = reta+2.0;
+	eta2d2 = eta2d*eta2d;
+	eta21 = 2.0*reta+1.0;
+	eta22 = eta21*eta21;
+	
+	//     ALPHA(I)
+	
+	al1 = -eta21*dak;
+	al2 = (14.0*eta2-4.0*reta-1.0)*dak2;
+	al3 = 36.0*eta2*dak4;
+	
+	//      BETA(I)
+	
+	be1 = -(eta2+7.0*reta+1.0)*dak;
+	be2 = 9.0*reta*(eta2+4.0*reta-2.0)*dak2;
+	be3 = 12.0*reta*(2.0*eta2+8.0*reta-1.0)*dak4;
+	
+	//      NU(I)
+	
+	vu1 = -(eta3+3.0*eta2+45.0*reta+5.0)*dak;
+	vu2 = (eta32+3.0*eta2+42.0*reta-2.0e1)*dak2;
+	vu3 = (eta32+3.0e1*reta-5.0)*dak4;
+	vu4 = vu1+e24*rak*vu3;
+	vu5 = eta6d*(vu2+4.0*vu3);
+	
+	//      PHI(I)
+	
+	ph1 = eta6d/rak;
+	ph2 = d-e12*dak2;
+	
+	//      TAU(I)
+	
+	ta1 = (reta+5.0)/(5.0*rak);
+	ta2 = eta2d*dak2;
+	ta3 = -e12*rgek*(ta1+ta2);
+	ta4 = eta3d*ak2*(ta1*ta1-ta2*ta2);
+	ta5 = eta3d*(reta+8.0)*1.0e-1-2.0*eta22*dak2;
+	
+	//     double PRECISION SINH(K), COSH(K)
+	
+	ex1 = exp(rak);
+	ex2 = 0.0;
+	if ( gMSAWave[12]<20.0) {
+		ex2=exp(-rak);
+	}
+	sk=0.5*(ex1-ex2);
+	ck = 0.5*(ex1+ex2);
+	ckma = ck-1.0-rak*sk;
+	skma = sk-rak*ck;
+	
+	//      a(I)
+	
+	a1 = (e24*rgek*(al1+al2+ak1*al3)-eta22)*dd4;
+	if (ibig==0) {
+		a2 = e24*(al3*skma+al2*sk-al1*ck)*dd4;
+		a3 = e24*(eta22*dak2-0.5*d2+al3*ckma-al1*sk+al2*ck)*dd4;
+	}
+	
+	//      b(I)
+	
+	b1 = (1.5*reta*eta2d2-e12*rgek*(be1+be2+ak1*be3))*dd4;
+	if (ibig==0) {
+		b2 = e12*(-be3*skma-be2*sk+be1*ck)*dd4;
+		b3 = e12*(0.5*d2*eta2d-eta3d*eta2d2*dak2-be3*ckma+be1*sk-be2*ck)*dd4;
+	}
+	
+	//      V(I)
+	
+	v1 = (eta21*(eta2-2.0*reta+1.0e1)*2.5e-1-rgek*(vu4+vu5))*dd45;
+	if (ibig==0) {
+		v2 = (vu4*ck-vu5*sk)*dd45;
+		v3 = ((eta3-6.0*eta2+5.0)*d-eta6d*(2.0*eta3-3.0*eta2+18.0*reta+1.0e1)*dak2+e24*vu3+vu4*sk-vu5*ck)*dd45;
+	}
+	
+	
+	//       P(I)
+	
+	pp1 = ph1*ph1;
+	pp2 = ph2*ph2;
+	pp = pp1+pp2;
+	p1p2 = ph1*ph2*2.0;
+	p1 = (rgek*(pp1+pp2-p1p2)-0.5*eta2d)*dd2;
+	if (ibig==0) {
+		p2 = (pp*sk+p1p2*ck)*dd2;
+		p3 = (pp*ck+p1p2*sk+pp1-pp2)*dd2;
+	}
+	
+	//       T(I)
+	
+	t1 = ta3+ta4*a1+ta5*b1;
+	if (ibig!=0) {
+		
+		//		VERY LARGE SCREENING:  ASYMPTOTIC SOLUTION
+		
+  		v3 = ((eta3-6.0*eta2+5.0)*d-eta6d*(2.0*eta3-3.0*eta2+18.0*reta+1.0e1)*dak2+e24*vu3)*dd45;
+		t3 = ta4*a3+ta5*b3+e12*ta2 - 4.0e-1*reta*(reta+1.0e1)-1.0;
+		p3 = (pp1-pp2)*dd2;
+		b3 = e12*(0.5*d2*eta2d-eta3d*eta2d2*dak2+be3)*dd4;
+		a3 = e24*(eta22*dak2-0.5*d2-al3)*dd4;
+		um6 = t3*a3-e12*v3*v3;
+		um5 = t1*a3+a1*t3-e24*v1*v3;
+		um4 = t1*a1-e12*v1*v1;
+		al6 = e12*p3*p3;
+		al5 = e24*p1*p3-b3-b3-ak2;
+		al4 = e12*p1*p1-b1-b1;
+		w56 = um5*al6-al5*um6;
+		w46 = um4*al6-al4*um6;
+		fa = -w46/w56;
+		ca = -fa;
+		gMSAWave[3] = fa;
+		gMSAWave[2] = ca;
+		gMSAWave[1] = b1+b3*fa;
+		gMSAWave[0] = a1+a3*fa;
+		gMSAWave[8] = v1+v3*fa;
+		gMSAWave[14] = -(p1+p3*fa);
+		gMSAWave[15] = gMSAWave[14];
+		if (fabs(gMSAWave[15])<1.0e-3) {
+			gMSAWave[15] = 0.0;
+		}
+		gMSAWave[10] = gMSAWave[16];
+		
+	} else {
+        
+		t2 = ta4*a2+ta5*b2+e12*(ta1*ck-ta2*sk);
+		t3 = ta4*a3+ta5*b3+e12*(ta1*sk-ta2*(ck-1.0))-4.0e-1*reta*(reta+1.0e1)-1.0;
+		
+		//		MU(i)
+		
+		um1 = t2*a2-e12*v2*v2;
+		um2 = t1*a2+t2*a1-e24*v1*v2;
+		um3 = t2*a3+t3*a2-e24*v2*v3;
+		um4 = t1*a1-e12*v1*v1;
+		um5 = t1*a3+t3*a1-e24*v1*v3;
+		um6 = t3*a3-e12*v3*v3;
+		
+		//			GILLAN CONDITION ?
+		//
+		//			YES - G(X=1+) = 0
+		//
+		//			COEFFICIENTS AND FUNCTION VALUE
+		//
+		if ((ix==1) || (ix==3)) {
+			
+			//			NO - CALCULATE REMAINING COEFFICIENTS.
+			
+			//			LAMBDA(I)
+			
+			al1 = e12*p2*p2;
+			al2 = e24*p1*p2-b2-b2;
+			al3 = e24*p2*p3;
+			al4 = e12*p1*p1-b1-b1;
+			al5 = e24*p1*p3-b3-b3-ak2;
+			al6 = e12*p3*p3;
+			
+			//			OMEGA(I)
+			
+			w16 = um1*al6-al1*um6;
+			w15 = um1*al5-al1*um5;
+			w14 = um1*al4-al1*um4;
+			w13 = um1*al3-al1*um3;
+			w12 = um1*al2-al1*um2;
+			
+			w26 = um2*al6-al2*um6;
+			w25 = um2*al5-al2*um5;
+			w24 = um2*al4-al2*um4;
+			
+			w36 = um3*al6-al3*um6;
+			w35 = um3*al5-al3*um5;
+			w34 = um3*al4-al3*um4;
+			w32 = um3*al2-al3*um2;
+			//
+			w46 = um4*al6-al4*um6;
+			w56 = um5*al6-al5*um6;
+			w3526 = w35+w26;
+			w3425 = w34+w25;
+			
+			//			QUARTIC COEFFICIENTS
+			
+			w4 = w16*w16-w13*w36;
+			w3 = 2.0*w16*w15-w13*w3526-w12*w36;
+			w2 = w15*w15+2.0*w16*w14-w13*w3425-w12*w3526;
+			w1 = 2.0*w15*w14-w13*w24-w12*w3425;
+			w0 = w14*w14-w12*w24;
+			
+			//			ESTIMATE THE STARTING VALUE OF f
+			
+			if (ix==1) {
+				//				LARGE K
+				fap = (w14-w34-w46)/(w12-w15+w35-w26+w56-w32);
+			} else {
+				//				ASSUME NOT TOO FAR FROM GILLAN CONDITION.
+				//				IF BOTH RGEK AND RAK ARE SMALL, USE P-W ESTIMATE.
+				gMSAWave[14]=0.5*eta2d*dd2*exp(-rgek);
+				if (( gMSAWave[11]<=2.0) && ( gMSAWave[11]>=0.0) && ( gMSAWave[12]<=1.0)) {
+					e24g = e24*rgek*exp(rak);
+					pwk = sqrt(e24g);
+					qpw = (1.0-sqrt(1.0+2.0*d2*d*pwk/eta22))*eta21/d;
+					gMSAWave[14] = -qpw*qpw/e24+0.5*eta2d*dd2;
+				}
+  				pg = p1+gMSAWave[14];
+				ca = ak2*pg+2.0*(b3*pg-b1*p3)+e12*gMSAWave[14]*gMSAWave[14]*p3;
+				ca = -ca/(ak2*p2+2.0*(b3*p2-b2*p3));
+				fap = -(pg+p2*ca)/p3;
+			}
+			
+			//			AND REFINE IT ACCORDING TO NEWTON
+			ii=0;
+			do {
+				ii = ii+1;
+				if (ii>itm) {
+					//					FAILED TO CONVERGE IN ITM ITERATIONS
+					ir=-2;
+					return (ir);
+				}
+				fa = fap;
+				fun = w0+(w1+(w2+(w3+w4*fa)*fa)*fa)*fa;
+				fund = w1+(2.0*w2+(3.0*w3+4.0*w4*fa)*fa)*fa;
+				fap = fa-fun/fund;
+				del=fabs((fap-fa)/fa);
+			} while (del>acc);
+			
+			ir = ir+ii;
+			fa = fap;
+			ca = -(w16*fa*fa+w15*fa+w14)/(w13*fa+w12);
+			gMSAWave[14] = -(p1+p2*ca+p3*fa);
+			gMSAWave[15] = gMSAWave[14];
+			if (fabs(gMSAWave[15])<1.0e-3) {
+				gMSAWave[15] = 0.0;
+			}
+			gMSAWave[10] = gMSAWave[16];
+		} else {
+			ca = ak2*p1+2.0*(b3*p1-b1*p3);
+			ca = -ca/(ak2*p2+2.0*(b3*p2-b2*p3));
+			fa = -(p1+p2*ca)/p3;
+			if (ix==2) {
+				gMSAWave[15] = um1*ca*ca+(um2+um3*fa)*ca+um4+um5*fa+um6*fa*fa;
+			}
+			if (ix==4) {
+				gMSAWave[15] = -(p1+p2*ca+p3*fa);
+			}
+		}
+   		gMSAWave[3] = fa;
+		gMSAWave[2] = ca;
+		gMSAWave[1] = b1+b2*ca+b3*fa;
+		gMSAWave[0] = a1+a2*ca+a3*fa;
+		gMSAWave[8] = (v1+v2*ca+v3*fa)/gMSAWave[0];
+	}
+   	g24 = e24*rgek*ex1;
+	gMSAWave[7] = (rak*ak2*ca-g24)/(ak2*g24);
+	return (ir);
+}
+
+double
+sqhcal(double qq, double gMSAWave[])
+{      	
+    double SofQ,etaz,akz,gekz,e24,x1,x2,ck,sk,ak2,qk,q2k,qk2,qk3,qqk,sink,cosk,asink,qcosk,aqk,inter; 		
+	//	WAVE gMSAWave = $"root:HayPenMSA:gMSAWave"
+
+	etaz = gMSAWave[10];
+	akz =  gMSAWave[12];
+	gekz =  gMSAWave[11];
+	e24 = 24.0*etaz;
+	x1 = exp(akz);
+	x2 = 0.0;
+	if ( gMSAWave[12]<20.0) {
+		x2 = exp(-akz);
+	}
+	ck = 0.5*(x1+x2);
+	sk = 0.5*(x1-x2);
+	ak2 = akz*akz;
+	
+	qk = qq/gMSAWave[13];
+	q2k = qk*qk;
+	if (qk<=1.0e-08) {
+		SofQ = -1.0/gMSAWave[0];
+	} else {
+	// this rescales Q.sigma = 2.Q.Radius, so is hard to predict the value to test the function
+	if (qk<=0.01) {
+		// try Taylor series expansion at small qk (RKH Feb 2016, with help from Mathematica), 
+		// transition point may need to depend on precision of cpu used and ALAS on the values of some of the parameters !
+		// note have adsorbed a factor 24 from SofQ=
+		// needs thorough test over wide range of parameter space!
+		// there seem to be some rounding issues here in single precision, must use double
+		aqk = gMSAWave[0]*(8.0+2.0*etaz) + 6*gMSAWave[1] -12.0*gMSAWave[3] 
+			-24*(gekz*(1.0+akz) -ck*akz*gMSAWave[2] +gMSAWave[3]*(ck-1.0) +(gMSAWave[2]-gMSAWave[3]*akz)*sk )/ak2
+			+q2k*( -(gMSAWave[0]*(48.0+15.0*etaz) +40.0*gMSAWave[1])/60.0 +gMSAWave[3] 
+			+(4.0/ak2)*(gekz*(9.0+7.0*akz) +ck*(9.0*gMSAWave[3] -7.0*gMSAWave[2]*akz) +sk*(9.0*gMSAWave[2] -7.0*gMSAWave[3]*akz)) );
+		SofQ = 1.0/(1.0-gMSAWave[10]*aqk);
+	} else {
+		qk2 = 1.0/q2k;
+		qk3 = qk2/qk;
+		qqk = 1.0/(qk*(q2k+ak2));
+		SINCOS(qk,sink,cosk);
+		asink = akz*sink;
+		qcosk = qk*cosk;
+		aqk = gMSAWave[0]*(sink-qcosk);
+		aqk=aqk+gMSAWave[1]*((2.0*qk2-1.0)*qcosk+2.0*sink-2.0/qk);
+		inter=24.0*qk3+4.0*(1.0-6.0*qk2)*sink;
+		aqk=(aqk+0.5*etaz*gMSAWave[0]*(inter-(1.0-12.0*qk2+24.0*qk2*qk2)*qcosk))*qk3;
+		aqk=aqk +gMSAWave[2]*(ck*asink-sk*qcosk)*qqk;
+		aqk=aqk +gMSAWave[3]*(sk*asink-qk*(ck*cosk-1.0))*qqk;
+		aqk=aqk +gMSAWave[3]*(cosk-1.0)*qk2;
+		aqk=aqk -gekz*(asink+qcosk)*qqk;
+		SofQ = 1.0/(1.0  -e24*aqk);
+	} }
+	return (SofQ);
+}
+
+

--- a/mcstas-comps/share/sas_hollow_rectangular_prism.c
+++ b/mcstas-comps/share/sas_hollow_rectangular_prism.c
@@ -1,0 +1,738 @@
+#define HAS_Iqabc
+#define HAS_FQ
+#define FORM_VOL
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/gauss76.c"
+
+// Created by Andrew Jackson on 4/23/07
+
+ #ifdef GAUSS_N
+ # undef GAUSS_N
+ # undef GAUSS_Z
+ # undef GAUSS_W
+ #endif
+ #define GAUSS_N 76
+ #define GAUSS_Z Gauss76Z
+ #define GAUSS_W Gauss76Wt
+
+// Gaussians
+constant double Gauss76Wt[76] = {
+	.00126779163408536,		//0
+	.00294910295364247,
+	.00462793522803742,
+	.00629918049732845,
+	.00795984747723973,
+	.00960710541471375,
+	.0112381685696677,
+	.0128502838475101,
+	.0144407317482767,
+	.0160068299122486,
+	.0175459372914742,		//10
+	.0190554584671906,
+	.020532847967908,
+	.0219756145344162,
+	.0233813253070112,
+	.0247476099206597,
+	.026072164497986,
+	.0273527555318275,
+	.028587223650054,
+	.029773487255905,
+	.0309095460374916,		//20
+	.0319934843404216,
+	.0330234743977917,
+	.0339977794120564,
+	.0349147564835508,
+	.0357728593807139,
+	.0365706411473296,
+	.0373067565423816,
+	.0379799643084053,
+	.0385891292645067,
+	.0391332242205184,		//30
+	.0396113317090621,
+	.0400226455325968,
+	.040366472122844,
+	.0406422317102947,
+	.0408494593018285,
+	.040987805464794,
+	.0410570369162294,
+	.0410570369162294,
+	.040987805464794,
+	.0408494593018285,		//40
+	.0406422317102947,
+	.040366472122844,
+	.0400226455325968,
+	.0396113317090621,
+	.0391332242205184,
+	.0385891292645067,
+	.0379799643084053,
+	.0373067565423816,
+	.0365706411473296,
+	.0357728593807139,		//50
+	.0349147564835508,
+	.0339977794120564,
+	.0330234743977917,
+	.0319934843404216,
+	.0309095460374916,
+	.029773487255905,
+	.028587223650054,
+	.0273527555318275,
+	.026072164497986,
+	.0247476099206597,		//60
+	.0233813253070112,
+	.0219756145344162,
+	.020532847967908,
+	.0190554584671906,
+	.0175459372914742,
+	.0160068299122486,
+	.0144407317482767,
+	.0128502838475101,
+	.0112381685696677,
+	.00960710541471375,		//70
+	.00795984747723973,
+	.00629918049732845,
+	.00462793522803742,
+	.00294910295364247,
+	.00126779163408536		//75 (indexed from 0)
+};
+
+constant double Gauss76Z[76] = {
+	-.999505948362153,		//0
+	-.997397786355355,
+	-.993608772723527,
+	-.988144453359837,
+	-.981013938975656,
+	-.972229228520377,
+	-.961805126758768,
+	-.949759207710896,
+	-.936111781934811,
+	-.92088586125215,
+	-.904107119545567,		//10
+	-.885803849292083,
+	-.866006913771982,
+	-.844749694983342,
+	-.822068037328975,
+	-.7980001871612,
+	-.77258672828181,
+	-.74587051350361,
+	-.717896592387704,
+	-.688712135277641,
+	-.658366353758143,		//20
+	-.626910417672267,
+	-.594397368836793,
+	-.560882031601237,
+	-.526420920401243,
+	-.491072144462194,
+	-.454895309813726,
+	-.417951418780327,
+	-.380302767117504,
+	-.342012838966962,
+	-.303146199807908,		//30
+	-.263768387584994,
+	-.223945802196474,
+	-.183745593528914,
+	-.143235548227268,
+	-.102483975391227,
+	-.0615595913906112,
+	-.0205314039939986,
+	.0205314039939986,
+	.0615595913906112,
+	.102483975391227,			//40
+	.143235548227268,
+	.183745593528914,
+	.223945802196474,
+	.263768387584994,
+	.303146199807908,
+	.342012838966962,
+	.380302767117504,
+	.417951418780327,
+	.454895309813726,
+	.491072144462194,		//50
+	.526420920401243,
+	.560882031601237,
+	.594397368836793,
+	.626910417672267,
+	.658366353758143,
+	.688712135277641,
+	.717896592387704,
+	.74587051350361,
+	.77258672828181,
+	.7980001871612,	//60
+	.822068037328975,
+	.844749694983342,
+	.866006913771982,
+	.885803849292083,
+	.904107119545567,
+	.92088586125215,
+	.936111781934811,
+	.949759207710896,
+	.961805126758768,
+	.972229228520377,		//70
+	.981013938975656,
+	.988144453359837,
+	.993608772723527,
+	.997397786355355,
+	.999505948362153		//75
+};
+
+
+#pragma acc declare copyin(Gauss76Wt[0:76], Gauss76Z[0:76])
+
+#line 1 ".././models/hollow_rectangular_prism.c"
+
+static double
+shell_volume(double length_a, double b2a_ratio, double c2a_ratio, double thickness)
+{
+    const double length_b = length_a * b2a_ratio;
+    const double length_c = length_a * c2a_ratio;
+    const double form_volume = length_a * length_b * length_c;
+    const double a_core = length_a - 2.0*thickness;
+    const double b_core = length_b - 2.0*thickness;
+    const double c_core = length_c - 2.0*thickness;
+    const double core_volume = a_core * b_core * c_core;
+    return form_volume - core_volume;
+}
+
+static double
+form_volume(double length_a, double b2a_ratio, double c2a_ratio, double thickness)
+{
+    const double length_b = length_a * b2a_ratio;
+    const double length_c = length_a * c2a_ratio;
+    const double form_volume = length_a * length_b * length_c;
+    return form_volume;
+}
+
+static double
+radius_from_excluded_volume(double length_a, double b2a_ratio, double c2a_ratio)
+{
+    const double r_equiv = sqrt(length_a*length_a*b2a_ratio/M_PI);
+    const double length_c = length_a*c2a_ratio;
+    return 0.5*cbrt(0.75*r_equiv*(2.0*r_equiv*length_c + (r_equiv + length_c)*(M_PI*r_equiv + length_c)));
+}
+
+static double
+radius_effective(int mode, double length_a, double b2a_ratio, double c2a_ratio, double thickness)
+// NOTE length_a is external dimension!
+{
+    switch (mode) {
+    default:
+    case 1: // equivalent cylinder excluded volume
+        return radius_from_excluded_volume(length_a, b2a_ratio, c2a_ratio);
+    case 2: // equivalent outer volume sphere
+        return cbrt(cube(length_a)*b2a_ratio*c2a_ratio/M_4PI_3);
+    case 3: // half length_a
+        return 0.5 * length_a;
+    case 4: // half length_b
+        return 0.5 * length_a*b2a_ratio;
+    case 5: // half length_c
+        return 0.5 * length_a*c2a_ratio;
+    case 6: // equivalent outer circular cross-section
+        return length_a*sqrt(b2a_ratio/M_PI);
+    case 7: // half ab diagonal
+        return 0.5*sqrt(square(length_a) * (1.0 + square(b2a_ratio)));
+    case 8: // half diagonal
+        return 0.5*sqrt(square(length_a) * (1.0 + square(b2a_ratio) + square(c2a_ratio)));
+    }
+}
+
+static void
+Fq(double q,
+    double *F1,
+    double *F2,
+    double sld,
+    double solvent_sld,
+    double length_a,
+    double b2a_ratio,
+    double c2a_ratio,
+    double thickness)
+{
+    const double length_b = length_a * b2a_ratio;
+    const double length_c = length_a * c2a_ratio;
+    const double a_half = 0.5 * length_a;
+    const double b_half = 0.5 * length_b;
+    const double c_half = 0.5 * length_c;
+    const double vol_total = length_a * length_b * length_c;
+    const double vol_core = 8.0 * (a_half-thickness) * (b_half-thickness) * (c_half-thickness);
+
+    //Integration limits to use in Gaussian quadrature
+    const double v1a = 0.0;
+    const double v1b = M_PI_2;  //theta integration limits
+    const double v2a = 0.0;
+    const double v2b = M_PI_2;  //phi integration limits
+
+    double outer_sum_F1 = 0.0;
+    double outer_sum_F2 = 0.0;
+    for(int i=0; i<GAUSS_N; i++) {
+
+        const double theta = 0.5 * ( GAUSS_Z[i]*(v1b-v1a) + v1a + v1b );
+        double sin_theta, cos_theta;
+        SINCOS(theta, sin_theta, cos_theta);
+
+        const double termC1 = sas_sinx_x(q * c_half * cos(theta));
+        const double termC2 = sas_sinx_x(q * (c_half-thickness)*cos(theta));
+
+        double inner_sum_F1 = 0.0;
+        double inner_sum_F2 = 0.0;
+        for(int j=0; j<GAUSS_N; j++) {
+
+            const double phi = 0.5 * ( GAUSS_Z[j]*(v2b-v2a) + v2a + v2b );
+            double sin_phi, cos_phi;
+            SINCOS(phi, sin_phi, cos_phi);
+
+            // Amplitude AP from eqn. (13), rewritten to avoid round-off effects when arg=0
+
+            const double termA1 = sas_sinx_x(q * a_half * sin_theta * sin_phi);
+            const double termA2 = sas_sinx_x(q * (a_half-thickness) * sin_theta * sin_phi);
+
+            const double termB1 = sas_sinx_x(q * b_half * sin_theta * cos_phi);
+            const double termB2 = sas_sinx_x(q * (b_half-thickness) * sin_theta * cos_phi);
+
+            const double AP1 = vol_total * termA1 * termB1 * termC1;
+            const double AP2 = vol_core * termA2 * termB2 * termC2;
+
+            inner_sum_F1 += GAUSS_W[j] * (AP1-AP2);
+            inner_sum_F2 += GAUSS_W[j] * square(AP1-AP2);
+        }
+        inner_sum_F1 *= 0.5 * (v2b-v2a);
+        inner_sum_F2 *= 0.5 * (v2b-v2a);
+
+        outer_sum_F1 += GAUSS_W[i] * inner_sum_F1 * sin(theta);
+        outer_sum_F2 += GAUSS_W[i] * inner_sum_F2 * sin(theta);
+    }
+    outer_sum_F1 *= 0.5*(v1b-v1a);
+    outer_sum_F2 *= 0.5*(v1b-v1a);
+
+    // Normalize as in Eqn. (15) without the volume factor (as cancels with (V*DelRho)^2 normalization)
+    // The factor 2 is due to the different theta integration limit (pi/2 instead of pi)
+    const double form_avg = outer_sum_F1/M_PI_2;
+    const double form_squared_avg = outer_sum_F2/M_PI_2;
+
+    // Multiply by contrast^2. Factor corresponding to volume^2 cancels with previous normalization.
+    const double contrast = sld - solvent_sld;
+
+    // Convert from [1e-12 A-1] to [cm-1]
+    *F1 = 1.0e-2 * contrast * form_avg;
+    *F2 = 1.0e-4 * contrast * contrast * form_squared_avg;
+}
+
+static double
+Iqabc(double qa, double qb, double qc,
+    double sld,
+    double solvent_sld,
+    double length_a,
+    double b2a_ratio,
+    double c2a_ratio,
+    double thickness)
+{
+    const double length_b = length_a * b2a_ratio;
+    const double length_c = length_a * c2a_ratio;
+    const double a_half = 0.5 * length_a;
+    const double b_half = 0.5 * length_b;
+    const double c_half = 0.5 * length_c;
+    const double vol_total = length_a * length_b * length_c;
+    const double vol_core = 8.0 * (a_half-thickness) * (b_half-thickness) * (c_half-thickness);
+
+    // Amplitude AP from eqn. (13)
+
+    const double termA1 = sas_sinx_x(qa * a_half);
+    const double termA2 = sas_sinx_x(qa * (a_half-thickness));
+
+    const double termB1 = sas_sinx_x(qb * b_half);
+    const double termB2 = sas_sinx_x(qb * (b_half-thickness));
+
+    const double termC1 = sas_sinx_x(qc * c_half);
+    const double termC2 = sas_sinx_x(qc * (c_half-thickness));
+
+    const double AP1 = vol_total * termA1 * termB1 * termC1;
+    const double AP2 = vol_core * termA2 * termB2 * termC2;
+
+    // Multiply by contrast^2. Factor corresponding to volume^2 cancels with previous normalization.
+    const double delrho = sld - solvent_sld;
+
+    // Convert from [1e-12 A-1] to [cm-1]
+    return 1.0e-4 * square(delrho * (AP1-AP2));
+}
+
+

--- a/mcstas-comps/share/sas_hollow_rectangular_prism_thin_walls.c
+++ b/mcstas-comps/share/sas_hollow_rectangular_prism_thin_walls.c
@@ -1,0 +1,696 @@
+#define HAS_FQ
+#define FORM_VOL
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/gauss76.c"
+
+// Created by Andrew Jackson on 4/23/07
+
+ #ifdef GAUSS_N
+ # undef GAUSS_N
+ # undef GAUSS_Z
+ # undef GAUSS_W
+ #endif
+ #define GAUSS_N 76
+ #define GAUSS_Z Gauss76Z
+ #define GAUSS_W Gauss76Wt
+
+// Gaussians
+constant double Gauss76Wt[76] = {
+	.00126779163408536,		//0
+	.00294910295364247,
+	.00462793522803742,
+	.00629918049732845,
+	.00795984747723973,
+	.00960710541471375,
+	.0112381685696677,
+	.0128502838475101,
+	.0144407317482767,
+	.0160068299122486,
+	.0175459372914742,		//10
+	.0190554584671906,
+	.020532847967908,
+	.0219756145344162,
+	.0233813253070112,
+	.0247476099206597,
+	.026072164497986,
+	.0273527555318275,
+	.028587223650054,
+	.029773487255905,
+	.0309095460374916,		//20
+	.0319934843404216,
+	.0330234743977917,
+	.0339977794120564,
+	.0349147564835508,
+	.0357728593807139,
+	.0365706411473296,
+	.0373067565423816,
+	.0379799643084053,
+	.0385891292645067,
+	.0391332242205184,		//30
+	.0396113317090621,
+	.0400226455325968,
+	.040366472122844,
+	.0406422317102947,
+	.0408494593018285,
+	.040987805464794,
+	.0410570369162294,
+	.0410570369162294,
+	.040987805464794,
+	.0408494593018285,		//40
+	.0406422317102947,
+	.040366472122844,
+	.0400226455325968,
+	.0396113317090621,
+	.0391332242205184,
+	.0385891292645067,
+	.0379799643084053,
+	.0373067565423816,
+	.0365706411473296,
+	.0357728593807139,		//50
+	.0349147564835508,
+	.0339977794120564,
+	.0330234743977917,
+	.0319934843404216,
+	.0309095460374916,
+	.029773487255905,
+	.028587223650054,
+	.0273527555318275,
+	.026072164497986,
+	.0247476099206597,		//60
+	.0233813253070112,
+	.0219756145344162,
+	.020532847967908,
+	.0190554584671906,
+	.0175459372914742,
+	.0160068299122486,
+	.0144407317482767,
+	.0128502838475101,
+	.0112381685696677,
+	.00960710541471375,		//70
+	.00795984747723973,
+	.00629918049732845,
+	.00462793522803742,
+	.00294910295364247,
+	.00126779163408536		//75 (indexed from 0)
+};
+
+constant double Gauss76Z[76] = {
+	-.999505948362153,		//0
+	-.997397786355355,
+	-.993608772723527,
+	-.988144453359837,
+	-.981013938975656,
+	-.972229228520377,
+	-.961805126758768,
+	-.949759207710896,
+	-.936111781934811,
+	-.92088586125215,
+	-.904107119545567,		//10
+	-.885803849292083,
+	-.866006913771982,
+	-.844749694983342,
+	-.822068037328975,
+	-.7980001871612,
+	-.77258672828181,
+	-.74587051350361,
+	-.717896592387704,
+	-.688712135277641,
+	-.658366353758143,		//20
+	-.626910417672267,
+	-.594397368836793,
+	-.560882031601237,
+	-.526420920401243,
+	-.491072144462194,
+	-.454895309813726,
+	-.417951418780327,
+	-.380302767117504,
+	-.342012838966962,
+	-.303146199807908,		//30
+	-.263768387584994,
+	-.223945802196474,
+	-.183745593528914,
+	-.143235548227268,
+	-.102483975391227,
+	-.0615595913906112,
+	-.0205314039939986,
+	.0205314039939986,
+	.0615595913906112,
+	.102483975391227,			//40
+	.143235548227268,
+	.183745593528914,
+	.223945802196474,
+	.263768387584994,
+	.303146199807908,
+	.342012838966962,
+	.380302767117504,
+	.417951418780327,
+	.454895309813726,
+	.491072144462194,		//50
+	.526420920401243,
+	.560882031601237,
+	.594397368836793,
+	.626910417672267,
+	.658366353758143,
+	.688712135277641,
+	.717896592387704,
+	.74587051350361,
+	.77258672828181,
+	.7980001871612,	//60
+	.822068037328975,
+	.844749694983342,
+	.866006913771982,
+	.885803849292083,
+	.904107119545567,
+	.92088586125215,
+	.936111781934811,
+	.949759207710896,
+	.961805126758768,
+	.972229228520377,		//70
+	.981013938975656,
+	.988144453359837,
+	.993608772723527,
+	.997397786355355,
+	.999505948362153		//75
+};
+
+
+#pragma acc declare copyin(Gauss76Wt[0:76], Gauss76Z[0:76])
+
+#line 1 ".././models/hollow_rectangular_prism_thin_walls.c"
+
+static double
+shell_volume(double length_a, double b2a_ratio, double c2a_ratio)
+{
+    const double length_b = length_a * b2a_ratio;
+    const double length_c = length_a * c2a_ratio;
+    const double shell_volume = 2.0 * (length_a*length_b + length_a*length_c + length_b*length_c);
+    return shell_volume;
+}
+
+static double
+form_volume(double length_a, double b2a_ratio, double c2a_ratio)
+{
+    const double length_b = length_a * b2a_ratio;
+    const double length_c = length_a * c2a_ratio;
+    const double form_volume = length_a * length_b * length_c;
+    return form_volume;
+}
+
+static double
+radius_from_excluded_volume(double length_a, double b2a_ratio, double c2a_ratio)
+{
+    const double r_equiv = sqrt(length_a*length_a*b2a_ratio/M_PI);
+    const double length_c = length_a*c2a_ratio;
+    return 0.5*cbrt(0.75*r_equiv*(2.0*r_equiv*length_c + (r_equiv + length_c)*(M_PI*r_equiv + length_c)));
+}
+
+static double
+radius_effective(int mode, double length_a, double b2a_ratio, double c2a_ratio)
+{
+    switch (mode) {
+    default:
+    case 1: // equivalent cylinder excluded volume
+        return radius_from_excluded_volume(length_a, b2a_ratio, c2a_ratio);
+    case 2: // equivalent outer volume sphere
+        return cbrt(cube(length_a)*b2a_ratio*c2a_ratio/M_4PI_3);
+    case 3: // half length_a
+        return 0.5 * length_a;
+    case 4: // half length_b
+        return 0.5 * length_a*b2a_ratio;
+    case 5: // half length_c
+        return 0.5 * length_a*c2a_ratio;
+    case 6: // equivalent outer circular cross-section
+        return length_a*sqrt(b2a_ratio/M_PI);
+    case 7: // half ab diagonal
+        return 0.5*sqrt(square(length_a) * (1.0 + square(b2a_ratio)));
+    case 8: // half diagonal
+        return 0.5*sqrt(square(length_a) * (1.0 + square(b2a_ratio) + square(c2a_ratio)));
+    }
+}
+
+static void
+Fq(double q,
+    double *F1,
+    double *F2,
+    double sld,
+    double solvent_sld,
+    double length_a,
+    double b2a_ratio,
+    double c2a_ratio)
+{
+    const double length_b = length_a * b2a_ratio;
+    const double length_c = length_a * c2a_ratio;
+    const double a_half = 0.5 * length_a;
+    const double b_half = 0.5 * length_b;
+    const double c_half = 0.5 * length_c;
+
+   //Integration limits to use in Gaussian quadrature
+    const double v1a = 0.0;
+    const double v1b = M_PI_2;  //theta integration limits
+    const double v2a = 0.0;
+    const double v2b = M_PI_2;  //phi integration limits
+
+    double outer_sum_F1 = 0.0;
+    double outer_sum_F2 = 0.0;
+    for(int i=0; i<GAUSS_N; i++) {
+        const double theta = 0.5 * ( GAUSS_Z[i]*(v1b-v1a) + v1a + v1b );
+
+        double sin_theta, cos_theta;
+        double sin_c, cos_c;
+        SINCOS(theta, sin_theta, cos_theta);
+        SINCOS(q*c_half*cos_theta, sin_c, cos_c);
+
+        // To check potential problems if denominator goes to zero here !!!
+        const double termAL_theta = 8.0 * cos_c / (q*q*sin_theta*sin_theta);
+        const double termAT_theta = 8.0 * sin_c / (q*q*sin_theta*cos_theta);
+
+        double inner_sum_F1 = 0.0;
+        double inner_sum_F2 = 0.0;
+        for(int j=0; j<GAUSS_N; j++) {
+            const double phi = 0.5 * ( GAUSS_Z[j]*(v2b-v2a) + v2a + v2b );
+
+            double sin_phi, cos_phi;
+            double sin_a, cos_a;
+            double sin_b, cos_b;
+            SINCOS(phi, sin_phi, cos_phi);
+            SINCOS(q*a_half*sin_theta*sin_phi, sin_a, cos_a);
+            SINCOS(q*b_half*sin_theta*cos_phi, sin_b, cos_b);
+
+            // Amplitude AL from eqn. (7c)
+            const double AL = termAL_theta
+                * sin_a*sin_b / (sin_phi*cos_phi);
+
+            // Amplitude AT from eqn. (9)
+            const double AT = termAT_theta
+                * ( cos_a*sin_b/cos_phi + cos_b*sin_a/sin_phi );
+
+            inner_sum_F1 += GAUSS_W[j] * (AL+AT);
+            inner_sum_F2 += GAUSS_W[j] * square(AL+AT);
+        }
+
+        inner_sum_F1 *= 0.5 * (v2b-v2a);
+        inner_sum_F2 *= 0.5 * (v2b-v2a);
+        outer_sum_F1 += GAUSS_W[i] * inner_sum_F1 * sin_theta;
+        outer_sum_F2 += GAUSS_W[i] * inner_sum_F2 * sin_theta;
+    }
+
+    outer_sum_F1 *= 0.5*(v1b-v1a);
+    outer_sum_F2 *= 0.5*(v1b-v1a);
+
+    // Normalize as in Eqn. (15) without the volume factor (as cancels with (V*DelRho)^2 normalization)
+    // The factor 2 is due to the different theta integration limit (pi/2 instead of pi)
+    const double form_avg = outer_sum_F1/M_PI_2;
+    const double form_squared_avg = outer_sum_F2/M_PI_2;
+
+    // Multiply by contrast^2. Factor corresponding to volume^2 cancels with previous normalization.
+    const double contrast = sld - solvent_sld;
+
+    // Convert from [1e-12 A-1] to [cm-1]
+    *F1 = 1e-2 * contrast * form_avg;
+    *F2 = 1e-4 * contrast * contrast * form_squared_avg;
+}
+
+

--- a/mcstas-comps/share/sas_lamellar_hg.c
+++ b/mcstas-comps/share/sas_lamellar_hg.c
@@ -1,0 +1,406 @@
+#define HAS_Iq
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lamellar_hg.c"
+
+double Iq(double q, double length_tail, double length_head, double sld, double sld_head, double sld_solvent)
+{
+    const double qsq = q*q;
+    const double drh = sld_head - sld_solvent;
+    const double drt = sld - sld_solvent;    //correction 13FEB06 by L.Porcar
+    const double qT = q*length_tail;
+    double Pq, inten;
+    Pq = drh*(sin(q*(length_head+length_tail))-sin(qT)) + drt*sin(qT);
+    Pq *= Pq;
+    Pq *= 4.0/(qsq);
+
+    inten = 2.0e-4*M_PI*Pq/qsq;
+
+    // normalize by the bilayer thickness
+    inten /= 2.0*(length_head+length_tail);
+
+    return inten;
+}
+

--- a/mcstas-comps/share/sas_lamellar_hg_stack_caille.c
+++ b/mcstas-comps/share/sas_lamellar_hg_stack_caille.c
@@ -1,0 +1,446 @@
+#define HAS_Iq
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lamellar_hg_stack_caille.c"
+
+/*	LamellarCailleHG kernel - allows for name changes of passed parameters ...
+    Maths identical to LamellarCaille apart from the line for P(Q)
+*/
+
+static double
+Iq(double qval,
+   double length_tail,
+   double length_head,
+   double fp_Nlayers,
+   double dd,
+   double Cp,
+   double tail_sld,
+   double head_sld,
+   double solvent_sld)
+{
+  int Nlayers = (int)(fp_Nlayers+0.5);    //cast to an integer for the loop
+  double inten,Pq,Sq,alpha,temp,t2;
+  //double dQ, dQDefault, t1, t3;
+  // from wikipedia 0.577215664901532860606512090082402431042159335
+  const double Euler = 0.577215664901533;   // Euler's constant, increased sig figs for new models Feb 2015
+  //dQDefault = 0.0;    //[=] 1/A, q-resolution, default value
+  //dQ = dQDefault; // REMOVED UNUSED dQ calculations for new models Feb 2015
+
+  Pq = (head_sld-solvent_sld)*(sin(qval*(length_head+length_tail))-sin(qval*length_tail))
+       + (tail_sld-solvent_sld)*sin(qval*length_tail);
+  Pq *= Pq;
+  Pq *= 4.0/(qval*qval);
+
+  Sq = 0.0;
+  for(int ii=1; ii < Nlayers; ii++) {
+    temp = 0.0;
+    alpha = Cp/4.0/M_PI/M_PI*(log(M_PI*ii) + Euler);
+    //t1 = 2.0*dQ*dQ*dd*dd*alpha;
+    t2 = 2.0*qval*qval*dd*dd*alpha;
+    //t3 = dQ*dQ*dd*dd*ii*ii;
+
+    temp = 1.0-(double)ii/(double)Nlayers;
+    //temp *= cos(dd*qval*ii/(1.0+t1));
+    temp *= cos(dd*qval*ii);
+    //if (temp < 0) printf("q=%g: ii=%d, cos(dd*q*ii)=cos(%g) < 0\n",qval,ii,dd*qval*ii);
+    //temp *= exp(-1.0*(t2 + t3)/(2.0*(1.0+t1)) );
+    temp *= exp(-t2/2.0);
+    //temp /= sqrt(1.0+t1);
+
+    Sq += temp;
+  }
+
+  Sq *= 2.0;
+  Sq += 1.0;
+
+  //if (Sq < 0) printf("q=%g: S(q) =%g\n", qval, Sq);
+
+  inten = 2.0*M_PI*Pq*Sq/(dd*qval*qval);
+
+  inten *= 1.0e-04;   // 1/A to 1/cm
+  return inten;
+}
+
+

--- a/mcstas-comps/share/sas_lamellar_stack_caille.c
+++ b/mcstas-comps/share/sas_lamellar_stack_caille.c
@@ -1,0 +1,442 @@
+#define HAS_Iq
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lamellar_stack_caille.c"
+
+/*	LamellarCaille kernel - allows for name changes of passed parameters ...
+
+*/
+
+static double
+Iq(double qval,
+   double del,
+   double fp_Nlayers,
+   double dd,
+   double Cp,
+   double sld,
+   double solvent_sld)
+{
+  int Nlayers = (int)(fp_Nlayers+0.5);    //cast to an integer for the loop
+  double contr;   //local variables of coefficient wave
+  double inten,Pq,Sq,alpha,temp,t2;
+  //double dQ, dQDefault, t1, t3;
+  // from wikipedia 0.577215664901532860606512090082402431042159335
+  const double Euler = 0.577215664901533;   // Euler's constant, increased sig figs for new models Feb 2015
+  //dQDefault = 0.0;    //[=] 1/A, q-resolution, default value
+  //dQ = dQDefault; // REMOVED UNUSED dQ calculations for new models Feb 2015
+
+  contr = sld - solvent_sld;
+
+  Pq = 2.0*contr*contr/qval/qval*(1.0-cos(qval*del));
+
+  Sq = 0.0;
+  for (int ii=1; ii < Nlayers; ii++) {
+    temp = 0.0;
+    alpha = Cp/4.0/M_PI/M_PI*(log(M_PI*ii) + Euler);
+    //t1 = 2.0*dQ*dQ*dd*dd*alpha;
+    t2 = 2.0*qval*qval*dd*dd*alpha;
+    //t3 = dQ*dQ*dd*dd*ii*ii;
+
+    temp = 1.0 - (double)ii / (double)Nlayers;
+    //temp *= cos(dd*qval*ii/(1.0+t1));
+    temp *= cos(dd*qval*ii);
+    //temp *= exp(-1.0*(t2 + t3)/(2.0*(1.0+t1)) );
+    temp *= exp(-t2/2.0);
+    //temp /= sqrt(1.0+t1);
+
+    Sq += temp;
+  }
+
+  Sq *= 2.0;
+  Sq += 1.0;
+
+  inten = 2.0*M_PI*Pq*Sq/(dd*qval*qval);
+
+  inten *= 1.0e-04;   // 1/A to 1/cm
+
+  return(inten);
+}
+
+

--- a/mcstas-comps/share/sas_lamellar_stack_paracrystal.c
+++ b/mcstas-comps/share/sas_lamellar_stack_paracrystal.c
@@ -1,0 +1,462 @@
+#define HAS_Iq
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lamellar_stack_paracrystal.c"
+
+/*	Lamellar_ParaCrystal - Pedersen's model
+
+*/
+double paraCryst_sn(double ww, double qval, double davg, int Nlayers, double an);
+double paraCryst_an(double ww, double qval, double davg, int Nlayers);
+
+static double
+Iq(double qval,
+   double th,
+   double fp_Nlayers,
+   double davg,
+   double pd,
+   double sld,
+   double solvent_sld)
+{
+	//get the fractional part of Nlayers, to determine the "mixing" of N's
+	int n1 = (int)(fp_Nlayers);		//truncate towards zero
+	int n2 = n1 + 1;
+	const double xn = (double)n2 - fp_Nlayers;	//fractional contribution of n1
+
+	const double ww = exp(-0.5*square(qval*pd*davg));
+
+	//calculate the n1 contribution
+	double Znq,Snq,an;
+	an = paraCryst_an(ww,qval,davg,n1);
+	Snq = paraCryst_sn(ww,qval,davg,n1,an);
+
+	Znq = xn*Snq;
+
+	//calculate the n2 contribution
+	an = paraCryst_an(ww,qval,davg,n2);
+	Snq = paraCryst_sn(ww,qval,davg,n2,an);
+
+	Znq += (1.0-xn)*Snq;
+
+	//and the independent contribution
+	Znq += (1.0-ww*ww)/(1.0+ww*ww-2.0*ww*cos(qval*davg));
+
+	//the limit when Nlayers approaches infinity
+//	Zq = (1-ww^2)/(1+ww^2-2*ww*cos(qval*davg))
+
+	const double xi = th/2.0;		//use 1/2 the bilayer thickness
+	const double Pbil = square(sas_sinx_x(qval*xi));
+
+	const double contr = sld - solvent_sld;
+	const double inten = 2.0*M_PI*contr*contr*Pbil*Znq/(qval*qval);
+//printf("q=%.7e wwm1=%g ww=%.5e an=% 12.5e Snq=% 12.5e Znq=% 12.5e Pbil=% 12.5e\n",qval,wwm1,ww,an,Snq,Znq,Pbil);
+	return 1.0e-4*inten;
+}
+
+// functions for the lamellar paracrystal model
+double
+paraCryst_sn(double ww, double qval, double davg, int Nlayers, double an) {
+
+	double Snq;
+
+	Snq = an/( (double)Nlayers*square(1.0+ww*ww-2.0*ww*cos(qval*davg)) );
+
+	return Snq;
+}
+
+double
+paraCryst_an(double ww, double qval, double davg, int Nlayers) {
+	double an;
+
+	an = 4.0*ww*ww - 2.0*(ww*ww*ww+ww)*cos(qval*davg);
+	an -= 4.0*pow(ww,(Nlayers+2))*cos((double)Nlayers*qval*davg);
+	an += 2.0*pow(ww,(Nlayers+3))*cos((double)(Nlayers-1)*qval*davg);
+	an += 2.0*pow(ww,(Nlayers+1))*cos((double)(Nlayers+1)*qval*davg);
+
+	return an;
+}
+
+
+

--- a/mcstas-comps/share/sas_line.c
+++ b/mcstas-comps/share/sas_line.c
@@ -1,0 +1,399 @@
+#define HAS_Iq
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/line.c"
+
+#include <math.h>
+
+double Iq(double q, double intercept, double slope);
+
+#pragma acc routine seq
+double Iq(double q, double intercept, double slope) {
+    double inten = intercept + slope * q;
+    return inten;
+}
+
+
+

--- a/mcstas-comps/share/sas_linear_pearls.c
+++ b/mcstas-comps/share/sas_linear_pearls.c
@@ -1,205 +1,520 @@
-// GENERATED CODE --- DO NOT EDIT ---
-// Code is produced by sasmodels.gen from sasmodels/models/MODEL.c
+#define HAS_Iq
+#define FORM_VOL
+#line 1 "../kernel_header.c"
 
 #ifdef __OPENCL_VERSION__
 # define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
 #endif
 
-#define USE_KAHAN_SUMMATION 0
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
 
 // If opencl is not available, then we are compiling a C function
 // Note: if using a C++ compiler, then define kernel as extern "C"
-#ifndef USE_OPENCL
-#  ifdef __cplusplus
-     #include <cstdio>
-     #include <cmath>
-     using namespace std;
-     #if defined(_MSC_VER)
-     #   define kernel extern "C" __declspec( dllexport )
-         inline float trunc(float x) { return x>=0?floor(x):-floor(-x); }
-	 inline float fmin(float x, float y) { return x>y ? y : x; }
-	 inline float fmax(float x, float y) { return x<y ? y : x; }
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
      #else
-     #   define kernel extern "C"
+         #define kernel extern "C"
+         #include <cstdint>
      #endif
-     inline void SINCOS(float angle, float &svar, float &cvar) { svar=sin(angle); cvar=cos(angle); }
-#  else
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
      #include <stdio.h>
-     #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
      // MSVC doesn't support C99, so no need for dllexport on C99 branch
      #define kernel
-     #define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
-#  define global
-#  define local
-#  define constant const
-// OpenCL powr(a,b) = C99 pow(a,b), b >= 0
-// OpenCL pown(a,b) = C99 pow(a,b), b integer
-#  define powr(a,b) pow(a,b)
-#  define pown(a,b) pow(a,b)
-#else
-#  ifdef USE_SINCOS
-#    define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
-#  else
-#    define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
 #endif
 
 // Standard mathematical constants:
 //   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
 //   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
-// OpenCL defines M_constant_F for float constants, and nothing if float
+// OpenCL defines M_constant_F for float constants, and nothing if double
 // is not enabled on the card, which is why these constants may be missing
 #ifndef M_PI
-#  define M_PI 3.141592653589793f
+#  define M_PI 3.141592653589793
 #endif
 #ifndef M_PI_2
-#  define M_PI_2 1.570796326794897f
+#  define M_PI_2 1.570796326794897
 #endif
 #ifndef M_PI_4
-#  define M_PI_4 0.7853981633974483f
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
 #endif
 
-// Non-standard pi/180, used for converting between degrees and radians
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
 #ifndef M_PI_180
-#  define M_PI_180 0.017453292519943295f
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
 #endif
 
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
 
-#define IQ_KERNEL_NAME linear_pearls_Iq
-#define IQ_PARAMETERS radius, edge_sep, num_pearls, pearl_sld, solvent_sld
-#define IQ_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float radius, \
-    const float edge_sep, \
-    const float num_pearls, \
-    const float pearl_sld, \
-    const float solvent_sld
-#define IQXY_KERNEL_NAME linear_pearls_Iqxy
-#define IQXY_PARAMETERS radius, edge_sep, num_pearls, pearl_sld, solvent_sld
-#define IQXY_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float radius, \
-    const float edge_sep, \
-    const float num_pearls, \
-    const float pearl_sld, \
-    const float solvent_sld
+//# Beginning of rotational operation definitions
 
-float form_volume(float radius, float num_pearls);
+typedef struct {
+          double R31, R32;
+      } QACRotation;
 
-float Iq(float q,
-            float radius,
-            float edge_sep,
-            float num_pearls,
-            float pearl_sld,
-            float solvent_sld);
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
 
-float Iqxy(float qx, float qy,
-            float radius,
-            float edge_sep,
-            float num_pearls,
-            float pearl_sld,
-            float solvent_sld);
-
-float linear_pearls_kernel(float q,
-            float radius,
-            float edge_sep,
-            float num_pearls,
-            float pearl_sld,
-            float solvent_sld);
-
-
-float form_volume(float radius, float num_pearls)
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
 {
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/sas_3j1x_x.c"
+
+/**
+* Spherical Bessel function 3*j1(x)/x
+*
+* Used for low q to avoid cancellation error.
+* Note that the values differ from sasview ~ 5e-12 rather than 5e-14, but
+* in this case it is likely cancellation errors in the original expression
+* using double precision that are the source.
+*/
+double sas_3j1x_x(double q);
+
+// The choice of the number of terms in the series and the cutoff value for
+// switching between series and direct calculation depends on the numeric
+// precision.
+//
+// Point where direct calculation reaches machine precision:
+//
+//   single machine precision eps 3e-8 at qr=1.1 **
+//   double machine precision eps 4e-16 at qr=1.1
+//
+// Point where Taylor series reaches machine precision (eps), where taylor
+// series matches direct calculation (cross) and the error at that point:
+//
+//   prec   n eps  cross  error
+//   single 3 0.28  0.4   6.2e-7
+//   single 4 0.68  0.7   2.3e-7
+//   single 5 1.18  1.2   7.5e-8
+//   double 3 0.01  0.03  2.3e-13
+//   double 4 0.06  0.1   3.1e-14
+//   double 5 0.16  0.2   5.0e-15
+//
+// ** Note: relative error on single precision starts increase on the direct
+// method at qr=1.1, rising from 3e-8 to 5e-5 by qr=1e3.  This should be
+// safe for the sans range, with objects of 100 nm supported to a q of 0.1
+// while maintaining 5 digits of precision.  For usans/sesans, the objects
+// are larger but the q is smaller, so again it should be fine.
+//
+// See explore/sph_j1c.py for code to explore these ranges.
+
+// Use 4th order series
+#if FLOAT_SIZE>4
+#define SPH_J1C_CUTOFF 0.1
+#else
+#define SPH_J1C_CUTOFF 0.7
+#endif
+#pragma acc routine seq
+double sas_3j1x_x(double q)
+{
+    // 2017-05-18 PAK - support negative q
+    if (fabs(q) < SPH_J1C_CUTOFF) {
+        const double q2 = q*q;
+        return (1.0 + q2*(-3./30. + q2*(3./840. + q2*(-3./45360.))));// + q2*(3./3991680.)))));
+    } else {
+        double sin_q, cos_q;
+        SINCOS(q, sin_q, cos_q);
+        return 3.0*(sin_q/q - cos_q)/(q*q);
+    }
+}
+
+
+#line 1 ".././models/linear_pearls.c"
+
+double form_volume(double radius, double num_pearls);
+
+double Iq(double q,
+            double radius,
+            double edge_sep,
+            double fp_num_pearls,
+            double pearl_sld,
+            double solvent_sld);
+
+double linear_pearls_kernel(double q,
+            double radius,
+            double edge_sep,
+            int num_pearls,
+            double pearl_sld,
+            double solvent_sld);
+
+
+double form_volume(double radius, double fp_num_pearls)
+{
+    int num_pearls = (int)(fp_num_pearls + 0.5);
     // Pearl volume
-    float pearl_vol = 4.0f /3.0f * M_PI * pow(radius, 3.0f);
+    double pearl_vol = M_4PI_3 * cube(radius);
     // Return total volume
     return num_pearls * pearl_vol;;
 }
 
-// If used elsewhere - factor out to lib/
-static
-float sinc(float x)
+double linear_pearls_kernel(double q,
+            double radius,
+            double edge_sep,
+            int num_pearls,
+            double pearl_sld,
+            double solvent_sld)
 {
-  if (x==0.0f){
-    return 1.0f;
-  }
-  return sin(x)/x;
-}
-
-float linear_pearls_kernel(float q,
-            float radius,
-            float edge_sep,
-            float num_pearls,
-            float pearl_sld,
-            float solvent_sld)
-{
-    float n_contrib;
     //relative sld
-    float contrast_pearl = pearl_sld - solvent_sld;
+    double contrast_pearl = pearl_sld - solvent_sld;
     //each volume
-    float pearl_vol = 4.0f /3.0f * M_PI * pow(radius, 3.0f);
+    double pearl_vol = M_4PI_3 * cube(radius);
     //total volume
-    float tot_vol = num_pearls * pearl_vol;
+    double tot_vol = num_pearls * pearl_vol;
     //mass
-    float m_s = contrast_pearl * pearl_vol;
+    double m_s = contrast_pearl * pearl_vol;
     //center to center distance between the neighboring pearls
-    float separation = edge_sep + 2.0f * radius;
-
-    float x=q*radius;
-
-    // Try Taylor on x*xos(x)
-	// float out_cos = x - pow(x,3)/2 + pow(x,5)/24 - pow(x,7)/720 + pow(x,9)/40320;
-    // psi -= x*out_cos;
+    double separation = edge_sep + 2.0 * radius;
 
     //sine functions of a pearl
-    float psi = sin(q * radius);
-    psi -= x * cos(x);
-    psi /= pow((q * radius), 3.0f);
+    double psi = sas_3j1x_x(q * radius);
 
-    // N pearls contribution
-    int n_max = num_pearls - 1;
-    n_contrib = num_pearls;
-    for(int num=1; num<=n_max; num++) {
-        n_contrib += (2.0f*(num_pearls-num)*sinc(q*separation*num));
+    // N pearls interaction terms
+    double structure_factor = (double)num_pearls;
+    for(int num=1; num<num_pearls; num++) {
+        structure_factor += 2.0*(num_pearls-num)*sas_sinx_x(q*separation*num);
     }
     // form factor for num_pearls
-    float form_factor = n_contrib;
-    form_factor *= pow((m_s*psi*3.0f), 2.0f);
-    form_factor /= (tot_vol * 1.0e4f);
+    double form_factor = 1.0e-4 * structure_factor * square(m_s*psi) / tot_vol;
 
     return form_factor;
 }
 
-float Iq(float q,
-            float radius,
-            float edge_sep,
-            float num_pearls,
-            float pearl_sld,
-            float solvent_sld)
+double Iq(double q,
+            double radius,
+            double edge_sep,
+            double fp_num_pearls,
+            double pearl_sld,
+            double solvent_sld)
 {
 
-	float result = linear_pearls_kernel(q,
-                    radius,
-                    edge_sep,
-                    num_pearls,
-                    pearl_sld,
-                    solvent_sld);
-
-	return result;
-}
-
-float Iqxy(float qx, float qy,
-            float radius,
-            float edge_sep,
-            float num_pearls,
-            float pearl_sld,
-            float solvent_sld)
-{
-	float q;
-	q = sqrt(qx*qx+qy*qy);
-
-	float result = linear_pearls_kernel(q,
+    int num_pearls = (int)(fp_num_pearls + 0.5);
+	double result = linear_pearls_kernel(q,
                     radius,
                     edge_sep,
                     num_pearls,
@@ -210,182 +525,3 @@ float Iqxy(float qx, float qy,
 }
 
 
-/*
-    ##########################################################
-    #                                                        #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #   !!                                              !!   #
-    #   !!  KEEP THIS CODE CONSISTENT WITH KERNELPY.PY  !!   #
-    #   !!                                              !!   #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #                                                        #
-    ##########################################################
-*/
-
-#ifdef IQ_KERNEL_NAME
-kernel void IQ_KERNEL_NAME(
-    global const float *q,
-    global float *result,
-    const int Nq,
-#ifdef IQ_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQ_DISPERSION_LENGTH_DECLARATIONS,
-#endif
-    IQ_FIXED_PARAMETER_DECLARATIONS
-    )
-{
-#ifdef USE_OPENCL
-  #ifdef IQ_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQ_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
-
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qi = q[i];
-#ifdef IQ_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-  #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-  #endif
-    IQ_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
-
-    const float weight = IQ_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-      const float scattering = Iq(qi, IQ_PARAMETERS);
-      // allow kernels to exclude invalid regions by returning NaN
-      if (!isnan(scattering)) {
-        ret += weight*scattering;
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-        norm_vol += vol_weight;
-      #endif
-      }
-    //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
-    }
-    IQ_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iq(qi, IQ_PARAMETERS) + background;
-#endif
-  }
-}
-#endif
-
-
-#ifdef IQXY_KERNEL_NAME
-kernel void IQXY_KERNEL_NAME(
-    global const float *qx,
-    global const float *qy,
-    global float *result,
-    const int Nq,
-#ifdef IQXY_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQXY_DISPERSION_LENGTH_DECLARATIONS,
-#endif
-    IQXY_FIXED_PARAMETER_DECLARATIONS
-    )
-{
-#ifdef USE_OPENCL
-  #ifdef IQXY_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQXY_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
-
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qxi = qx[i];
-    const float qyi = qy[i];
-    #if USE_KAHAN_SUMMATION
-    float accumulated_error = 0.0f;
-    #endif
-#ifdef IQXY_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-    #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-    #endif
-    IQXY_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
-
-    const float weight = IQXY_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-
-      const float scattering = Iqxy(qxi, qyi, IQXY_PARAMETERS);
-      if (!isnan(scattering)) { // if scattering is bad, exclude it from sum
-      //if (scattering >= 0.0f) { // scattering cannot be negative
-        // TODO: use correct angle for spherical correction
-        // Definition of theta and phi are probably reversed relative to the
-        // equation which gave rise to this correction, leading to an
-        // attenuation of the pattern as theta moves through pi/2.f  Either
-        // reverse the meanings of phi and theta in the forms, or use phi
-        // rather than theta in this correction.  Current code uses cos(theta)
-        // so that values match those of sasview.
-      #if defined(IQXY_HAS_THETA) // && 0
-        const float spherical_correction
-          = (Ntheta>1 ? fabs(cos(M_PI_180*theta))*M_PI_2:1.0f);
-        const float next = spherical_correction * weight * scattering;
-      #else
-        const float next = weight * scattering;
-      #endif
-      #if USE_KAHAN_SUMMATION
-        const float y = next - accumulated_error;
-        const float t = ret + y;
-        accumulated_error = (t - ret) - y;
-        ret = t;
-      #else
-        ret += next;
-      #endif
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-      #endif
-        norm_vol += vol_weight;
-      }
-      //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
-    }
-    IQXY_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iqxy(qxi, qyi, IQXY_PARAMETERS) + background;
-#endif
-  }
-}
-#endif

--- a/mcstas-comps/share/sas_lorentz.c
+++ b/mcstas-comps/share/sas_lorentz.c
@@ -1,277 +1,393 @@
-// GENERATED CODE --- DO NOT EDIT ---
-// Code is produced by sasmodels.gen from sasmodels/models/MODEL.c
+#define HAS_Iq
+#line 1 "../kernel_header.c"
 
 #ifdef __OPENCL_VERSION__
 # define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
 #endif
 
-#define USE_KAHAN_SUMMATION 0
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
 
 // If opencl is not available, then we are compiling a C function
 // Note: if using a C++ compiler, then define kernel as extern "C"
-#ifndef USE_OPENCL
-#  ifdef __cplusplus
-     #include <cstdio>
-     #include <cmath>
-     using namespace std;
-     #if defined(_MSC_VER)
-     #   define kernel extern "C" __declspec( dllexport )
-         inline float trunc(float x) { return x>=0?floor(x):-floor(-x); }
-	 inline float fmin(float x, float y) { return x>y ? y : x; }
-	 inline float fmax(float x, float y) { return x<y ? y : x; }
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
      #else
-     #   define kernel extern "C"
+         #define kernel extern "C"
+         #include <cstdint>
      #endif
-     inline void SINCOS(float angle, float &svar, float &cvar) { svar=sin(angle); cvar=cos(angle); }
-#  else
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
      #include <stdio.h>
-     #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
      // MSVC doesn't support C99, so no need for dllexport on C99 branch
      #define kernel
-     #define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
-#  define global
-#  define local
-#  define constant const
-// OpenCL powr(a,b) = C99 pow(a,b), b >= 0
-// OpenCL pown(a,b) = C99 pow(a,b), b integer
-#  define powr(a,b) pow(a,b)
-#  define pown(a,b) pow(a,b)
-#else
-#  ifdef USE_SINCOS
-#    define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
-#  else
-#    define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
 #endif
 
 // Standard mathematical constants:
 //   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
 //   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
-// OpenCL defines M_constant_F for float constants, and nothing if float
+// OpenCL defines M_constant_F for float constants, and nothing if double
 // is not enabled on the card, which is why these constants may be missing
 #ifndef M_PI
-#  define M_PI 3.141592653589793f
+#  define M_PI 3.141592653589793
 #endif
 #ifndef M_PI_2
-#  define M_PI_2 1.570796326794897f
+#  define M_PI_2 1.570796326794897
 #endif
 #ifndef M_PI_4
-#  define M_PI_4 0.7853981633974483f
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
 #endif
 
-// Non-standard pi/180, used for converting between degrees and radians
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
 #ifndef M_PI_180
-#  define M_PI_180 0.017453292519943295f
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
 #endif
 
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
 
-#define IQ_KERNEL_NAME lorentz_Iq
-#define IQ_PARAMETERS cor_length
-#define IQ_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float cor_length
-#define IQ_PARAMETER_DECLARATIONS float cor_length
-#define IQXY_KERNEL_NAME lorentz_Iqxy
-#define IQXY_PARAMETERS cor_length
-#define IQXY_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float cor_length
-#define IQXY_PARAMETER_DECLARATIONS float cor_length
+//# Beginning of rotational operation definitions
 
-float Iq(float q, IQ_PARAMETER_DECLARATIONS);
-float Iq(float q, IQ_PARAMETER_DECLARATIONS) {
-    
-    float denominator = 1 + (q*cor_length)*(q*cor_length);
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lorentz.c"
+
+double Iq(double q, double cor_length)
+{
+    double denominator = 1 + (q*cor_length)*(q*cor_length);
     return 1/denominator;
-
 }
 
-
-float Iqxy(float qx, float qy, IQXY_PARAMETER_DECLARATIONS);
-float Iqxy(float qx, float qy, IQXY_PARAMETER_DECLARATIONS) {
-    
-    return Iq(sqrt(qx*qx + qy*qy), cor_length);
-    
-}
-
-
-/*
-    ##########################################################
-    #                                                        #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #   !!                                              !!   #
-    #   !!  KEEP THIS CODE CONSISTENT WITH KERNELPY.PY  !!   #
-    #   !!                                              !!   #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #                                                        #
-    ##########################################################
-*/
-
-#ifdef IQ_KERNEL_NAME
-kernel void IQ_KERNEL_NAME(
-    global const float *q,
-    global float *result,
-    const int Nq,
-#ifdef IQ_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQ_DISPERSION_LENGTH_DECLARATIONS,
-#endif
-    IQ_FIXED_PARAMETER_DECLARATIONS
-    )
-{
-#ifdef USE_OPENCL
-  #ifdef IQ_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQ_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
-
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qi = q[i];
-#ifdef IQ_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-  #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-  #endif
-    IQ_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
-
-    const float weight = IQ_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-      const float scattering = Iq(qi, IQ_PARAMETERS);
-      // allow kernels to exclude invalid regions by returning NaN
-      if (!isnan(scattering)) {
-        ret += weight*scattering;
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-        norm_vol += vol_weight;
-      #endif
-      }
-    //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
-    }
-    IQ_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iq(qi, IQ_PARAMETERS) + background;
-#endif
-  }
-}
-#endif
-
-
-#ifdef IQXY_KERNEL_NAME
-kernel void IQXY_KERNEL_NAME(
-    global const float *qx,
-    global const float *qy,
-    global float *result,
-    const int Nq,
-#ifdef IQXY_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQXY_DISPERSION_LENGTH_DECLARATIONS,
-#endif
-    IQXY_FIXED_PARAMETER_DECLARATIONS
-    )
-{
-#ifdef USE_OPENCL
-  #ifdef IQXY_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQXY_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
-
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qxi = qx[i];
-    const float qyi = qy[i];
-    #if USE_KAHAN_SUMMATION
-    float accumulated_error = 0.0f;
-    #endif
-#ifdef IQXY_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-    #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-    #endif
-    IQXY_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
-
-    const float weight = IQXY_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-
-      const float scattering = Iqxy(qxi, qyi, IQXY_PARAMETERS);
-      if (!isnan(scattering)) { // if scattering is bad, exclude it from sum
-      //if (scattering >= 0.0f) { // scattering cannot be negative
-        // TODO: use correct angle for spherical correction
-        // Definition of theta and phi are probably reversed relative to the
-        // equation which gave rise to this correction, leading to an
-        // attenuation of the pattern as theta moves through pi/2.f  Either
-        // reverse the meanings of phi and theta in the forms, or use phi
-        // rather than theta in this correction.  Current code uses cos(theta)
-        // so that values match those of sasview.
-      #if defined(IQXY_HAS_THETA) // && 0
-        const float spherical_correction
-          = (Ntheta>1 ? fabs(cos(M_PI_180*theta))*M_PI_2:1.0f);
-        const float next = spherical_correction * weight * scattering;
-      #else
-        const float next = weight * scattering;
-      #endif
-      #if USE_KAHAN_SUMMATION
-        const float y = next - accumulated_error;
-        const float t = ret + y;
-        accumulated_error = (t - ret) - y;
-        ret = t;
-      #else
-        ret += next;
-      #endif
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-      #endif
-        norm_vol += vol_weight;
-      }
-      //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
-    }
-    IQXY_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iqxy(qxi, qyi, IQXY_PARAMETERS) + background;
-#endif
-  }
-}
-#endif

--- a/mcstas-comps/share/sas_mass_fractal.c
+++ b/mcstas-comps/share/sas_mass_fractal.c
@@ -1,85 +1,389 @@
-// GENERATED CODE --- DO NOT EDIT ---
-// Code is produced by sasmodels.gen from sasmodels/models/MODEL.c
+#define HAS_Iq
+#line 1 "../kernel_header.c"
 
 #ifdef __OPENCL_VERSION__
 # define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
 #endif
 
-#define USE_KAHAN_SUMMATION 0
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
 
 // If opencl is not available, then we are compiling a C function
 // Note: if using a C++ compiler, then define kernel as extern "C"
-#ifndef USE_OPENCL
-#  ifdef __cplusplus
-     #include <cstdio>
-     #include <cmath>
-     using namespace std;
-     #if defined(_MSC_VER)
-     #   define kernel extern "C" __declspec( dllexport )
-         inline float trunc(float x) { return x>=0?floor(x):-floor(-x); }
-	 inline float fmin(float x, float y) { return x>y ? y : x; }
-	 inline float fmax(float x, float y) { return x<y ? y : x; }
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
      #else
-     #   define kernel extern "C"
+         #define kernel extern "C"
+         #include <cstdint>
      #endif
-     inline void SINCOS(float angle, float &svar, float &cvar) { svar=sin(angle); cvar=cos(angle); }
-#  else
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
      #include <stdio.h>
-     #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
      // MSVC doesn't support C99, so no need for dllexport on C99 branch
      #define kernel
-     #define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
-#  define global
-#  define local
-#  define constant const
-// OpenCL powr(a,b) = C99 pow(a,b), b >= 0
-// OpenCL pown(a,b) = C99 pow(a,b), b integer
-#  define powr(a,b) pow(a,b)
-#  define pown(a,b) pow(a,b)
-#else
-#  ifdef USE_SINCOS
-#    define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
-#  else
-#    define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
 #endif
 
 // Standard mathematical constants:
 //   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
 //   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
-// OpenCL defines M_constant_F for float constants, and nothing if float
+// OpenCL defines M_constant_F for float constants, and nothing if double
 // is not enabled on the card, which is why these constants may be missing
 #ifndef M_PI
-#  define M_PI 3.141592653589793f
+#  define M_PI 3.141592653589793
 #endif
 #ifndef M_PI_2
-#  define M_PI_2 1.570796326794897f
+#  define M_PI_2 1.570796326794897
 #endif
 #ifndef M_PI_4
-#  define M_PI_4 0.7853981633974483f
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
 #endif
 
-// Non-standard pi/180, used for converting between degrees and radians
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
 #ifndef M_PI_180
-#  define M_PI_180 0.017453292519943295f
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
 #endif
 
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
 
-#define IQ_KERNEL_NAME mass_fractal_Iq
-#define IQ_PARAMETERS radius, mass_dim, cutoff_length
-#define IQ_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float radius, \
-    const float mass_dim, \
-    const float cutoff_length
-#define IQXY_KERNEL_NAME mass_fractal_Iqxy
-#define IQXY_PARAMETERS radius, mass_dim, cutoff_length
-#define IQXY_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float radius, \
-    const float mass_dim, \
-    const float cutoff_length
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/sas_3j1x_x.c"
 
 /**
 * Spherical Bessel function 3*j1(x)/x
@@ -87,315 +391,247 @@
 * Used for low q to avoid cancellation error.
 * Note that the values differ from sasview ~ 5e-12 rather than 5e-14, but
 * in this case it is likely cancellation errors in the original expression
-* using float precision that are the source.  Single precision only
-* requires the first 3 terms.  Double precision requires the 4th term.
-* The fifth term is not needed, and is commented out.
-* Taylor expansion:
-*      1.0f + q2*(-3.f/30.f + q2*(3.f/840.f))+ q2*(-3.f/45360.f + q2*(3.f/3991680.f))))
-* Expression returned from Herbie (herbie.uwpise.org/demo):
-*      const float t = ((1.f + 3.f*q2*q2/5600.f) - q2/20.f);
-*      return t*t;
+* using double precision that are the source.
 */
+double sas_3j1x_x(double q);
 
-float sph_j1c(float q);
-float sph_j1c(float q)
+// The choice of the number of terms in the series and the cutoff value for
+// switching between series and direct calculation depends on the numeric
+// precision.
+//
+// Point where direct calculation reaches machine precision:
+//
+//   single machine precision eps 3e-8 at qr=1.1 **
+//   double machine precision eps 4e-16 at qr=1.1
+//
+// Point where Taylor series reaches machine precision (eps), where taylor
+// series matches direct calculation (cross) and the error at that point:
+//
+//   prec   n eps  cross  error
+//   single 3 0.28  0.4   6.2e-7
+//   single 4 0.68  0.7   2.3e-7
+//   single 5 1.18  1.2   7.5e-8
+//   double 3 0.01  0.03  2.3e-13
+//   double 4 0.06  0.1   3.1e-14
+//   double 5 0.16  0.2   5.0e-15
+//
+// ** Note: relative error on single precision starts increase on the direct
+// method at qr=1.1, rising from 3e-8 to 5e-5 by qr=1e3.  This should be
+// safe for the sans range, with objects of 100 nm supported to a q of 0.1
+// while maintaining 5 digits of precision.  For usans/sesans, the objects
+// are larger but the q is smaller, so again it should be fine.
+//
+// See explore/sph_j1c.py for code to explore these ranges.
+
+// Use 4th order series
+#if FLOAT_SIZE>4
+#define SPH_J1C_CUTOFF 0.1
+#else
+#define SPH_J1C_CUTOFF 0.7
+#endif
+#pragma acc routine seq
+double sas_3j1x_x(double q)
 {
-    const float q2 = q*q;
-    float sin_q, cos_q;
-
-    SINCOS(q, sin_q, cos_q);
-
-    const float bessel = (q < 0.384038453352533f)
-        ? (1.0f + q2*(-3.f/30.f + q2*(3.f/840.f)))
-        : 3.0f*(sin_q/q - cos_q)/q2;
-
-    return bessel;
-
- /*
-    // Code to test various expressions
-    if (sizeof(q2) > 4) {
-        return 3.0f*(sin_q/q - cos_q)/q2;
-    } else if (q < 0.384038453352533f) {
-        //const float t = ((1.f + 3.f*q2*q2/5600.f) - q2/20.f); return t*t;
-        return 1.0f + q2*q2*(3.f/840.f) - q2*(3.f/30.f);
-        //return 1.0f + q2*(-3.f/30.f + q2*(3.f/840.f));
-        //return 1.0f + q2*(-3.f/30.f + q2*(3.f/840.f + q2*(-3.f/45360.f)));
-        //return 1.0f + q2*(-3.f/30.f + q2*(3.f/840.f + q2*(-3.f/45360.f + q2*(3.f/3991680.f))));
+    // 2017-05-18 PAK - support negative q
+    if (fabs(q) < SPH_J1C_CUTOFF) {
+        const double q2 = q*q;
+        return (1.0 + q2*(-3./30. + q2*(3./840. + q2*(-3./45360.))));// + q2*(3./3991680.)))));
     } else {
-        return 3.0f*(sin_q/q - cos_q)/q2;
+        double sin_q, cos_q;
+        SINCOS(q, sin_q, cos_q);
+        return 3.0*(sin_q/q - cos_q)/(q*q);
     }
-*/
 }
 
 
-float lanczos_gamma(float q);
-float lanczos_gamma(float q)
-{
-    // Lanczos approximation to the Gamma function.
-
-    float x,y,tmp,ser;
-    float coeff[6]=
-        {76.18009172947146f,     -86.50532032941677f,
-         24.01409824083091f,     -1.231739572450155f,
-          0.1208650973866179e-2f,-0.5395239384953e-5f};
-
-    y=x=q;
-    tmp  = x+5.5f;
-    tmp -= (x+0.5f)*log(tmp);
-    ser  = 1.000000000190015f;
-    for (int j=0; j<=5; j++) {
-        y+=1.0f;
-        ser += coeff[j]/y;
-    }
-    return -tmp+log(2.5066282746310005f*ser/x);
-}
-
-float form_volume(float radius);
-
-float Iq(float q,
-          float radius,
-          float mass_dim,
-          float cutoff_length);
-
-float Iqxy(float qx, float qy,
-          float radius,
-          float mass_dim,
-          float cutoff_length);
-
-
-static float _mass_fractal_kernel(float q,
-          float radius,
-          float mass_dim,
-          float cutoff_length)
-{
-    // Actively check the argument.
-    if (mass_dim <= 1.0f){
-       return 0.0f;
-    }
-
-    //calculate P(q)
-    float pq = sph_j1c(q*radius);
-    pq = pq*pq;
-
-    //calculate S(q)
-    float mmo = mass_dim-1.0f;
-    float sq = exp(lanczos_gamma(mmo))*sin((mmo)*atan(q*cutoff_length));
-    sq *= pow(cutoff_length, mmo);
-    sq /= pow((1.0f + (q*cutoff_length)*(q*cutoff_length)),(mmo/2.0f));
-    sq /= q;
-
-    //combine and return
-    float result = pq * sq;
-
-    return result;
-}
-float form_volume(float radius){
-
-    return 1.333333333333333f*M_PI*radius*radius*radius;
-}
-
-float Iq(float q,
-          float radius,
-          float mass_dim,
-          float cutoff_length)
-{
-    return _mass_fractal_kernel(q,
-           radius,
-           mass_dim,
-           cutoff_length);
-}
-
-// Iqxy is never called since no orientation or magnetic parameters.
-float Iqxy(float qx, float qy,
-          float radius,
-          float mass_dim,
-          float cutoff_length)
-{
-    float q = sqrt(qx*qx + qy*qy);
-    return _mass_fractal_kernel(q,
-           radius,
-           mass_dim,
-           cutoff_length);
-}
-
-
+#line 1 ".././models/lib/sas_gamma.c"
 
 /*
-    ##########################################################
-    #                                                        #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #   !!                                              !!   #
-    #   !!  KEEP THIS CODE CONSISTENT WITH KERNELPY.PY  !!   #
-    #   !!                                              !!   #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #                                                        #
-    ##########################################################
+The wrapper for gamma function from OpenCL and standard libraries
+The OpenCL gamma function fails miserably on values lower than 1.0
+while works fine on larger values.
+We use gamma definition Gamma(t + 1) = t * Gamma(t) to compute
+to function for values lower than 1.0. Namely Gamma(t) = 1/t * Gamma(t + 1)
+For t < 0, we use Gamma(t) = pi / ( Gamma(1 - t) * sin(pi * t) )
 */
 
-#ifdef IQ_KERNEL_NAME
-kernel void IQ_KERNEL_NAME(
-    global const float *q,
-    global float *result,
-    const int Nq,
-#ifdef IQ_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQ_DISPERSION_LENGTH_DECLARATIONS,
-#endif
-    IQ_FIXED_PARAMETER_DECLARATIONS
-    )
+#if defined(NEED_TGAMMA)
+#pragma acc routine seq
+static double cephes_stirf(double x)
 {
-#ifdef USE_OPENCL
-  #ifdef IQ_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQ_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
+	const double MAXSTIR=143.01608;
+	const double SQTPI=2.50662827463100050242E0;
+	double y, w, v;
 
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qi = q[i];
-#ifdef IQ_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-  #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-  #endif
-    IQ_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
+	w = 1.0 / x;
 
-    const float weight = IQ_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-      const float scattering = Iq(qi, IQ_PARAMETERS);
-      // allow kernels to exclude invalid regions by returning NaN
-      if (!isnan(scattering)) {
-        ret += weight*scattering;
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-        norm_vol += vol_weight;
-      #endif
-      }
-    //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
-    }
-    IQ_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iq(qi, IQ_PARAMETERS) + background;
-#endif
-  }
+	w = ((((
+		7.87311395793093628397E-4*w
+		- 2.29549961613378126380E-4)*w
+		- 2.68132617805781232825E-3)*w
+		+ 3.47222221605458667310E-3)*w
+		+ 8.33333333333482257126E-2)*w
+		+ 1.0;
+	y = exp(x);
+	if (x > MAXSTIR)
+	{ /* Avoid overflow in pow() */
+		v = pow(x, 0.5 * x - 0.25);
+		y = v * (v / y);
+	}
+	else
+	{
+		y = pow(x, x - 0.5) / y;
+	}
+	y = SQTPI * y * w;
+	return(y);
 }
-#endif
 
+#pragma acc routine seq
+static double tgamma(double x) {
+	double p, q, z;
+	int sgngam;
+	int i;
 
-#ifdef IQXY_KERNEL_NAME
-kernel void IQXY_KERNEL_NAME(
-    global const float *qx,
-    global const float *qy,
-    global float *result,
-    const int Nq,
-#ifdef IQXY_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQXY_DISPERSION_LENGTH_DECLARATIONS,
-#endif
-    IQXY_FIXED_PARAMETER_DECLARATIONS
-    )
+	sgngam = 1;
+	if (isnan(x))
+		return(x);
+	q = fabs(x);
+
+	if (q > 33.0)
+	{
+		if (x < 0.0)
+		{
+			p = floor(q);
+			if (p == q)
+			{
+				return (NAN);
+			}
+			i = p;
+			if ((i & 1) == 0)
+				sgngam = -1;
+			z = q - p;
+			if (z > 0.5)
+			{
+				p += 1.0;
+				z = q - p;
+			}
+			z = q * sin(M_PI * z);
+			if (z == 0.0)
+			{
+				return(NAN);
+			}
+			z = fabs(z);
+			z = M_PI / (z * cephes_stirf(q));
+		}
+		else
+		{
+			z = cephes_stirf(x);
+		}
+		return(sgngam * z);
+	}
+
+	z = 1.0;
+	while (x >= 3.0)
+	{
+		x -= 1.0;
+		z *= x;
+	}
+
+	while (x < 0.0)
+	{
+		if (x > -1.E-9)
+			goto small;
+		z /= x;
+		x += 1.0;
+	}
+
+	while (x < 2.0)
+	{
+		if (x < 1.e-9)
+			goto small;
+		z /= x;
+		x += 1.0;
+	}
+
+	if (x == 2.0)
+		return(z);
+
+	x -= 2.0;
+	p = (((((
+		+1.60119522476751861407E-4*x
+		+ 1.19135147006586384913E-3)*x
+		+ 1.04213797561761569935E-2)*x
+		+ 4.76367800457137231464E-2)*x
+		+ 2.07448227648435975150E-1)*x
+		+ 4.94214826801497100753E-1)*x
+		+ 9.99999999999999996796E-1;
+	q = ((((((
+		-2.31581873324120129819E-5*x
+		+ 5.39605580493303397842E-4)*x
+		- 4.45641913851797240494E-3)*x
+		+ 1.18139785222060435552E-2)*x
+		+ 3.58236398605498653373E-2)*x
+		- 2.34591795718243348568E-1)*x
+		+ 7.14304917030273074085E-2)*x
+		+ 1.00000000000000000320E0;
+	return(z * p / q);
+
+small:
+	if (x == 0.0)
+	{
+		return (NAN);
+	}
+	else
+		return(z / ((1.0 + 0.5772156649015329 * x) * x));
+}
+#endif // NEED_TGAMMA
+
+#pragma acc routine seq
+inline double sas_gamma(double x)
 {
-#ifdef USE_OPENCL
-  #ifdef IQXY_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQXY_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
-
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qxi = qx[i];
-    const float qyi = qy[i];
-    #if USE_KAHAN_SUMMATION
-    float accumulated_error = 0.0f;
-    #endif
-#ifdef IQXY_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-    #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-    #endif
-    IQXY_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
-
-    const float weight = IQXY_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-
-      const float scattering = Iqxy(qxi, qyi, IQXY_PARAMETERS);
-      if (!isnan(scattering)) { // if scattering is bad, exclude it from sum
-      //if (scattering >= 0.0f) { // scattering cannot be negative
-        // TODO: use correct angle for spherical correction
-        // Definition of theta and phi are probably reversed relative to the
-        // equation which gave rise to this correction, leading to an
-        // attenuation of the pattern as theta moves through pi/2.f  Either
-        // reverse the meanings of phi and theta in the forms, or use phi
-        // rather than theta in this correction.  Current code uses cos(theta)
-        // so that values match those of sasview.
-      #if defined(IQXY_HAS_THETA) // && 0
-        const float spherical_correction
-          = (Ntheta>1 ? fabs(cos(M_PI_180*theta))*M_PI_2:1.0f);
-        const float next = spherical_correction * weight * scattering;
-      #else
-        const float next = weight * scattering;
-      #endif
-      #if USE_KAHAN_SUMMATION
-        const float y = next - accumulated_error;
-        const float t = ret + y;
-        accumulated_error = (t - ret) - y;
-        ret = t;
-      #else
-        ret += next;
-      #endif
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-      #endif
-        norm_vol += vol_weight;
-      }
-      //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
-    }
-    IQXY_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iqxy(qxi, qyi, IQXY_PARAMETERS) + background;
-#endif
-  }
+    // Note: the builtin tgamma can give slow and unreliable results for x<1.
+    // The following transform extends it to zero and to negative values.
+    // It should return NaN for zero and negative integers but doesn't.
+    // The accuracy is okay but not wonderful for negative numbers, maybe
+    // one or two digits lost in the calculation. If higher accuracy is
+    // needed, you could test the following loop:
+    //    double norm = 1.;
+    //    while (x<1.) { norm*=x; x+=1.; }
+    //    return tgamma(x)/norm;
+    return (x<0. ? M_PI/tgamma(1.-x)/sin(M_PI*x) : tgamma(x+1)/x);
 }
-#endif
+
+
+#line 1 ".././models/mass_fractal.c"
+
+static double
+Iq(double q, double radius, double fractal_dim_mass, double cutoff_length)
+{
+    //calculate P(q)
+    const double pq = square(sas_3j1x_x(q*radius));
+
+    //calculate S(q)
+    // S(q) = gamma(D-1) sin((D-1)atan(q c))/q c^(D-1) (1+(q c)^2)^(-(D-1)/2)
+    // lim D->1 [gamma(D-1) sin((D-1) a)] = a
+    // lim q->0 [sin((D-1) atan(q c))/q] = (D-1) c
+    // lim q,D->0,1 [gamma(D-1) sin((D-1)atan(q c))/q] = c
+    double sq;
+    if (q > 0. && fractal_dim_mass > 1.) {
+        const double Dm1 = fractal_dim_mass - 1.0;
+        const double t1 = sas_gamma(Dm1)*sin(Dm1*atan(q*cutoff_length));
+        const double t2 = pow(cutoff_length, Dm1);
+        const double t3 = pow(1.0 + square(q*cutoff_length), -0.5*Dm1);
+        sq = t1 * t2 * t3 / q;
+    } else if (q > 0.) {
+        sq = atan(q*cutoff_length)/q;
+    } else if (fractal_dim_mass > 1.) {
+        const double D = fractal_dim_mass;
+        sq = pow(cutoff_length, D) * sas_gamma(D);
+    } else {
+        sq = cutoff_length;
+    }
+
+    return pq * sq;
+}
+
+

--- a/mcstas-comps/share/sas_mass_surface_fractal.c
+++ b/mcstas-comps/share/sas_mass_surface_fractal.c
@@ -1,342 +1,406 @@
-// GENERATED CODE --- DO NOT EDIT ---
-// Code is produced by sasmodels.gen from sasmodels/models/MODEL.c
+#define HAS_Iq
+#line 1 "../kernel_header.c"
 
 #ifdef __OPENCL_VERSION__
 # define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
 #endif
 
-#define USE_KAHAN_SUMMATION 0
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
 
 // If opencl is not available, then we are compiling a C function
 // Note: if using a C++ compiler, then define kernel as extern "C"
-#ifndef USE_OPENCL
-#  ifdef __cplusplus
-     #include <cstdio>
-     #include <cmath>
-     using namespace std;
-     #if defined(_MSC_VER)
-     #   define kernel extern "C" __declspec( dllexport )
-         inline float trunc(float x) { return x>=0?floor(x):-floor(-x); }
-	 inline float fmin(float x, float y) { return x>y ? y : x; }
-	 inline float fmax(float x, float y) { return x<y ? y : x; }
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
      #else
-     #   define kernel extern "C"
+         #define kernel extern "C"
+         #include <cstdint>
      #endif
-     inline void SINCOS(float angle, float &svar, float &cvar) { svar=sin(angle); cvar=cos(angle); }
-#  else
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
      #include <stdio.h>
-     #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
      // MSVC doesn't support C99, so no need for dllexport on C99 branch
      #define kernel
-     #define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
-#  define global
-#  define local
-#  define constant const
-// OpenCL powr(a,b) = C99 pow(a,b), b >= 0
-// OpenCL pown(a,b) = C99 pow(a,b), b integer
-#  define powr(a,b) pow(a,b)
-#  define pown(a,b) pow(a,b)
-#else
-#  ifdef USE_SINCOS
-#    define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
-#  else
-#    define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
 #endif
 
 // Standard mathematical constants:
 //   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
 //   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
-// OpenCL defines M_constant_F for float constants, and nothing if float
+// OpenCL defines M_constant_F for float constants, and nothing if double
 // is not enabled on the card, which is why these constants may be missing
 #ifndef M_PI
-#  define M_PI 3.141592653589793f
+#  define M_PI 3.141592653589793
 #endif
 #ifndef M_PI_2
-#  define M_PI_2 1.570796326794897f
+#  define M_PI_2 1.570796326794897
 #endif
 #ifndef M_PI_4
-#  define M_PI_4 0.7853981633974483f
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
 #endif
 
-// Non-standard pi/180, used for converting between degrees and radians
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
 #ifndef M_PI_180
-#  define M_PI_180 0.017453292519943295f
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
 #endif
 
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
 
-#define IQ_KERNEL_NAME mass_surface_fractal_Iq
-#define IQ_PARAMETERS mass_dim, surface_dim, cluster_rg, primary_rg
-#define IQ_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float mass_dim, \
-    const float surface_dim, \
-    const float cluster_rg, \
-    const float primary_rg
-#define IQXY_KERNEL_NAME mass_surface_fractal_Iqxy
-#define IQXY_PARAMETERS mass_dim, surface_dim, cluster_rg, primary_rg
-#define IQXY_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float mass_dim, \
-    const float surface_dim, \
-    const float cluster_rg, \
-    const float primary_rg
+//# Beginning of rotational operation definitions
 
-float form_volume(float radius);
+typedef struct {
+          double R31, R32;
+      } QACRotation;
 
-float Iq(float q,
-          float mass_dim,
-          float surface_dim,
-          float cluster_rg,
-          float primary_rg);
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
 
-float Iqxy(float qx, float qy,
-          float mass_dim,
-          float surface_dim,
-          float cluster_rg,
-          float primary_rg);
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
 
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
 
-static float _mass_surface_fractal_kernel(float q,
-          float mass_dim,
-          float surface_dim,
-          float cluster_rg,
-          float primary_rg)
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/mass_surface_fractal.c"
+
+static double
+Iq(double q,
+          double fractal_dim_mass,
+          double fractal_dim_surf,
+          double rg_cluster,
+          double rg_primary)
 {
      //computation
-    float tot_dim = 6.0f - surface_dim - mass_dim;
-    mass_dim /= 2.0f;
-    tot_dim /= 2.0f;
+    const double Dm = 0.5*fractal_dim_mass;
+    const double Dt = 0.5*(6.0 - (fractal_dim_mass + fractal_dim_surf));
 
-    float rc_norm = cluster_rg * cluster_rg / (3.0f * mass_dim);
-    float rp_norm = primary_rg * primary_rg / (3.0f * tot_dim);
+    const double t1 = Dm==0. ? 1.0 : pow(1.0 + square(q*rg_cluster)/(3.0*Dm), -Dm);
+    const double t2 = Dt==0. ? 1.0 : pow(1.0 + square(q*rg_primary)/(3.0*Dt), -Dt);
+    const double form = t1*t2;
 
-    //x for P
-    float x_val1 = 1.0f +  q * q * rc_norm;
-    float x_val2 = 1.0f +  q * q * rp_norm;
-
-    float inv_form = pow(x_val1, mass_dim) * pow(x_val2, tot_dim);
-
-    //another singular
-    if (inv_form == 0.0f) return 0.0f;
-
-    float form_factor = 1.0f;
-    form_factor /= inv_form;
-
-    return (form_factor);
-}
-float form_volume(float radius){
-
-    return 1.333333333333333f*M_PI*radius*radius*radius;
-}
-
-float Iq(float q,
-          float mass_dim,
-          float surface_dim,
-          float cluster_rg,
-          float primary_rg)
-{
-    return _mass_surface_fractal_kernel(q,
-            mass_dim,
-            surface_dim,
-            cluster_rg,
-            primary_rg);
-}
-
-// Iqxy is never called since no orientation or magnetic parameters.
-float Iqxy(float qx, float qy,
-          float mass_dim,
-          float surface_dim,
-          float cluster_rg,
-          float primary_rg)
-{
-    float q = sqrt(qx*qx + qy*qy);
-    return _mass_surface_fractal_kernel(q,
-           mass_dim,
-           surface_dim,
-           cluster_rg,
-           primary_rg);
+    return form;
 }
 
 
-
-/*
-    ##########################################################
-    #                                                        #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #   !!                                              !!   #
-    #   !!  KEEP THIS CODE CONSISTENT WITH KERNELPY.PY  !!   #
-    #   !!                                              !!   #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #                                                        #
-    ##########################################################
-*/
-
-#ifdef IQ_KERNEL_NAME
-kernel void IQ_KERNEL_NAME(
-    global const float *q,
-    global float *result,
-    const int Nq,
-#ifdef IQ_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQ_DISPERSION_LENGTH_DECLARATIONS,
-#endif
-    IQ_FIXED_PARAMETER_DECLARATIONS
-    )
-{
-#ifdef USE_OPENCL
-  #ifdef IQ_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQ_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
-
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qi = q[i];
-#ifdef IQ_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-  #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-  #endif
-    IQ_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
-
-    const float weight = IQ_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-      const float scattering = Iq(qi, IQ_PARAMETERS);
-      // allow kernels to exclude invalid regions by returning NaN
-      if (!isnan(scattering)) {
-        ret += weight*scattering;
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-        norm_vol += vol_weight;
-      #endif
-      }
-    //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
-    }
-    IQ_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iq(qi, IQ_PARAMETERS) + background;
-#endif
-  }
-}
-#endif
-
-
-#ifdef IQXY_KERNEL_NAME
-kernel void IQXY_KERNEL_NAME(
-    global const float *qx,
-    global const float *qy,
-    global float *result,
-    const int Nq,
-#ifdef IQXY_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQXY_DISPERSION_LENGTH_DECLARATIONS,
-#endif
-    IQXY_FIXED_PARAMETER_DECLARATIONS
-    )
-{
-#ifdef USE_OPENCL
-  #ifdef IQXY_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQXY_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
-
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qxi = qx[i];
-    const float qyi = qy[i];
-    #if USE_KAHAN_SUMMATION
-    float accumulated_error = 0.0f;
-    #endif
-#ifdef IQXY_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-    #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-    #endif
-    IQXY_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
-
-    const float weight = IQXY_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-
-      const float scattering = Iqxy(qxi, qyi, IQXY_PARAMETERS);
-      if (!isnan(scattering)) { // if scattering is bad, exclude it from sum
-      //if (scattering >= 0.0f) { // scattering cannot be negative
-        // TODO: use correct angle for spherical correction
-        // Definition of theta and phi are probably reversed relative to the
-        // equation which gave rise to this correction, leading to an
-        // attenuation of the pattern as theta moves through pi/2.f  Either
-        // reverse the meanings of phi and theta in the forms, or use phi
-        // rather than theta in this correction.  Current code uses cos(theta)
-        // so that values match those of sasview.
-      #if defined(IQXY_HAS_THETA) // && 0
-        const float spherical_correction
-          = (Ntheta>1 ? fabs(cos(M_PI_180*theta))*M_PI_2:1.0f);
-        const float next = spherical_correction * weight * scattering;
-      #else
-        const float next = weight * scattering;
-      #endif
-      #if USE_KAHAN_SUMMATION
-        const float y = next - accumulated_error;
-        const float t = ret + y;
-        accumulated_error = (t - ret) - y;
-        ret = t;
-      #else
-        ret += next;
-      #endif
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-      #endif
-        norm_vol += vol_weight;
-      }
-      //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
-    }
-    IQXY_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iqxy(qxi, qyi, IQXY_PARAMETERS) + background;
-#endif
-  }
-}
-#endif

--- a/mcstas-comps/share/sas_mono_gauss_coil.c
+++ b/mcstas-comps/share/sas_mono_gauss_coil.c
@@ -1,0 +1,453 @@
+#define HAS_Iq
+#define FORM_VOL
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/mono_gauss_coil.c"
+
+static double
+form_volume(double rg)
+{
+    return 1.0;
+}
+
+static double
+radius_effective(int mode, double rg)
+{
+    switch (mode) {
+    default:
+    case 1: // R_g
+        return rg;
+    case 2: // 2R_g
+        return 2.0*rg;
+    case 3: // 3R_g
+        return 3.0*rg;
+    case 4: // (5/3)^0.5*R_g
+        return sqrt(5.0/3.0)*rg;
+    }
+}
+
+static double
+gauss_coil(double qr)
+{
+    const double x = qr*qr;
+
+    // Use series expansion at low q for higher accuracy. We could use
+    // smaller polynomials if we sacrifice some digits of precision or
+    // introduce an additional series expansion around x == 1.
+    // See explore/precision.py, gauss_coil function.
+#if FLOAT_SIZE>4 // DOUBLE_PRECISION
+    // For double precision: use O(5) Pade with 0.5 cutoff (10 mad + 1 divide)
+    if (x < 0.5) {
+        // PadeApproximant[2*Exp[-x^2] + x^2-1)/x^4, {x, 0, 8}]
+        const double A1=1./12., A2=2./99., A3=1./2640., A4=1./23760., A5=-1./1995840.;
+        const double B1=5./12., B2=5./66., B3=1./132., B4=1./2376., B5=1./95040.;
+        return (((((A5*x + A4)*x + A3)*x + A2)*x + A1)*x + 1.)
+                / (((((B5*x + B4)*x + B3)*x + B2)*x + B1)*x + 1.);
+    }
+#else
+    // For single precision: use O(7) Taylor with 0.8 cutoff (7 mad)
+    if (x < 0.8) {
+        const double C0 = +1.;
+        const double C1 = -1./3.;
+        const double C2 = +1./12.;
+        const double C3 = -1./60.;
+        const double C4 = +1./360.;
+        const double C5 = -1./2520.;
+        const double C6 = +1./20160.;
+        const double C7 = -1./181440.;
+        return ((((((C7*x + C6)*x + C5)*x + C4)*x + C3)*x + C2)*x + C1)*x + C0;
+    }
+#endif
+
+    return 2.0 * (expm1(-x) + x)/(x*x);
+}
+
+static double
+Iq(double q, double i_zero, double rg)
+{
+    return i_zero * gauss_coil(q*rg);
+}
+
+

--- a/mcstas-comps/share/sas_multilayer_vesicle.c
+++ b/mcstas-comps/share/sas_multilayer_vesicle.c
@@ -1,0 +1,531 @@
+#define HAS_FQ
+#define FORM_VOL
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/sas_3j1x_x.c"
+
+/**
+* Spherical Bessel function 3*j1(x)/x
+*
+* Used for low q to avoid cancellation error.
+* Note that the values differ from sasview ~ 5e-12 rather than 5e-14, but
+* in this case it is likely cancellation errors in the original expression
+* using double precision that are the source.
+*/
+double sas_3j1x_x(double q);
+
+// The choice of the number of terms in the series and the cutoff value for
+// switching between series and direct calculation depends on the numeric
+// precision.
+//
+// Point where direct calculation reaches machine precision:
+//
+//   single machine precision eps 3e-8 at qr=1.1 **
+//   double machine precision eps 4e-16 at qr=1.1
+//
+// Point where Taylor series reaches machine precision (eps), where taylor
+// series matches direct calculation (cross) and the error at that point:
+//
+//   prec   n eps  cross  error
+//   single 3 0.28  0.4   6.2e-7
+//   single 4 0.68  0.7   2.3e-7
+//   single 5 1.18  1.2   7.5e-8
+//   double 3 0.01  0.03  2.3e-13
+//   double 4 0.06  0.1   3.1e-14
+//   double 5 0.16  0.2   5.0e-15
+//
+// ** Note: relative error on single precision starts increase on the direct
+// method at qr=1.1, rising from 3e-8 to 5e-5 by qr=1e3.  This should be
+// safe for the sans range, with objects of 100 nm supported to a q of 0.1
+// while maintaining 5 digits of precision.  For usans/sesans, the objects
+// are larger but the q is smaller, so again it should be fine.
+//
+// See explore/sph_j1c.py for code to explore these ranges.
+
+// Use 4th order series
+#if FLOAT_SIZE>4
+#define SPH_J1C_CUTOFF 0.1
+#else
+#define SPH_J1C_CUTOFF 0.7
+#endif
+#pragma acc routine seq
+double sas_3j1x_x(double q)
+{
+    // 2017-05-18 PAK - support negative q
+    if (fabs(q) < SPH_J1C_CUTOFF) {
+        const double q2 = q*q;
+        return (1.0 + q2*(-3./30. + q2*(3./840. + q2*(-3./45360.))));// + q2*(3./3991680.)))));
+    } else {
+        double sin_q, cos_q;
+        SINCOS(q, sin_q, cos_q);
+        return 3.0*(sin_q/q - cos_q)/(q*q);
+    }
+}
+
+
+#line 1 ".././models/multilayer_vesicle.c"
+
+static double
+form_volume(double radius,
+          double thick_shell,
+          double thick_solvent,
+          double fp_n_shells)
+{
+    int n_shells = (int)(fp_n_shells + 0.5);
+    double R_N = radius + n_shells*(thick_shell+thick_solvent) - thick_solvent;
+    return M_4PI_3*cube(R_N);
+}
+
+static double
+multilayer_vesicle_kernel(double q,
+          double radius,
+          double thick_shell,
+          double thick_solvent,
+          double sld_solvent,
+          double sld,
+          int n_shells)
+{
+    //calculate with a loop, two shells at a time
+    int ii = 0;
+    double fval = 0.0;
+    double voli = 0.0;
+    const double sldi = sld_solvent-sld;
+
+    do {
+        double ri = radius + (double)ii*(thick_shell + thick_solvent);
+
+        // layer 1
+        voli = M_4PI_3*ri*ri*ri;
+        fval += voli*sldi*sas_3j1x_x(ri*q);
+
+        ri += thick_shell;
+
+        // layer 2
+        voli = M_4PI_3*ri*ri*ri;
+        fval -= voli*sldi*sas_3j1x_x(ri*q);
+
+        //do 2 layers at a time
+        ii++;
+
+    } while(ii <= n_shells-1);  //change to make 0 < n_shells < 2 correspond to
+                               //unilamellar vesicles (C. Glinka, 11/24/03)
+
+    return fval;  // Volume normalization happens in caller
+}
+
+static double
+radius_effective(int mode, double radius, double thick_shell, double thick_solvent, double fp_n_shells)
+{
+    // case 1: outer radius
+    return radius + fp_n_shells*thick_shell + (fp_n_shells - 1.0)*thick_solvent;
+}
+
+static void
+Fq(double q,
+          double *F1,
+          double *F2,
+          double volfraction,
+          double radius,
+          double thick_shell,
+          double thick_solvent,
+          double sld_solvent,
+          double sld,
+          double fp_n_shells)
+{
+    int n_shells = (int)(fp_n_shells + 0.5);
+    const double fq = multilayer_vesicle_kernel(q,
+           radius,
+           thick_shell,
+           thick_solvent,
+           sld_solvent,
+           sld,
+           n_shells);
+    // See comment in vesicle.c regarding volfraction normalization.
+    *F1 = 1.0e-2 * sqrt(volfraction)*fq;
+    *F2 = 1.0e-4 * volfraction*fq*fq;
+}
+
+
+

--- a/mcstas-comps/share/sas_onion.c
+++ b/mcstas-comps/share/sas_onion.c
@@ -1,0 +1,524 @@
+#define HAS_FQ
+#define FORM_VOL
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/sas_3j1x_x.c"
+
+/**
+* Spherical Bessel function 3*j1(x)/x
+*
+* Used for low q to avoid cancellation error.
+* Note that the values differ from sasview ~ 5e-12 rather than 5e-14, but
+* in this case it is likely cancellation errors in the original expression
+* using double precision that are the source.
+*/
+double sas_3j1x_x(double q);
+
+// The choice of the number of terms in the series and the cutoff value for
+// switching between series and direct calculation depends on the numeric
+// precision.
+//
+// Point where direct calculation reaches machine precision:
+//
+//   single machine precision eps 3e-8 at qr=1.1 **
+//   double machine precision eps 4e-16 at qr=1.1
+//
+// Point where Taylor series reaches machine precision (eps), where taylor
+// series matches direct calculation (cross) and the error at that point:
+//
+//   prec   n eps  cross  error
+//   single 3 0.28  0.4   6.2e-7
+//   single 4 0.68  0.7   2.3e-7
+//   single 5 1.18  1.2   7.5e-8
+//   double 3 0.01  0.03  2.3e-13
+//   double 4 0.06  0.1   3.1e-14
+//   double 5 0.16  0.2   5.0e-15
+//
+// ** Note: relative error on single precision starts increase on the direct
+// method at qr=1.1, rising from 3e-8 to 5e-5 by qr=1e3.  This should be
+// safe for the sans range, with objects of 100 nm supported to a q of 0.1
+// while maintaining 5 digits of precision.  For usans/sesans, the objects
+// are larger but the q is smaller, so again it should be fine.
+//
+// See explore/sph_j1c.py for code to explore these ranges.
+
+// Use 4th order series
+#if FLOAT_SIZE>4
+#define SPH_J1C_CUTOFF 0.1
+#else
+#define SPH_J1C_CUTOFF 0.7
+#endif
+#pragma acc routine seq
+double sas_3j1x_x(double q)
+{
+    // 2017-05-18 PAK - support negative q
+    if (fabs(q) < SPH_J1C_CUTOFF) {
+        const double q2 = q*q;
+        return (1.0 + q2*(-3./30. + q2*(3./840. + q2*(-3./45360.))));// + q2*(3./3991680.)))));
+    } else {
+        double sin_q, cos_q;
+        SINCOS(q, sin_q, cos_q);
+        return 3.0*(sin_q/q - cos_q)/(q*q);
+    }
+}
+
+
+#line 1 ".././models/onion.c"
+
+
+static double
+f_exp(double q, double r, double sld_in, double sld_out,
+    double thickness, double A, double side)
+{
+  const double vol = M_4PI_3 * cube(r);
+  const double qr = q * r;
+  const double bes = sas_3j1x_x(qr);
+  const double alpha = A * r/thickness;
+  double result;
+  if (qr == 0.0) {
+    result = 1.0;
+  } else if (fabs(A) > 0.0) {
+    const double qrsq = qr * qr;
+    const double alphasq = alpha * alpha;
+    const double sumsq = alphasq + qrsq;
+    double sinqr, cosqr;
+    SINCOS(qr, sinqr, cosqr);
+    const double t1 = (alphasq - qrsq)*sinqr/qr - 2.0*alpha*cosqr;
+    const double t2 = alpha*sinqr/qr - cosqr;
+    const double fun = -3.0*(t1/sumsq - t2)/sumsq;
+    const double slope = (sld_out - sld_in)/expm1(A);
+    const double contrast = slope*exp(A*side);
+    result = contrast*fun + (sld_in-slope)*bes;
+  } else {
+    result = sld_in*bes;
+  }
+  return vol * result;
+}
+
+static double
+outer_radius(double radius_core, double n_shells, double thickness[])
+{
+  int n = (int)(n_shells+0.5);
+  double r = radius_core;
+  for (int i=0; i < n; i++) {
+    r += thickness[i];
+  }
+  return r;
+}
+
+static double
+form_volume(double radius_core, double n_shells, double thickness[])
+{
+  return M_4PI_3*cube(outer_radius(radius_core, n_shells, thickness));
+}
+
+static double
+radius_effective(int mode, double radius_core, double n_shells, double thickness[])
+{
+  // case 1: outer radius
+  return outer_radius(radius_core, n_shells, thickness);
+}
+
+static void
+Fq(double q, double *F1, double *F2, double sld_core, double radius_core, double sld_solvent,
+    double n_shells, double sld_in[], double sld_out[], double thickness[],
+    double A[])
+{
+  int n = (int)(n_shells+0.5);
+  double r_out = radius_core;
+  double f = f_exp(q, r_out, sld_core, 0.0, 0.0, 0.0, 0.0);
+  for (int i=0; i < n; i++){
+    const double r_in = r_out;
+    r_out += thickness[i];
+    f -= f_exp(q, r_in, sld_in[i], sld_out[i], thickness[i], A[i], 0.0);
+    f += f_exp(q, r_out, sld_in[i], sld_out[i], thickness[i], A[i], 1.0);
+  }
+  f -= f_exp(q, r_out, sld_solvent, 0.0, 0.0, 0.0, 0.0);
+
+  *F1 = 1e-2 * f;
+  *F2 = 1e-4 * f * f;
+}
+
+

--- a/mcstas-comps/share/sas_peak_lorentz.c
+++ b/mcstas-comps/share/sas_peak_lorentz.c
@@ -1,0 +1,399 @@
+#define HAS_Iq
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/peak_lorentz.c"
+
+#include <math.h>
+    
+double Iq(double q, double peak_pos, double peak_hwhm);
+
+#pragma acc routine seq
+double Iq(double q, double peak_pos, double peak_hwhm) {
+    double inten = 1.0 / (1.0 + pow((q - peak_pos) / peak_hwhm, 2.0));
+    return inten;
+}
+
+
+

--- a/mcstas-comps/share/sas_poly_gauss_coil.c
+++ b/mcstas-comps/share/sas_poly_gauss_coil.c
@@ -1,0 +1,418 @@
+#define HAS_Iq
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/poly_gauss_coil.c"
+
+    
+double Iq(double q, double i_zero, double rg, double polydispersity);
+
+#pragma acc routine seq
+double Iq(double q, double i_zero, double rg, double polydispersity) {
+    double u = polydispersity - 1.0;
+    double z = q * q * (rg * rg / (1.0 + 2.0 * u));
+
+    // need to trap the case of the polydispersity being 1 (ie, monodisperse!)
+    double result;
+    if (polydispersity == 1.0) {
+        if (q == 0.0) {
+            result = 1.0;
+        } else {
+            result = 2.0 * (expm1(-z) + z) / (q * q);
+        }
+    } else {
+        // Taylor series around z=0 of (2*(1+uz)^(-1/u) + z - 1) / (z^2(u+1))
+        double p[3] = {(+1 + 5 * u + 6 * u * u) / 12.0, (-1 - 2 * u) / 3.0, (+1)};
+        result = 2.0 * (pow(1.0 + u * z, -1.0 / u) + z - 1.0) / (1.0 + u);
+        if (z > 1e-4) {
+            result /= (q * q * z * z);
+        } else {
+            result = p[0] * z * z + p[1] * z + p[2];
+        }
+    }
+    return i_zero * result;
+}
+
+
+

--- a/mcstas-comps/share/sas_polymer_excl_volume.c
+++ b/mcstas-comps/share/sas_polymer_excl_volume.c
@@ -1,0 +1,430 @@
+#define HAS_Iq
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/polymer_excl_volume.c"
+
+#include <math.h>
+#define NEED_TGAMMA
+
+double tgammainc(double a, double x);
+double Iq(double q, double rg, double porod_exp);
+
+#pragma acc routine seq
+double tgammainc(double a, double x)
+{
+    const double eps = 1e-14;  // desired precision
+
+    // Initialize the result and the current term
+    double result = 0.0;
+    double term = pow(x, a) * exp(-x) / tgamma(a + 1.0);
+    int n = 1;
+
+    // Sum terms until convergence or maximum number of iterations
+    while (fabs(term) > eps && n <= 1000) {
+        result += term;
+        term = pow(x, a + n) * exp(-x) / tgamma(a + n + 1.0);
+        n++;
+    }
+
+    return result;
+}
+    
+#pragma acc routine seq
+double Iq(double q, double rg, double porod_exp) {
+    double usub = pow(q * rg, 2) * (2.0 / porod_exp + 1.0) * (2.0 / porod_exp + 2.0) / 6.0;
+    double upow = pow(usub, -0.5 * porod_exp);
+    double gamma_1 = tgamma(0.5 * porod_exp);
+    double gamma_2 = tgamma(porod_exp);
+    double gammainc_1 = tgammainc(0.5 * porod_exp, usub);
+    double gammainc_2 = tgammainc(porod_exp, usub);
+    double result = porod_exp * upow * (gamma_1 * gammainc_1 - upow * gamma_2 * gammainc_2);
+    if (q <= 0) {
+        result = 1.0;
+    }
+    return result;
+}
+
+
+

--- a/mcstas-comps/share/sas_polymer_micelle.c
+++ b/mcstas-comps/share/sas_polymer_micelle.c
@@ -1,0 +1,537 @@
+#define HAS_Iq
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/sas_3j1x_x.c"
+
+/**
+* Spherical Bessel function 3*j1(x)/x
+*
+* Used for low q to avoid cancellation error.
+* Note that the values differ from sasview ~ 5e-12 rather than 5e-14, but
+* in this case it is likely cancellation errors in the original expression
+* using double precision that are the source.
+*/
+double sas_3j1x_x(double q);
+
+// The choice of the number of terms in the series and the cutoff value for
+// switching between series and direct calculation depends on the numeric
+// precision.
+//
+// Point where direct calculation reaches machine precision:
+//
+//   single machine precision eps 3e-8 at qr=1.1 **
+//   double machine precision eps 4e-16 at qr=1.1
+//
+// Point where Taylor series reaches machine precision (eps), where taylor
+// series matches direct calculation (cross) and the error at that point:
+//
+//   prec   n eps  cross  error
+//   single 3 0.28  0.4   6.2e-7
+//   single 4 0.68  0.7   2.3e-7
+//   single 5 1.18  1.2   7.5e-8
+//   double 3 0.01  0.03  2.3e-13
+//   double 4 0.06  0.1   3.1e-14
+//   double 5 0.16  0.2   5.0e-15
+//
+// ** Note: relative error on single precision starts increase on the direct
+// method at qr=1.1, rising from 3e-8 to 5e-5 by qr=1e3.  This should be
+// safe for the sans range, with objects of 100 nm supported to a q of 0.1
+// while maintaining 5 digits of precision.  For usans/sesans, the objects
+// are larger but the q is smaller, so again it should be fine.
+//
+// See explore/sph_j1c.py for code to explore these ranges.
+
+// Use 4th order series
+#if FLOAT_SIZE>4
+#define SPH_J1C_CUTOFF 0.1
+#else
+#define SPH_J1C_CUTOFF 0.7
+#endif
+#pragma acc routine seq
+double sas_3j1x_x(double q)
+{
+    // 2017-05-18 PAK - support negative q
+    if (fabs(q) < SPH_J1C_CUTOFF) {
+        const double q2 = q*q;
+        return (1.0 + q2*(-3./30. + q2*(3./840. + q2*(-3./45360.))));// + q2*(3./3991680.)))));
+    } else {
+        double sin_q, cos_q;
+        SINCOS(q, sin_q, cos_q);
+        return 3.0*(sin_q/q - cos_q)/(q*q);
+    }
+}
+
+
+#line 1 ".././models/polymer_micelle.c"
+
+double Iq(double q,
+        double ndensity,
+        double v_core,
+        double v_corona,
+        double solvent_sld,
+        double core_sld,
+        double corona_sld,
+        double radius_core,
+        double rg,
+        double d_penetration,
+        double n_aggreg);
+
+static double micelle_spherical_kernel(double q,
+        double ndensity,
+        double v_core,
+        double v_corona,
+        double solvent_sld,
+        double core_sld,
+        double corona_sld,
+        double radius_core,
+        double rg,
+        double d_penetration,
+        double n_aggreg)
+{
+    const double rho_solv = solvent_sld;     // sld of solvent [1/A^2]
+    const double rho_core = core_sld;        // sld of core [1/A^2]
+    const double rho_corona = corona_sld;    // sld of corona [1/A^2]
+
+    const double beta_core = v_core * (rho_core - rho_solv);
+    const double beta_corona = v_corona * (rho_corona - rho_solv);
+
+    // Self-correlation term of the core
+    const double bes_core = sas_3j1x_x(q*radius_core);
+    const double term1 = square(n_aggreg*beta_core*bes_core);
+
+    // Self-correlation term of the chains
+    const double qrg2 = square(q*rg);
+    const double debye_chain = (qrg2 == 0.0) ? 1.0 : 2.0*(expm1(-qrg2)+qrg2)/(qrg2*qrg2);
+    const double term2 = n_aggreg * beta_corona * beta_corona * debye_chain;
+
+    // Interference cross-term between core and chains
+    const double chain_ampl = (qrg2 == 0.0) ? 1.0 : -expm1(-qrg2)/qrg2;
+    const double bes_corona = sas_sinx_x(q*(radius_core + d_penetration * rg));
+    const double term3 = 2.0 * n_aggreg * n_aggreg * beta_core * beta_corona *
+                 bes_core * chain_ampl * bes_corona;
+
+    // Interference cross-term between chains
+    const double term4 = n_aggreg * (n_aggreg - 1.0)
+                 * square(beta_corona * chain_ampl * bes_corona);
+
+    // I(q)_micelle : Sum of 4 terms computed above
+    double i_micelle = term1 + term2 + term3 + term4;
+
+    // rescale from [A^2] to [cm^2]
+    i_micelle *= 1.0e-13;
+
+    // "normalize" by number density --> intensity in [cm-1]
+    i_micelle *= ndensity;
+
+    return(i_micelle);
+
+}
+
+double Iq(double q,
+        double ndensity,
+        double v_core,
+        double v_corona,
+        double solvent_sld,
+        double core_sld,
+        double corona_sld,
+        double radius_core,
+        double rg,
+        double d_penetration,
+        double n_aggreg)
+{
+    return micelle_spherical_kernel(q,
+            ndensity,
+            v_core,
+            v_corona,
+            solvent_sld,
+            core_sld,
+            corona_sld,
+            radius_core,
+            rg,
+            d_penetration,
+            n_aggreg);
+}
+
+

--- a/mcstas-comps/share/sas_porod.c
+++ b/mcstas-comps/share/sas_porod.c
@@ -1,0 +1,398 @@
+#define HAS_Iq
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/porod.c"
+
+#include <math.h>
+  
+double Iq(double q);
+
+#pragma acc routine seq
+double Iq(double q) {
+    return pow(q, -4);
+}
+
+
+

--- a/mcstas-comps/share/sas_power_law.c
+++ b/mcstas-comps/share/sas_power_law.c
@@ -1,0 +1,399 @@
+#define HAS_Iq
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/power_law.c"
+
+#include <math.h>
+
+double Iq(double q, double power);
+
+#pragma acc routine seq
+double Iq(double q, double power) {
+    double result = pow(q, -power);
+    return result;
+}
+
+
+

--- a/mcstas-comps/share/sas_pringle.c
+++ b/mcstas-comps/share/sas_pringle.c
@@ -1,0 +1,1536 @@
+#define HAS_Iq
+#define FORM_VOL
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/polevl.c"
+
+/*							polevl.c
+ *							p1evl.c
+ *
+ *	Evaluate polynomial
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * int N;
+ * double x, y, coef[N+1], polevl[];
+ *
+ * y = polevl( x, coef, N );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Evaluates polynomial of degree N:
+ *
+ *                     2          N
+ * y  =  C  + C x + C x  +...+ C x
+ *        0    1     2          N
+ *
+ * Coefficients are stored in reverse order:
+ *
+ * coef[0] = C  , ..., coef[N] = C  .
+ *            N                   0
+ *
+ * The function p1evl() assumes that C_N = 1.0 and is
+ * omitted from the array.  Its calling arguments are
+ * otherwise the same as polevl().
+ *
+ *
+ * SPEED:
+ *
+ * In the interest of speed, there are no checks for out
+ * of bounds arithmetic.  This routine is used by most of
+ * the functions in the library.  Depending on available
+ * equipment features, the user may wish to rewrite the
+ * program in microcode or assembly language.
+ *
+ */
+
+
+/*
+Cephes Math Library Release 2.1:  December, 1988
+Copyright 1984, 1987, 1988 by Stephen L. Moshier
+Direct inquiries to 30 Frost Street, Cambridge, MA 02140
+*/
+#pragma acc routine seq
+static
+double polevl( double x, pconstant double *coef, int N )
+{
+
+    int i = 0;
+    double ans = coef[i];
+
+    while (i < N) {
+        i++;
+        ans = ans * x + coef[i];
+    }
+
+    return ans;
+}
+
+/*							p1evl()	*/
+/*                                          N
+ * Evaluate polynomial when coefficient of x  is 1.0.
+ * Otherwise same as polevl.
+ */
+#pragma acc routine seq
+static
+double p1evl( double x, pconstant double *coef, int N )
+{
+    int i=0;
+    double ans = x+coef[i];
+
+    while (i < N-1) {
+        i++;
+        ans = ans*x + coef[i];
+    }
+
+    return ans;
+}
+
+
+#line 1 ".././models/lib/sas_J0.c"
+
+/*							j0.c
+ *
+ *	Bessel function of order zero
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * double x, y, j0();
+ *
+ * y = j0( x );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Returns Bessel function of order zero of the argument.
+ *
+ * The domain is divided into the intervals [0, 5] and
+ * (5, infinity). In the first interval the following rational
+ * approximation is used:
+ *
+ *
+ *        2         2
+ * (w - r  ) (w - r  ) P (w) / Q (w)
+ *       1         2    3       8
+ *
+ *            2
+ * where w = x  and the two r's are zeros of the function.
+ *
+ * In the second interval, the Hankel asymptotic expansion
+ * is employed with two rational functions of degree 6/6
+ * and 7/7.
+ *
+ *
+ *
+ * ACCURACY:
+ *
+ *                      Absolute error:
+ * arithmetic   domain     # trials      peak         rms
+ *    DEC       0, 30       10000       4.4e-17     6.3e-18
+ *    IEEE      0, 30       60000       4.2e-16     1.1e-16
+ *
+ */
+
+/*
+Cephes Math Library Release 2.8:  June, 2000
+Copyright 1984, 1987, 1989, 2000 by Stephen L. Moshier
+*/
+
+/* Note: all coefficients satisfy the relative error criterion
+ * except YP, YQ which are designed for absolute error. */
+
+#if FLOAT_SIZE>4
+//Cephes double precission
+double cephes_j0(double x);
+
+ constant double PPJ0[8] = {
+        7.96936729297347051624E-4,
+        8.28352392107440799803E-2,
+        1.23953371646414299388E0,
+        5.44725003058768775090E0,
+        8.74716500199817011941E0,
+        5.30324038235394892183E0,
+        9.99999999999999997821E-1,
+        0.0
+    };
+
+ constant double PQJ0[8] = {
+        9.24408810558863637013E-4,
+        8.56288474354474431428E-2,
+        1.25352743901058953537E0,
+        5.47097740330417105182E0,
+        8.76190883237069594232E0,
+        5.30605288235394617618E0,
+        1.00000000000000000218E0,
+        0.0
+    };
+
+ constant double QPJ0[8] = {
+        -1.13663838898469149931E-2,
+        -1.28252718670509318512E0,
+        -1.95539544257735972385E1,
+        -9.32060152123768231369E1,
+        -1.77681167980488050595E2,
+        -1.47077505154951170175E2,
+        -5.14105326766599330220E1,
+        -6.05014350600728481186E0,
+    };
+
+ constant double QQJ0[8] = {
+        /*  1.00000000000000000000E0,*/
+        6.43178256118178023184E1,
+        8.56430025976980587198E2,
+        3.88240183605401609683E3,
+        7.24046774195652478189E3,
+        5.93072701187316984827E3,
+        2.06209331660327847417E3,
+        2.42005740240291393179E2,
+    };
+
+ constant double YPJ0[8] = {
+        1.55924367855235737965E4,
+        -1.46639295903971606143E7,
+        5.43526477051876500413E9,
+        -9.82136065717911466409E11,
+        8.75906394395366999549E13,
+        -3.46628303384729719441E15,
+        4.42733268572569800351E16,
+        -1.84950800436986690637E16,
+ };
+
+
+ constant double YQJ0[7] = {
+        /* 1.00000000000000000000E0,*/
+        1.04128353664259848412E3,
+        6.26107330137134956842E5,
+        2.68919633393814121987E8,
+        8.64002487103935000337E10,
+        2.02979612750105546709E13,
+        3.17157752842975028269E15,
+        2.50596256172653059228E17,
+  };
+
+ constant double RPJ0[8] = {
+        -4.79443220978201773821E9,
+        1.95617491946556577543E12,
+        -2.49248344360967716204E14,
+        9.70862251047306323952E15,
+        0.0,
+        0.0,
+        0.0,
+        0.0
+  };
+
+ constant double RQJ0[8] = {
+        /* 1.00000000000000000000E0,*/
+        4.99563147152651017219E2,
+        1.73785401676374683123E5,
+        4.84409658339962045305E7,
+        1.11855537045356834862E10,
+        2.11277520115489217587E12,
+        3.10518229857422583814E14,
+        3.18121955943204943306E16,
+        1.71086294081043136091E18,
+  };
+
+#pragma acc declare copyin( PPJ0[0:8], PQJ0[0:8], QPJ0[0:8], QQJ0[0:8], YPJ0[0:8], YQJ0[0:7], RPJ0[0:8], RQJ0[0:8])
+
+#pragma acc routine seq
+double cephes_j0(double x)
+{
+    double w, z, p, q, xn;
+
+    //const double TWOOPI = 6.36619772367581343075535E-1;
+    const double SQ2OPI = 7.9788456080286535587989E-1;
+    const double PIO4 = 7.85398163397448309616E-1;
+
+    const double DR1 = 5.78318596294678452118E0;
+    const double DR2 = 3.04712623436620863991E1;
+
+
+    if( x < 0 )
+        x = -x;
+
+    if( x <= 5.0 ) {
+        z = x * x;
+        if( x < 1.0e-5 )
+            return( 1.0 - z/4.0 );
+
+        p = (z - DR1) * (z - DR2);
+        p = p * polevl( z, RPJ0, 3)/p1evl( z, RQJ0, 8 );
+        return( p );
+    }
+
+    w = 5.0/x;
+    q = 25.0/(x*x);
+    p = polevl( q, PPJ0, 6)/polevl( q, PQJ0, 6 );
+    q = polevl( q, QPJ0, 7)/p1evl( q, QQJ0, 7 );
+    xn = x - PIO4;
+
+    double sn, cn;
+    SINCOS(xn, sn, cn);
+    p = p * cn - w * q * sn;
+
+    return( p * SQ2OPI / sqrt(x) );
+}
+#else
+//Cephes single precission
+
+#pragma acc routine seq
+float cephes_j0f(float x);
+
+ constant float MOJ0[8] = {
+        -6.838999669318810E-002,
+        1.864949361379502E-001,
+        -2.145007480346739E-001,
+        1.197549369473540E-001,
+        -3.560281861530129E-003,
+        -4.969382655296620E-002,
+        -3.355424622293709E-006,
+        7.978845717621440E-001
+  };
+
+ constant float PHJ0[8] = {
+        3.242077816988247E+001,
+        -3.630592630518434E+001,
+        1.756221482109099E+001,
+        -4.974978466280903E+000,
+        1.001973420681837E+000,
+        -1.939906941791308E-001,
+        6.490598792654666E-002,
+        -1.249992184872738E-001
+  };
+
+ constant float JPJ0[8] = {
+        -6.068350350393235E-008,
+        6.388945720783375E-006,
+        -3.969646342510940E-004,
+        1.332913422519003E-002,
+        -1.729150680240724E-001,
+        0.0,
+        0.0,
+        0.0
+ };
+
+#pragma acc declare copyin( MOJ0[0:8], PHJ0[0:8], JPJ0[0:8])
+
+#pragma acc routine seq
+float cephes_j0f(float x)
+{
+    float xx, w, z, p, q, xn;
+
+    //const double YZ1 =  0.43221455686510834878;
+    //const double YZ2 = 22.401876406482861405;
+    //const double YZ3 = 64.130620282338755553;
+    const float DR1 =  5.78318596294678452118;
+    const float PIO4F = 0.7853981633974483096;
+
+    if( x < 0 )
+        xx = -x;
+    else
+        xx = x;
+
+    // 2017-05-18 PAK - support negative x
+    if( xx <= 2.0 ) {
+        z = xx * xx;
+        if( xx < 1.0e-3 )
+            return( 1.0 - 0.25*z );
+
+        p = (z-DR1) * polevl( z, JPJ0, 4);
+        return( p );
+    }
+
+    q = 1.0/xx;
+    w = sqrt(q);
+
+    p = w * polevl( q, MOJ0, 7);
+    w = q*q;
+    xn = q * polevl( w, PHJ0, 7) - PIO4F;
+    p = p * cos(xn + xx);
+    return(p);
+}
+#endif
+
+#if FLOAT_SIZE>4
+#define sas_J0 cephes_j0
+#else
+#define sas_J0 cephes_j0f
+#endif
+
+
+#line 1 ".././models/lib/sas_J1.c"
+
+/*							j1.c
+ *
+ *	Bessel function of order one
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * double x, y, j1();
+ *
+ * y = j1( x );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Returns Bessel function of order one of the argument.
+ *
+ * The domain is divided into the intervals [0, 8] and
+ * (8, infinity). In the first interval a 24 term Chebyshev
+ * expansion is used. In the second, the asymptotic
+ * trigonometric representation is employed using two
+ * rational functions of degree 5/5.
+ *
+ *
+ *
+ * ACCURACY:
+ *
+ *                      Absolute error:
+ * arithmetic   domain      # trials      peak         rms
+ *    DEC       0, 30       10000       4.0e-17     1.1e-17
+ *    IEEE      0, 30       30000       2.6e-16     1.1e-16
+ *
+ *
+ */
+
+/*
+Cephes Math Library Release 2.8:  June, 2000
+Copyright 1984, 1987, 1989, 2000 by Stephen L. Moshier
+*/
+
+#if FLOAT_SIZE>4
+//Cephes double pression function
+
+constant double RPJ1[8] = {
+    -8.99971225705559398224E8,
+    4.52228297998194034323E11,
+    -7.27494245221818276015E13,
+    3.68295732863852883286E15,
+    0.0,
+    0.0,
+    0.0,
+    0.0 };
+
+constant double RQJ1[8] = {
+    6.20836478118054335476E2,
+    2.56987256757748830383E5,
+    8.35146791431949253037E7,
+    2.21511595479792499675E10,
+    4.74914122079991414898E12,
+    7.84369607876235854894E14,
+    8.95222336184627338078E16,
+    5.32278620332680085395E18
+    };
+
+constant double PPJ1[8] = {
+    7.62125616208173112003E-4,
+    7.31397056940917570436E-2,
+    1.12719608129684925192E0,
+    5.11207951146807644818E0,
+    8.42404590141772420927E0,
+    5.21451598682361504063E0,
+    1.00000000000000000254E0,
+    0.0} ;
+
+
+constant double PQJ1[8] = {
+    5.71323128072548699714E-4,
+    6.88455908754495404082E-2,
+    1.10514232634061696926E0,
+    5.07386386128601488557E0,
+    8.39985554327604159757E0,
+    5.20982848682361821619E0,
+    9.99999999999999997461E-1,
+    0.0 };
+
+constant double QPJ1[8] = {
+    5.10862594750176621635E-2,
+    4.98213872951233449420E0,
+    7.58238284132545283818E1,
+    3.66779609360150777800E2,
+    7.10856304998926107277E2,
+    5.97489612400613639965E2,
+    2.11688757100572135698E2,
+    2.52070205858023719784E1 };
+
+constant double QQJ1[8] = {
+    7.42373277035675149943E1,
+    1.05644886038262816351E3,
+    4.98641058337653607651E3,
+    9.56231892404756170795E3,
+    7.99704160447350683650E3,
+    2.82619278517639096600E3,
+    3.36093607810698293419E2,
+    0.0 };
+
+#pragma acc declare copyin( RPJ1[0:8], RQJ1[0:8], PPJ1[0:8], PQJ1[0:8], QPJ1[0:8], QQJ1[0:8])
+
+#pragma acc routine seq
+static
+double cephes_j1(double x)
+{
+
+    double w, z, p, q, abs_x, sign_x;
+
+    const double Z1 = 1.46819706421238932572E1;
+    const double Z2 = 4.92184563216946036703E1;
+
+    // 2017-05-18 PAK - mathematica and mpmath use J1(-x) = -J1(x)
+    if (x < 0) {
+        abs_x = -x;
+        sign_x = -1.0;
+    } else {
+        abs_x = x;
+        sign_x = 1.0;
+    }
+
+    if( abs_x <= 5.0 ) {
+        z = abs_x * abs_x;
+        w = polevl( z, RPJ1, 3 ) / p1evl( z, RQJ1, 8 );
+        w = w * abs_x * (z - Z1) * (z - Z2);
+        return( sign_x * w );
+    }
+
+    w = 5.0/abs_x;
+    z = w * w;
+    p = polevl( z, PPJ1, 6)/polevl( z, PQJ1, 6 );
+    q = polevl( z, QPJ1, 7)/p1evl( z, QQJ1, 7 );
+
+    // 2017-05-19 PAK improve accuracy using trig identies
+    // original:
+    //    const double THPIO4 =  2.35619449019234492885;
+    //    const double SQ2OPI = 0.79788456080286535588;
+    //    double sin_xn, cos_xn;
+    //    SINCOS(abs_x - THPIO4, sin_xn, cos_xn);
+    //    p = p * cos_xn - w * q * sin_xn;
+    //    return( sign_x * p * SQ2OPI / sqrt(abs_x) );
+    // expanding p*cos(a - 3 pi/4) - wq sin(a - 3 pi/4)
+    //    [ p(sin(a) - cos(a)) + wq(sin(a) + cos(a)) / sqrt(2)
+    // note that sqrt(1/2) * sqrt(2/pi) = sqrt(1/pi)
+    const double SQRT1_PI = 0.56418958354775628;
+    double sin_x, cos_x;
+    SINCOS(abs_x, sin_x, cos_x);
+    p = p*(sin_x - cos_x) + w*q*(sin_x + cos_x);
+    return( sign_x * p * SQRT1_PI / sqrt(abs_x) );
+}
+
+#else
+//Single precission version of cephes
+
+constant float JPJ1[8] = {
+    -4.878788132172128E-009,
+    6.009061827883699E-007,
+    -4.541343896997497E-005,
+    1.937383947804541E-003,
+    -3.405537384615824E-002,
+    0.0,
+    0.0,
+    0.0
+    };
+
+constant float MO1J1[8] = {
+    6.913942741265801E-002,
+    -2.284801500053359E-001,
+    3.138238455499697E-001,
+    -2.102302420403875E-001,
+    5.435364690523026E-003,
+    1.493389585089498E-001,
+    4.976029650847191E-006,
+    7.978845453073848E-001
+    };
+
+constant float PH1J1[8] = {
+    -4.497014141919556E+001,
+    5.073465654089319E+001,
+    -2.485774108720340E+001,
+    7.222973196770240E+000,
+    -1.544842782180211E+000,
+    3.503787691653334E-001,
+    -1.637986776941202E-001,
+    3.749989509080821E-001
+    };
+
+#pragma acc declare copyin( JPJ1[0:8], MO1J1[0:8], PH1J1[0:8])
+
+#pragma acc routine seq
+static
+float cephes_j1f(float xx)
+{
+
+    float x, w, z, p, q, xn;
+
+    const float Z1 = 1.46819706421238932572E1;
+
+
+    // 2017-05-18 PAK - mathematica and mpmath use J1(-x) = -J1(x)
+    x = xx;
+    if( x < 0 )
+        x = -xx;
+
+    if( x <= 2.0 ) {
+        z = x * x;
+        p = (z-Z1) * x * polevl( z, JPJ1, 4 );
+        return( xx < 0. ? -p : p );
+    }
+
+    q = 1.0/x;
+    w = sqrt(q);
+
+    p = w * polevl( q, MO1J1, 7);
+    w = q*q;
+    // 2017-05-19 PAK improve accuracy using trig identies
+    // original:
+    //    const float THPIO4F =  2.35619449019234492885;    /* 3*pi/4 */
+    //    xn = q * polevl( w, PH1J1, 7) - THPIO4F;
+    //    p = p * cos(xn + x);
+    //    return( xx < 0. ? -p : p );
+    // expanding cos(a + b - 3 pi/4) is
+    //    [sin(a)sin(b) + sin(a)cos(b) + cos(a)sin(b)-cos(a)cos(b)] / sqrt(2)
+    xn = q * polevl( w, PH1J1, 7);
+    float cos_xn, sin_xn;
+    float cos_x, sin_x;
+    SINCOS(xn, sin_xn, cos_xn);  // about xn and 1
+    SINCOS(x, sin_x, cos_x);
+    p *= M_SQRT1_2*(sin_xn*(sin_x+cos_x) + cos_xn*(sin_x-cos_x));
+
+    return( xx < 0. ? -p : p );
+}
+#endif
+
+#if FLOAT_SIZE>4
+#define sas_J1 cephes_j1
+#else
+#define sas_J1 cephes_j1f
+#endif
+
+//Finally J1c function that equals 2*J1(x)/x
+    
+#pragma acc routine seq
+static
+double sas_2J1x_x(double x)
+{
+    return (x != 0.0 ) ? 2.0*sas_J1(x)/x : 1.0;
+}
+
+
+#line 1 ".././models/lib/sas_JN.c"
+
+/*							jn.c
+ *
+ *	Bessel function of integer order
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * int n;
+ * double x, y, jn();
+ *
+ * y = jn( n, x );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Returns Bessel function of order n, where n is a
+ * (possibly negative) integer.
+ *
+ * The ratio of jn(x) to j0(x) is computed by backward
+ * recurrence.  First the ratio jn/jn-1 is found by a
+ * continued fraction expansion.  Then the recurrence
+ * relating successive orders is applied until j0 or j1 is
+ * reached.
+ *
+ * If n = 0 or 1 the routine for j0 or j1 is called
+ * directly.
+ *
+ *
+ *
+ * ACCURACY:
+ *
+ *                      Absolute error:
+ * arithmetic   range      # trials      peak         rms
+ *    DEC       0, 30        5500       6.9e-17     9.3e-18
+ *    IEEE      0, 30        5000       4.4e-16     7.9e-17
+ *
+ *
+ * Not suitable for large n or x. Use jv() instead.
+ *
+ */
+
+/*							jn.c
+Cephes Math Library Release 2.8:  June, 2000
+Copyright 1984, 1987, 2000 by Stephen L. Moshier
+*/
+
+#if FLOAT_SIZE > 4
+
+double cephes_jn( int n, double x );
+
+    
+#pragma acc routine seq
+double cephes_jn( int n, double x ) {
+
+    // PAK: seems to be machine epsilon/2
+    const double MACHEP = 1.11022302462515654042E-16;
+    double pkm2, pkm1, pk, xk, r, ans;
+    int k, sign;
+
+    if( n < 0 ) {
+        n = -n;
+        if( (n & 1) == 0 )	/* -1**n */
+            sign = 1;
+        else
+            sign = -1;
+    } else {
+        sign = 1;
+    }
+
+    if( x < 0.0 ) {
+        if( n & 1 )
+            sign = -sign;
+    x = -x;
+    }
+
+    if( n == 0 )
+        return( sign * cephes_j0(x) );
+    if( n == 1 )
+        return( sign * cephes_j1(x) );
+    if( n == 2 )
+        return( sign * (2.0 * cephes_j1(x) / x  -  cephes_j0(x)) );
+
+    if( x < MACHEP )
+        return( 0.0 );
+
+    k = 53;
+    pk = 2 * (n + k);
+    ans = pk;
+    xk = x * x;
+
+    do {
+        pk -= 2.0;
+        ans = pk - (xk/ans);
+    } while( --k > 0 );
+
+    /* backward recurrence */
+
+    pk = 1.0;
+
+    ans = x/ans;
+    pkm1 = 1.0/ans;
+
+    k = n-1;
+    r = 2 * k;
+
+    do {
+        pkm2 = (pkm1 * r  -  pk * x) / x;
+        pk = pkm1;
+        pkm1 = pkm2;
+        r -= 2.0;
+    } while( --k > 0 );
+
+    if( fabs(pk) > fabs(pkm1) )
+        ans = cephes_j1(x)/pk;
+    else
+        ans = cephes_j0(x)/pkm1;
+
+    return( sign * ans );
+}
+
+#else
+
+float cephes_jnf(int n, float x);
+
+    
+#pragma acc routine seq
+float cephes_jnf(int n, float x)
+{
+    // PAK: seems to be machine epsilon/2
+    const double MACHEP = 5.9604645e-08;
+    float pkm2, pkm1, pk, xk, r, ans;
+    int k, sign;
+
+    if( n < 0 ) {
+        n = -n;
+        if( (n & 1) == 0 ) /* -1**n */
+            sign = 1;
+        else
+            sign = -1;
+    } else {
+        sign = 1;
+    }
+
+    if( x < 0.0 ) {
+        if( n & 1 )
+            sign = -sign;
+        x = -x;
+    }
+
+    if( n == 0 )
+        return( sign * cephes_j0f(x) );
+    if( n == 1 )
+        return( sign * cephes_j1f(x) );
+    if( n == 2 )
+        return( sign * (2.0 * cephes_j1f(x) / x  -  cephes_j0f(x)) );
+
+    if( x < MACHEP )
+        return( 0.0 );
+
+    k = 24;
+    pk = 2 * (n + k);
+    ans = pk;
+    xk = x * x;
+
+    do {
+        pk -= 2.0;
+        ans = pk - (xk/ans);
+    } while( --k > 0 );
+
+    /* backward recurrence */
+
+    pk = 1.0;
+
+    const float xinv = 1.0/x;
+    pkm1 = ans * xinv;
+    k = n-1;
+    r = (float )(2 * k);
+
+    do {
+        pkm2 = (pkm1 * r  -  pk * x) * xinv;
+        pk = pkm1;
+        pkm1 = pkm2;
+        r -= 2.0;
+    } while( --k > 0 );
+
+    r = pk;
+    if( r < 0 )
+        r = -r;
+    ans = pkm1;
+    if( ans < 0 )
+        ans = -ans;
+
+    if( r > ans )  /* if( fabs(pk) > fabs(pkm1) ) */
+        ans = sign * cephes_j1f(x)/pk;
+    else
+        ans = sign * cephes_j0f(x)/pkm1;
+    return( ans );
+}
+#endif
+
+#if FLOAT_SIZE>4
+#define sas_JN cephes_jn
+#else
+#define sas_JN cephes_jnf
+#endif
+
+
+#line 1 ".././models/lib/gauss76.c"
+
+// Created by Andrew Jackson on 4/23/07
+
+ #ifdef GAUSS_N
+ # undef GAUSS_N
+ # undef GAUSS_Z
+ # undef GAUSS_W
+ #endif
+ #define GAUSS_N 76
+ #define GAUSS_Z Gauss76Z
+ #define GAUSS_W Gauss76Wt
+
+// Gaussians
+constant double Gauss76Wt[76] = {
+	.00126779163408536,		//0
+	.00294910295364247,
+	.00462793522803742,
+	.00629918049732845,
+	.00795984747723973,
+	.00960710541471375,
+	.0112381685696677,
+	.0128502838475101,
+	.0144407317482767,
+	.0160068299122486,
+	.0175459372914742,		//10
+	.0190554584671906,
+	.020532847967908,
+	.0219756145344162,
+	.0233813253070112,
+	.0247476099206597,
+	.026072164497986,
+	.0273527555318275,
+	.028587223650054,
+	.029773487255905,
+	.0309095460374916,		//20
+	.0319934843404216,
+	.0330234743977917,
+	.0339977794120564,
+	.0349147564835508,
+	.0357728593807139,
+	.0365706411473296,
+	.0373067565423816,
+	.0379799643084053,
+	.0385891292645067,
+	.0391332242205184,		//30
+	.0396113317090621,
+	.0400226455325968,
+	.040366472122844,
+	.0406422317102947,
+	.0408494593018285,
+	.040987805464794,
+	.0410570369162294,
+	.0410570369162294,
+	.040987805464794,
+	.0408494593018285,		//40
+	.0406422317102947,
+	.040366472122844,
+	.0400226455325968,
+	.0396113317090621,
+	.0391332242205184,
+	.0385891292645067,
+	.0379799643084053,
+	.0373067565423816,
+	.0365706411473296,
+	.0357728593807139,		//50
+	.0349147564835508,
+	.0339977794120564,
+	.0330234743977917,
+	.0319934843404216,
+	.0309095460374916,
+	.029773487255905,
+	.028587223650054,
+	.0273527555318275,
+	.026072164497986,
+	.0247476099206597,		//60
+	.0233813253070112,
+	.0219756145344162,
+	.020532847967908,
+	.0190554584671906,
+	.0175459372914742,
+	.0160068299122486,
+	.0144407317482767,
+	.0128502838475101,
+	.0112381685696677,
+	.00960710541471375,		//70
+	.00795984747723973,
+	.00629918049732845,
+	.00462793522803742,
+	.00294910295364247,
+	.00126779163408536		//75 (indexed from 0)
+};
+
+constant double Gauss76Z[76] = {
+	-.999505948362153,		//0
+	-.997397786355355,
+	-.993608772723527,
+	-.988144453359837,
+	-.981013938975656,
+	-.972229228520377,
+	-.961805126758768,
+	-.949759207710896,
+	-.936111781934811,
+	-.92088586125215,
+	-.904107119545567,		//10
+	-.885803849292083,
+	-.866006913771982,
+	-.844749694983342,
+	-.822068037328975,
+	-.7980001871612,
+	-.77258672828181,
+	-.74587051350361,
+	-.717896592387704,
+	-.688712135277641,
+	-.658366353758143,		//20
+	-.626910417672267,
+	-.594397368836793,
+	-.560882031601237,
+	-.526420920401243,
+	-.491072144462194,
+	-.454895309813726,
+	-.417951418780327,
+	-.380302767117504,
+	-.342012838966962,
+	-.303146199807908,		//30
+	-.263768387584994,
+	-.223945802196474,
+	-.183745593528914,
+	-.143235548227268,
+	-.102483975391227,
+	-.0615595913906112,
+	-.0205314039939986,
+	.0205314039939986,
+	.0615595913906112,
+	.102483975391227,			//40
+	.143235548227268,
+	.183745593528914,
+	.223945802196474,
+	.263768387584994,
+	.303146199807908,
+	.342012838966962,
+	.380302767117504,
+	.417951418780327,
+	.454895309813726,
+	.491072144462194,		//50
+	.526420920401243,
+	.560882031601237,
+	.594397368836793,
+	.626910417672267,
+	.658366353758143,
+	.688712135277641,
+	.717896592387704,
+	.74587051350361,
+	.77258672828181,
+	.7980001871612,	//60
+	.822068037328975,
+	.844749694983342,
+	.866006913771982,
+	.885803849292083,
+	.904107119545567,
+	.92088586125215,
+	.936111781934811,
+	.949759207710896,
+	.961805126758768,
+	.972229228520377,		//70
+	.981013938975656,
+	.988144453359837,
+	.993608772723527,
+	.997397786355355,
+	.999505948362153		//75
+};
+
+
+#pragma acc declare copyin(Gauss76Wt[0:76], Gauss76Z[0:76])
+
+#line 1 ".././models/pringle.c"
+
+double form_volume(double radius, double thickness, double alpha, double beta);
+
+double Iq(double q,
+          double radius,
+          double thickness,
+          double alpha,
+          double beta,
+          double sld,
+          double sld_solvent);
+
+
+static
+void _integrate_bessel(
+    double radius,
+    double alpha,
+    double beta,
+    double q_sin_psi,
+    double q_cos_psi,
+    double n,
+    double *Sn,
+    double *Cn)
+{
+    // translate gauss point z in [-1,1] to a point in [0, radius]
+    const double zm = 0.5*radius;
+    const double zb = 0.5*radius;
+
+    // evaluate at Gauss points
+    double sumS = 0.0;		// initialize integral
+    double sumC = 0.0;		// initialize integral
+    double r;
+    for (int i=0; i < GAUSS_N; i++) {
+        r = GAUSS_Z[i]*zm + zb;
+
+        const double qrs = r*q_sin_psi;
+        const double qrrc = r*r*q_cos_psi;
+
+        double y = GAUSS_W[i] * r * sas_JN(n, beta*qrrc) * sas_JN(2*n, qrs);
+        double S, C;
+        SINCOS(alpha*qrrc, S, C);
+        sumS += y*S;
+        sumC += y*C;
+    }
+
+    *Sn = zm*sumS / (radius*radius);
+    *Cn = zm*sumC / (radius*radius);
+}
+
+static
+double _sum_bessel_orders(
+    double radius,
+    double alpha,
+    double beta,
+    double q_sin_psi,
+    double q_cos_psi)
+{
+    //calculate sum term from n = -3 to 3
+    //Note 1:
+    //    S_n(-x) = (-1)^S_n(x)
+    //    => S_n^2(-x) = S_n^2(x),
+    //    => sum_-k^k Sk = S_0^2 + 2*sum_1^kSk^2
+    //Note 2:
+    //    better precision to sum terms from smaller to larger
+    //    though it doesn't seem to make a difference in this case.
+    double Sn, Cn, sum;
+    sum = 0.0;
+    for (int n=3; n>0; n--) {
+      _integrate_bessel(radius, alpha, beta, q_sin_psi, q_cos_psi, n, &Sn, &Cn);
+      sum += 2.0*(Sn*Sn + Cn*Cn);
+    }
+    _integrate_bessel(radius, alpha, beta, q_sin_psi, q_cos_psi, 0, &Sn, &Cn);
+    sum += Sn*Sn+ Cn*Cn;
+    return sum;
+}
+
+static
+double _integrate_psi(
+    double q,
+    double radius,
+    double thickness,
+    double alpha,
+    double beta)
+{
+    // translate gauss point z in [-1,1] to a point in [0, pi/2]
+    const double zm = M_PI_4;
+    const double zb = M_PI_4;
+
+    double sum = 0.0;
+    for (int i = 0; i < GAUSS_N; i++) {
+        double psi = GAUSS_Z[i]*zm + zb;
+        double sin_psi, cos_psi;
+        SINCOS(psi, sin_psi, cos_psi);
+        double bessel_term = _sum_bessel_orders(radius, alpha, beta, q*sin_psi, q*cos_psi);
+        double sinc_term = square(sas_sinx_x(q * thickness * cos_psi / 2.0));
+        double pringle_kernel = 4.0 * sin_psi * bessel_term * sinc_term;
+        sum += GAUSS_W[i] * pringle_kernel;
+    }
+
+    return zm * sum;
+}
+
+double form_volume(double radius, double thickness, double alpha, double beta)
+{
+    return M_PI*radius*radius*thickness;
+}
+
+static double
+radius_from_excluded_volume(double radius, double thickness)
+{
+    return 0.5*cbrt(0.75*radius*(2.0*radius*thickness + (radius + thickness)*(M_PI*radius + thickness)));
+}
+
+static double
+radius_effective(int mode, double radius, double thickness, double alpha, double beta)
+{
+    switch (mode) {
+    default:
+    case 1: // equivalent cylinder excluded volume
+        return radius_from_excluded_volume(radius, thickness);
+    case 2: // equivalent volume sphere
+        return cbrt(M_PI*radius*radius*thickness/M_4PI_3);
+    case 3: // radius
+        return radius;
+    }
+}
+
+double Iq(
+    double q,
+    double radius,
+    double thickness,
+    double alpha,
+    double beta,
+    double sld,
+    double sld_solvent)
+{
+    double form = _integrate_psi(q, radius, thickness, alpha, beta);
+    double contrast = sld - sld_solvent;
+    double volume = M_PI*radius*radius*thickness;
+    return 1.0e-4*form * square(contrast * volume);
+}
+
+

--- a/mcstas-comps/share/sas_raspberry.c
+++ b/mcstas-comps/share/sas_raspberry.c
@@ -1,0 +1,547 @@
+#define HAS_Iq
+#define FORM_VOL
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/sas_3j1x_x.c"
+
+/**
+* Spherical Bessel function 3*j1(x)/x
+*
+* Used for low q to avoid cancellation error.
+* Note that the values differ from sasview ~ 5e-12 rather than 5e-14, but
+* in this case it is likely cancellation errors in the original expression
+* using double precision that are the source.
+*/
+double sas_3j1x_x(double q);
+
+// The choice of the number of terms in the series and the cutoff value for
+// switching between series and direct calculation depends on the numeric
+// precision.
+//
+// Point where direct calculation reaches machine precision:
+//
+//   single machine precision eps 3e-8 at qr=1.1 **
+//   double machine precision eps 4e-16 at qr=1.1
+//
+// Point where Taylor series reaches machine precision (eps), where taylor
+// series matches direct calculation (cross) and the error at that point:
+//
+//   prec   n eps  cross  error
+//   single 3 0.28  0.4   6.2e-7
+//   single 4 0.68  0.7   2.3e-7
+//   single 5 1.18  1.2   7.5e-8
+//   double 3 0.01  0.03  2.3e-13
+//   double 4 0.06  0.1   3.1e-14
+//   double 5 0.16  0.2   5.0e-15
+//
+// ** Note: relative error on single precision starts increase on the direct
+// method at qr=1.1, rising from 3e-8 to 5e-5 by qr=1e3.  This should be
+// safe for the sans range, with objects of 100 nm supported to a q of 0.1
+// while maintaining 5 digits of precision.  For usans/sesans, the objects
+// are larger but the q is smaller, so again it should be fine.
+//
+// See explore/sph_j1c.py for code to explore these ranges.
+
+// Use 4th order series
+#if FLOAT_SIZE>4
+#define SPH_J1C_CUTOFF 0.1
+#else
+#define SPH_J1C_CUTOFF 0.7
+#endif
+#pragma acc routine seq
+double sas_3j1x_x(double q)
+{
+    // 2017-05-18 PAK - support negative q
+    if (fabs(q) < SPH_J1C_CUTOFF) {
+        const double q2 = q*q;
+        return (1.0 + q2*(-3./30. + q2*(3./840. + q2*(-3./45360.))));// + q2*(3./3991680.)))));
+    } else {
+        double sin_q, cos_q;
+        SINCOS(q, sin_q, cos_q);
+        return 3.0*(sin_q/q - cos_q)/(q*q);
+    }
+}
+
+
+#line 1 ".././models/raspberry.c"
+
+double form_volume(double radius_lg, double radius_sm, double penetration);
+
+double Iq(double q,
+          double sld_lg, double sld_sm, double sld_solvent,
+          double volfraction_lg, double volfraction_sm, double surf_fraction,
+          double radius_lg, double radius_sm, double penetration);
+
+double form_volume(double radius_lg, double radius_sm, double penetration)
+{
+    //Because of the complex structure, volume normalization must
+    //happen in the Iq code below.  Thus the form volume is set to 1.0 here
+    double volume=1.0;
+    return volume;
+}
+
+static double
+radius_effective(int mode, double radius_lg, double radius_sm, double penetration)
+{
+    switch (mode) {
+    default:
+    case 1: // radius_large
+        return radius_lg;
+    case 2: // radius_outer
+        return radius_lg + 2.0*radius_sm - penetration;
+    }
+}
+
+double Iq(double q,
+          double sld_lg, double sld_sm, double sld_solvent,
+          double volfraction_lg, double volfraction_sm, double surface_fraction,
+          double radius_lg, double radius_sm, double penetration)
+{
+    // Ref: J. coll. inter. sci. (2010) vol. 343 (1) pp. 36-41.
+
+
+    double vfL, rL, sldL, vfS, rS, sldS, deltaS, delrhoL, delrhoS, sldSolv;
+    double VL, VS, Np, f2, fSs;
+    double psiL,psiS;
+    double sfLS,sfSS;
+    double slT;
+
+    vfL = volfraction_lg;
+    rL = radius_lg;
+    sldL = sld_lg;
+    vfS = volfraction_sm;
+    fSs = surface_fraction;
+    rS = radius_sm;
+    sldS = sld_sm;
+    deltaS = penetration;
+    sldSolv = sld_solvent;
+
+    delrhoL = fabs(sldL - sldSolv);
+    delrhoS = fabs(sldS - sldSolv);
+
+    VL = M_4PI_3*rL*rL*rL;
+    VS = M_4PI_3*rS*rS*rS;
+
+    //Number of small particles per large particle
+    Np = vfS*fSs*VL/vfL/VS;
+
+    //Total scattering length difference
+    slT = delrhoL*VL + Np*delrhoS*VS;
+
+    //Form factors for each particle
+    psiL = sas_3j1x_x(q*rL);
+    psiS = sas_3j1x_x(q*rS);
+
+    //Cross term between large and small particles
+    sfLS = psiL*psiS*sas_sinx_x(q*(rL+deltaS*rS));
+    //Cross term between small particles at the surface
+    sfSS = psiS*psiS*sas_sinx_x(q*(rL+deltaS*rS))*sas_sinx_x(q*(rL+deltaS*rS));
+
+    //Large sphere form factor term
+    f2 = delrhoL*delrhoL*VL*VL*psiL*psiL;
+    //Small sphere form factor term
+    f2 += Np*delrhoS*delrhoS*VS*VS*psiS*psiS;
+    //Small particle - small particle cross term
+    f2 += Np*(Np-1)*delrhoS*delrhoS*VS*VS*sfSS;
+    //Large-small particle cross term
+    f2 += 2*Np*delrhoL*delrhoS*VL*VS*sfLS;
+    //Normalise by total scattering length difference
+    if (f2 != 0.0){
+        f2 = f2/slT/slT;
+        }
+
+    //I(q) for large-small composite particles
+    f2 = f2*(vfL*delrhoL*delrhoL*VL + vfS*fSs*Np*delrhoS*delrhoS*VS);
+    //I(q) for free small particles
+    f2+= vfS*(1.0-fSs)*delrhoS*delrhoS*VS*psiS*psiS;
+
+    // normalize to single particle volume and convert to 1/cm
+    f2 *= 1.0e8;        // [=] 1/cm
+    f2 *= 1.0e-12;      // convert for (1/A^-6)^2 to (1/A)^2
+
+    return f2;
+}
+
+

--- a/mcstas-comps/share/sas_rectangular_prism.c
+++ b/mcstas-comps/share/sas_rectangular_prism.c
@@ -1,0 +1,764 @@
+#define HAS_Iqabc
+#define HAS_Iq
+#define FORM_VOL
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/gauss76.c"
+
+// Created by Andrew Jackson on 4/23/07
+
+ #ifdef GAUSS_N
+ # undef GAUSS_N
+ # undef GAUSS_Z
+ # undef GAUSS_W
+ #endif
+ #define GAUSS_N 76
+ #define GAUSS_Z Gauss76Z
+ #define GAUSS_W Gauss76Wt
+
+// Gaussians
+constant double Gauss76Wt[76] = {
+	.00126779163408536,		//0
+	.00294910295364247,
+	.00462793522803742,
+	.00629918049732845,
+	.00795984747723973,
+	.00960710541471375,
+	.0112381685696677,
+	.0128502838475101,
+	.0144407317482767,
+	.0160068299122486,
+	.0175459372914742,		//10
+	.0190554584671906,
+	.020532847967908,
+	.0219756145344162,
+	.0233813253070112,
+	.0247476099206597,
+	.026072164497986,
+	.0273527555318275,
+	.028587223650054,
+	.029773487255905,
+	.0309095460374916,		//20
+	.0319934843404216,
+	.0330234743977917,
+	.0339977794120564,
+	.0349147564835508,
+	.0357728593807139,
+	.0365706411473296,
+	.0373067565423816,
+	.0379799643084053,
+	.0385891292645067,
+	.0391332242205184,		//30
+	.0396113317090621,
+	.0400226455325968,
+	.040366472122844,
+	.0406422317102947,
+	.0408494593018285,
+	.040987805464794,
+	.0410570369162294,
+	.0410570369162294,
+	.040987805464794,
+	.0408494593018285,		//40
+	.0406422317102947,
+	.040366472122844,
+	.0400226455325968,
+	.0396113317090621,
+	.0391332242205184,
+	.0385891292645067,
+	.0379799643084053,
+	.0373067565423816,
+	.0365706411473296,
+	.0357728593807139,		//50
+	.0349147564835508,
+	.0339977794120564,
+	.0330234743977917,
+	.0319934843404216,
+	.0309095460374916,
+	.029773487255905,
+	.028587223650054,
+	.0273527555318275,
+	.026072164497986,
+	.0247476099206597,		//60
+	.0233813253070112,
+	.0219756145344162,
+	.020532847967908,
+	.0190554584671906,
+	.0175459372914742,
+	.0160068299122486,
+	.0144407317482767,
+	.0128502838475101,
+	.0112381685696677,
+	.00960710541471375,		//70
+	.00795984747723973,
+	.00629918049732845,
+	.00462793522803742,
+	.00294910295364247,
+	.00126779163408536		//75 (indexed from 0)
+};
+
+constant double Gauss76Z[76] = {
+	-.999505948362153,		//0
+	-.997397786355355,
+	-.993608772723527,
+	-.988144453359837,
+	-.981013938975656,
+	-.972229228520377,
+	-.961805126758768,
+	-.949759207710896,
+	-.936111781934811,
+	-.92088586125215,
+	-.904107119545567,		//10
+	-.885803849292083,
+	-.866006913771982,
+	-.844749694983342,
+	-.822068037328975,
+	-.7980001871612,
+	-.77258672828181,
+	-.74587051350361,
+	-.717896592387704,
+	-.688712135277641,
+	-.658366353758143,		//20
+	-.626910417672267,
+	-.594397368836793,
+	-.560882031601237,
+	-.526420920401243,
+	-.491072144462194,
+	-.454895309813726,
+	-.417951418780327,
+	-.380302767117504,
+	-.342012838966962,
+	-.303146199807908,		//30
+	-.263768387584994,
+	-.223945802196474,
+	-.183745593528914,
+	-.143235548227268,
+	-.102483975391227,
+	-.0615595913906112,
+	-.0205314039939986,
+	.0205314039939986,
+	.0615595913906112,
+	.102483975391227,			//40
+	.143235548227268,
+	.183745593528914,
+	.223945802196474,
+	.263768387584994,
+	.303146199807908,
+	.342012838966962,
+	.380302767117504,
+	.417951418780327,
+	.454895309813726,
+	.491072144462194,		//50
+	.526420920401243,
+	.560882031601237,
+	.594397368836793,
+	.626910417672267,
+	.658366353758143,
+	.688712135277641,
+	.717896592387704,
+	.74587051350361,
+	.77258672828181,
+	.7980001871612,	//60
+	.822068037328975,
+	.844749694983342,
+	.866006913771982,
+	.885803849292083,
+	.904107119545567,
+	.92088586125215,
+	.936111781934811,
+	.949759207710896,
+	.961805126758768,
+	.972229228520377,		//70
+	.981013938975656,
+	.988144453359837,
+	.993608772723527,
+	.997397786355355,
+	.999505948362153		//75
+};
+
+
+#pragma acc declare copyin(Gauss76Wt[0:76], Gauss76Z[0:76])
+
+#line 1 ".././models/rectangular_prism.c"
+
+static double
+form_volume(double length_a, double b2a_ratio, double c2a_ratio)
+{
+    return length_a * (length_a*b2a_ratio) * (length_a*c2a_ratio);
+}
+
+static double
+radius_from_excluded_volume(double length_a, double b2a_ratio, double c2a_ratio)
+{
+    double const r_equiv   = sqrt(length_a*length_a*b2a_ratio/M_PI);
+    double const length_c  = c2a_ratio*length_a;
+    return 0.5*cbrt(0.75*r_equiv*(2.0*r_equiv*length_c + (r_equiv + length_c)*(M_PI*r_equiv + length_c)));
+}
+
+static double
+radius_effective(int mode, double length_a, double b2a_ratio, double c2a_ratio)
+{
+    switch (mode) {
+    default:
+    case 1: // equivalent cylinder excluded volume
+        return radius_from_excluded_volume(length_a,b2a_ratio,c2a_ratio);
+    case 2: // equivalent volume sphere
+        return cbrt(cube(length_a)*b2a_ratio*c2a_ratio/M_4PI_3);
+    case 3: // half length_a
+        return 0.5 * length_a;
+    case 4: // half length_b
+        return 0.5 * length_a*b2a_ratio;
+    case 5: // half length_c
+        return 0.5 * length_a*c2a_ratio;
+    case 6: // equivalent circular cross-section
+        return length_a*sqrt(b2a_ratio/M_PI);
+    case 7: // half ab diagonal
+        return 0.5*sqrt(square(length_a) * (1.0 + square(b2a_ratio)));
+    case 8: // half diagonal
+        return 0.5*sqrt(square(length_a) * (1.0 + square(b2a_ratio) + square(c2a_ratio)));
+    }
+}
+
+static double
+Iq(double q,
+    double sld,
+    double solvent_sld,
+    double length_a,
+    double b2a_ratio,
+    double c2a_ratio)
+{
+    const double length_b = length_a * b2a_ratio;
+    const double length_c = length_a * c2a_ratio;
+    const double a_half = 0.5 * length_a;
+    const double b_half = 0.5 * length_b;
+    const double c_half = 0.5 * length_c;
+
+   //Integration limits to use in Gaussian quadrature
+    const double v1a = 0.0;
+    const double v1b = M_PI_2;  //theta integration limits
+    const double v2a = 0.0;
+    const double v2b = M_PI_2;  //phi integration limits
+
+    double outer_sum = 0.0;
+    for(int i=0; i<GAUSS_N; i++) {
+        const double theta = 0.5 * ( GAUSS_Z[i]*(v1b-v1a) + v1a + v1b );
+        double sin_theta, cos_theta;
+        SINCOS(theta, sin_theta, cos_theta);
+
+        const double termC = sas_sinx_x(q * c_half * cos_theta);
+
+        double inner_sum = 0.0;
+        for(int j=0; j<GAUSS_N; j++) {
+            double phi = 0.5 * ( GAUSS_Z[j]*(v2b-v2a) + v2a + v2b );
+            double sin_phi, cos_phi;
+            SINCOS(phi, sin_phi, cos_phi);
+
+            // Amplitude AP from eqn. (12), rewritten to avoid round-off effects when arg=0
+            const double termA = sas_sinx_x(q * a_half * sin_theta * sin_phi);
+            const double termB = sas_sinx_x(q * b_half * sin_theta * cos_phi);
+            const double AP = termA * termB * termC;
+            inner_sum += GAUSS_W[j] * AP * AP;
+        }
+        inner_sum = 0.5 * (v2b-v2a) * inner_sum;
+        outer_sum += GAUSS_W[i] * inner_sum * sin_theta;
+    }
+
+    double answer = 0.5*(v1b-v1a)*outer_sum;
+
+    // Normalize by Pi (Eqn. 16).
+    // The term (ABC)^2 does not appear because it was introduced before on
+    // the definitions of termA, termB, termC.
+    // The factor 2 appears because the theta integral has been defined between
+    // 0 and pi/2, instead of 0 to pi.
+    answer /= M_PI_2; //Form factor P(q)
+
+    // Multiply by contrast^2 and volume^2
+    const double volume = length_a * length_b * length_c;
+    answer *= square((sld-solvent_sld)*volume);
+
+    // Convert from [1e-12 A-1] to [cm-1]
+    answer *= 1.0e-4;
+
+    return answer;
+}
+
+static void
+Fq(double q,
+    double *F1,
+    double *F2,
+    double sld,
+    double solvent_sld,
+    double length_a,
+    double b2a_ratio,
+    double c2a_ratio)
+{
+    const double length_b = length_a * b2a_ratio;
+    const double length_c = length_a * c2a_ratio;
+    const double a_half = 0.5 * length_a;
+    const double b_half = 0.5 * length_b;
+    const double c_half = 0.5 * length_c;
+
+   //Integration limits to use in Gaussian quadrature
+    const double v1a = 0.0;
+    const double v1b = M_PI_2;  //theta integration limits
+    const double v2a = 0.0;
+    const double v2b = M_PI_2;  //phi integration limits
+
+    double outer_sum_F1 = 0.0;
+    double outer_sum_F2 = 0.0;
+    for(int i=0; i<GAUSS_N; i++) {
+        const double theta = 0.5 * ( GAUSS_Z[i]*(v1b-v1a) + v1a + v1b );
+        double sin_theta, cos_theta;
+        SINCOS(theta, sin_theta, cos_theta);
+
+        const double termC = sas_sinx_x(q * c_half * cos_theta);
+
+        double inner_sum_F1 = 0.0;
+        double inner_sum_F2 = 0.0;
+        for(int j=0; j<GAUSS_N; j++) {
+            double phi = 0.5 * ( GAUSS_Z[j]*(v2b-v2a) + v2a + v2b );
+            double sin_phi, cos_phi;
+            SINCOS(phi, sin_phi, cos_phi);
+
+            // Amplitude AP from eqn. (12), rewritten to avoid round-off effects when arg=0
+            const double termA = sas_sinx_x(q * a_half * sin_theta * sin_phi);
+            const double termB = sas_sinx_x(q * b_half * sin_theta * cos_phi);
+            const double AP = termA * termB * termC;
+            inner_sum_F1 += GAUSS_W[j] * AP;
+            inner_sum_F2 += GAUSS_W[j] * AP * AP;
+        }
+        inner_sum_F1 = 0.5 * (v2b-v2a) * inner_sum_F1;
+        inner_sum_F2 = 0.5 * (v2b-v2a) * inner_sum_F2;
+        outer_sum_F1 += GAUSS_W[i] * inner_sum_F1 * sin_theta;
+        outer_sum_F2 += GAUSS_W[i] * inner_sum_F2 * sin_theta;
+    }
+
+    outer_sum_F1 *= 0.5*(v1b-v1a);
+    outer_sum_F2 *= 0.5*(v1b-v1a);
+
+    // Normalize by Pi (Eqn. 16).
+    // The term (ABC)^2 does not appear because it was introduced before on
+    // the definitions of termA, termB, termC.
+    // The factor 2 appears because the theta integral has been defined between
+    // 0 and pi/2, instead of 0 to pi.
+    outer_sum_F1 /= M_PI_2;
+    outer_sum_F2 /= M_PI_2;
+
+    // Multiply by contrast and volume
+    const double s = (sld-solvent_sld) * (length_a * length_b * length_c);
+
+    // Convert from [1e-12 A-1] to [cm-1]
+    *F1 = 1e-2 * s * outer_sum_F1;
+    *F2 = 1e-4 * s * s * outer_sum_F2;
+}
+
+
+static double
+Iqabc(double qa, double qb, double qc,
+    double sld,
+    double solvent_sld,
+    double length_a,
+    double b2a_ratio,
+    double c2a_ratio)
+{
+    const double length_b = length_a * b2a_ratio;
+    const double length_c = length_a * c2a_ratio;
+    const double a_half = 0.5 * length_a;
+    const double b_half = 0.5 * length_b;
+    const double c_half = 0.5 * length_c;
+
+    // Amplitude AP from eqn. (13)
+    const double termA = sas_sinx_x(qa * a_half);
+    const double termB = sas_sinx_x(qb * b_half);
+    const double termC = sas_sinx_x(qc * c_half);
+    const double AP = termA * termB * termC;
+
+    // Multiply by contrast and volume
+    const double s = (sld-solvent_sld) * (length_a * length_b * length_c);
+
+    // Convert from [1e-12 A-1] to [cm-1]
+    return 1.0e-4 * square(s * AP);
+}
+
+

--- a/mcstas-comps/share/sas_rpa.c
+++ b/mcstas-comps/share/sas_rpa.c
@@ -1,0 +1,1004 @@
+#define HAS_Iq
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/rpa.c"
+
+double Iq(double q, double fp_case_num,
+    double N[], double Phi[], double v[], double L[], double b[],
+    double Kab, double Kac, double Kad,
+    double Kbc, double Kbd, double Kcd
+    );
+
+double Iq(double q, double fp_case_num,
+    double N[],    // DEGREE OF POLYMERIZATION
+    double Phi[],  // VOL FRACTION
+    double v[],    // SPECIFIC VOLUME
+    double L[],    // SCATT. LENGTH
+    double b[],    // SEGMENT LENGTH
+    double Kab, double Kac, double Kad,  // CHI PARAM
+    double Kbc, double Kbd, double Kcd
+    )
+{
+  int icase = (int)(fp_case_num+0.5);
+
+  double Nab,Nac,Nad,Nbc,Nbd,Ncd;
+  double Phiab,Phiac,Phiad,Phibc,Phibd,Phicd;
+  double vab,vac,vad,vbc,vbd,vcd;
+  double m;
+  double Xa,Xb,Xc,Xd;
+  double Paa,S0aa,Pab,S0ab,Pac,S0ac,Pad,S0ad;
+  double S0ba,Pbb,S0bb,Pbc,S0bc,Pbd,S0bd;
+  double S0ca,S0cb,Pcc,S0cc,Pcd,S0cd;
+  //double S0da,S0db,S0dc;
+  double Pdd,S0dd;
+  double Kaa,Kbb,Kcc;
+  double Kba,Kca,Kcb;
+  //double Kda,Kdb,Kdc,Kdd;
+  double Zaa,Zab,Zac,Zba,Zbb,Zbc,Zca,Zcb,Zcc;
+  double DenT,T11,T12,T13,T21,T22,T23,T31,T32,T33;
+  double Y1,Y2,Y3,X11,X12,X13,X21,X22,X23,X31,X32,X33;
+  double ZZ,DenQ1,DenQ2,DenQ3,DenQ,Q11,Q12,Q13,Q21,Q22,Q23,Q31,Q32,Q33;
+  double N11,N12,N13,N21,N22,N23,N31,N32,N33;
+  double M11,M12,M13,M21,M22,M23,M31,M32,M33;
+  double S11,S12,S22,S23,S13,S33;
+  //double S21,S31,S32,S44; 
+  //double S14,S24,S34,S41,S42,S43;
+  double Lad,Lbd,Lcd,Nav,Intg;
+
+  // Set values for non existent parameters (eg. no A or B in case 0 and 1 etc)
+  //icase was shifted to N-1 from the original code
+  if (icase <= 1){
+    Phi[0] = Phi[1] = 0.0000001;
+    N[0] = N[1] = 1000.0;
+    L[0] = L[1] = 1.e-12;
+    v[0] = v[1] = 100.0;
+    b[0] = b[1] = 5.0;
+    Kab = Kac = Kad = Kbc = Kbd = -0.0004;
+  }
+  else if ((icase > 1) && (icase <= 4)){
+    Phi[0] = 0.0000001;
+    N[0] = 1000.0;
+    L[0] = 1.e-12;
+    v[0] = 100.0;
+    b[0] = 5.0;
+    Kab = Kac = Kad = -0.0004;
+  }
+
+  // Set volume fraction of component D based on constraint that sum of vol frac =1
+  Phi[3]=1.0-Phi[0]-Phi[1]-Phi[2];
+
+  //set up values for cross terms in case of block copolymers (1,3,4,6,7,8,9)
+  Nab=sqrt(N[0]*N[1]);
+  Nac=sqrt(N[0]*N[2]);
+  Nad=sqrt(N[0]*N[3]);
+  Nbc=sqrt(N[1]*N[2]);
+  Nbd=sqrt(N[1]*N[3]);
+  Ncd=sqrt(N[2]*N[3]);
+
+  vab=sqrt(v[0]*v[1]);
+  vac=sqrt(v[0]*v[2]);
+  vad=sqrt(v[0]*v[3]);
+  vbc=sqrt(v[1]*v[2]);
+  vbd=sqrt(v[1]*v[3]);
+  vcd=sqrt(v[2]*v[3]);
+
+  Phiab=sqrt(Phi[0]*Phi[1]);
+  Phiac=sqrt(Phi[0]*Phi[2]);
+  Phiad=sqrt(Phi[0]*Phi[3]);
+  Phibc=sqrt(Phi[1]*Phi[2]);
+  Phibd=sqrt(Phi[1]*Phi[3]);
+  Phicd=sqrt(Phi[2]*Phi[3]);
+
+  // Calculate Q^2 * Rg^2 for each homopolymer assuming random walk
+  Xa=q*q*b[0]*b[0]*N[0]/6.0;
+  Xb=q*q*b[1]*b[1]*N[1]/6.0;
+  Xc=q*q*b[2]*b[2]*N[2]/6.0;
+  Xd=q*q*b[3]*b[3]*N[3]/6.0;
+
+  //calculate all partial structure factors Pij and normalize n^2
+  Paa=2.0*(exp(-Xa)-1.0+Xa)/(Xa*Xa); // free A chain form factor
+  S0aa=N[0]*Phi[0]*v[0]*Paa; // Phi * Vp * P(Q)= I(Q0)/delRho^2
+  Pab=((1.0-exp(-Xa))/Xa)*((1.0-exp(-Xb))/Xb); //AB diblock (anchored Paa * anchored Pbb) partial form factor
+  S0ab=(Phiab*vab*Nab)*Pab;
+  Pac=((1.0-exp(-Xa))/Xa)*exp(-Xb)*((1.0-exp(-Xc))/Xc); //ABC triblock AC partial form factor
+  S0ac=(Phiac*vac*Nac)*Pac;
+  Pad=((1.0-exp(-Xa))/Xa)*exp(-Xb-Xc)*((1.0-exp(-Xd))/Xd); //ABCD four block
+  S0ad=(Phiad*vad*Nad)*Pad;
+
+  S0ba=S0ab;
+  Pbb=2.0*(exp(-Xb)-1.0+Xb)/(Xb*Xb); // free B chain
+  S0bb=N[1]*Phi[1]*v[1]*Pbb;
+  Pbc=((1.0-exp(-Xb))/Xb)*((1.0-exp(-Xc))/Xc); // BC diblock
+  S0bc=(Phibc*vbc*Nbc)*Pbc;
+  Pbd=((1.0-exp(-Xb))/Xb)*exp(-Xc)*((1.0-exp(-Xd))/Xd); // BCD triblock
+  S0bd=(Phibd*vbd*Nbd)*Pbd;
+
+  S0ca=S0ac;
+  S0cb=S0bc;
+  Pcc=2.0*(exp(-Xc)-1.0+Xc)/(Xc*Xc); // Free C chain
+  S0cc=N[2]*Phi[2]*v[2]*Pcc;
+  Pcd=((1.0-exp(-Xc))/Xc)*((1.0-exp(-Xd))/Xd); // CD diblock
+  S0cd=(Phicd*vcd*Ncd)*Pcd;
+
+  //S0da=S0ad;
+  //S0db=S0bd;
+  //S0dc=S0cd;
+  Pdd=2.0*(exp(-Xd)-1.0+Xd)/(Xd*Xd); // free D chain
+  S0dd=N[3]*Phi[3]*v[3]*Pdd;
+
+  // Reset all unused partial structure factors to 0 (depends on case)
+  //icase was shifted to N-1 from the original code
+  switch(icase){
+  case 0:
+    S0aa=0.000001;
+    S0ab=0.000002;
+    S0ac=0.000003;
+    S0ad=0.000004;
+    S0bb=0.000005;
+    S0bc=0.000006;
+    S0bd=0.000007;
+    S0cd=0.000008;
+    break;
+  case 1:
+    S0aa=0.000001;
+    S0ab=0.000002;
+    S0ac=0.000003;
+    S0ad=0.000004;
+    S0bb=0.000005;
+    S0bc=0.000006;
+    S0bd=0.000007;
+    break;
+  case 2:
+    S0aa=0.000001;
+    S0ab=0.000002;
+    S0ac=0.000003;
+    S0ad=0.000004;
+    S0bc=0.000005;
+    S0bd=0.000006;
+    S0cd=0.000007;
+    break;
+  case 3:
+    S0aa=0.000001;
+    S0ab=0.000002;
+    S0ac=0.000003;
+    S0ad=0.000004;
+    S0bc=0.000005;
+    S0bd=0.000006;
+    break;
+  case 4:
+    S0aa=0.000001;
+    S0ab=0.000002;
+    S0ac=0.000003;
+    S0ad=0.000004;
+    break;
+  case 5:
+    S0ab=0.000001;
+    S0ac=0.000002;
+    S0ad=0.000003;
+    S0bc=0.000004;
+    S0bd=0.000005;
+    S0cd=0.000006;
+    break;
+  case 6:
+    S0ab=0.000001;
+    S0ac=0.000002;
+    S0ad=0.000003;
+    S0bc=0.000004;
+    S0bd=0.000005;
+    break;
+  case 7:
+    S0ab=0.000001;
+    S0ac=0.000002;
+    S0ad=0.000003;
+    break;
+  case 8:
+    S0ac=0.000001;
+    S0ad=0.000002;
+    S0bc=0.000003;
+    S0bd=0.000004;
+    break;
+  default : //case 9:
+    break;
+  }
+  S0ba=S0ab;
+  S0ca=S0ac;
+  S0cb=S0bc;
+  //S0da=S0ad;
+  //S0db=S0bd;
+  //S0dc=S0cd;
+
+  // self chi parameter is 0 ... of course
+  Kaa=0.0;
+  Kbb=0.0;
+  Kcc=0.0;
+  //Kdd=0.0;
+
+  Kba=Kab;
+  Kca=Kac;
+  Kcb=Kbc;
+  //Kda=Kad;
+  //Kdb=Kbd;
+  //Kdc=Kcd;
+
+  Zaa=Kaa-Kad-Kad;
+  Zab=Kab-Kad-Kbd;
+  Zac=Kac-Kad-Kcd;
+  Zba=Kba-Kbd-Kad;
+  Zbb=Kbb-Kbd-Kbd;
+  Zbc=Kbc-Kbd-Kcd;
+  Zca=Kca-Kcd-Kad;
+  Zcb=Kcb-Kcd-Kbd;
+  Zcc=Kcc-Kcd-Kcd;
+
+  DenT=(-(S0ac*S0bb*S0ca) + S0ab*S0bc*S0ca + S0ac*S0ba*S0cb - S0aa*S0bc*S0cb - S0ab*S0ba*S0cc + S0aa*S0bb*S0cc);
+
+  T11= (-(S0bc*S0cb) + S0bb*S0cc)/DenT;
+  T12= (S0ac*S0cb - S0ab*S0cc)/DenT;
+  T13= (-(S0ac*S0bb) + S0ab*S0bc)/DenT;
+  T21= (S0bc*S0ca - S0ba*S0cc)/DenT;
+  T22= (-(S0ac*S0ca) + S0aa*S0cc)/DenT;
+  T23= (S0ac*S0ba - S0aa*S0bc)/DenT;
+  T31= (-(S0bb*S0ca) + S0ba*S0cb)/DenT;
+  T32= (S0ab*S0ca - S0aa*S0cb)/DenT;
+  T33= (-(S0ab*S0ba) + S0aa*S0bb)/DenT;
+
+  Y1=T11*S0ad+T12*S0bd+T13*S0cd+1.0;
+  Y2=T21*S0ad+T22*S0bd+T23*S0cd+1.0;
+  Y3=T31*S0ad+T32*S0bd+T33*S0cd+1.0;
+
+  X11=Y1*Y1;
+  X12=Y1*Y2;
+  X13=Y1*Y3;
+  X21=Y2*Y1;
+  X22=Y2*Y2;
+  X23=Y2*Y3;
+  X31=Y3*Y1;
+  X32=Y3*Y2;
+  X33=Y3*Y3;
+
+  ZZ=S0ad*(T11*S0ad+T12*S0bd+T13*S0cd)+S0bd*(T21*S0ad+T22*S0bd+T23*S0cd)+S0cd*(T31*S0ad+T32*S0bd+T33*S0cd);
+
+  // D is considered the matrix or background component so enters here
+  m=1.0/(S0dd-ZZ);
+
+  N11=m*X11+Zaa;
+  N12=m*X12+Zab;
+  N13=m*X13+Zac;
+  N21=m*X21+Zba;
+  N22=m*X22+Zbb;
+  N23=m*X23+Zbc;
+  N31=m*X31+Zca;
+  N32=m*X32+Zcb;
+  N33=m*X33+Zcc;
+
+  M11= N11*S0aa + N12*S0ab + N13*S0ac;
+  M12= N11*S0ab + N12*S0bb + N13*S0bc;
+  M13= N11*S0ac + N12*S0bc + N13*S0cc;
+  M21= N21*S0aa + N22*S0ab + N23*S0ac;
+  M22= N21*S0ab + N22*S0bb + N23*S0bc;
+  M23= N21*S0ac + N22*S0bc + N23*S0cc;
+  M31= N31*S0aa + N32*S0ab + N33*S0ac;
+  M32= N31*S0ab + N32*S0bb + N33*S0bc;
+  M33= N31*S0ac + N32*S0bc + N33*S0cc;
+
+  DenQ1=1.0+M11-M12*M21+M22+M11*M22-M13*M31-M13*M22*M31;
+  DenQ2=  M12*M23*M31+M13*M21*M32-M23*M32-M11*M23*M32+M33+M11*M33;
+  DenQ3=  -M12*M21*M33+M22*M33+M11*M22*M33;
+  DenQ=DenQ1+DenQ2+DenQ3;
+
+  Q11= (1.0 + M22-M23*M32 + M33 + M22*M33)/DenQ;
+  Q12= (-M12 + M13*M32 - M12*M33)/DenQ;
+  Q13= (-M13 - M13*M22 + M12*M23)/DenQ;
+  Q21= (-M21 + M23*M31 - M21*M33)/DenQ;
+  Q22= (1.0 + M11 - M13*M31 + M33 + M11*M33)/DenQ;
+  Q23= (M13*M21 - M23 - M11*M23)/DenQ;
+  Q31= (-M31 - M22*M31 + M21*M32)/DenQ;
+  Q32= (M12*M31 - M32 - M11*M32)/DenQ;
+  Q33= (1.0 + M11 - M12*M21 + M22 + M11*M22)/DenQ;
+
+  S11= Q11*S0aa + Q21*S0ab + Q31*S0ac;
+  S12= Q12*S0aa + Q22*S0ab + Q32*S0ac;
+  S13= Q13*S0aa + Q23*S0ab + Q33*S0ac;
+  S22= Q12*S0ba + Q22*S0bb + Q32*S0bc;
+  S23= Q13*S0ba + Q23*S0bb + Q33*S0bc;
+  S33= Q13*S0ca + Q23*S0cb + Q33*S0cc;
+  //S21= Q11*S0ba + Q21*S0bb + Q31*S0bc;
+  //S31= Q11*S0ca + Q21*S0cb + Q31*S0cc;
+  //S32= Q12*S0ca + Q22*S0cb + Q32*S0cc;
+  //S44=S11+S22+S33+2.0*S12+2.0*S13+2.0*S23;
+  //S14=-S11-S12-S13;
+  //S24=-S21-S22-S23;
+  //S34=-S31-S32-S33;
+  //S41=S14;
+  //S42=S24;
+  //S43=S34;
+
+  //calculate contrast where L[i] is the scattering length of i and D is the matrix
+  //Note that should multiply by Nav to get units of SLD which will become
+  // Nav*2 in the next line (SLD^2) but then normalization in that line would
+  //need to divide by Nav leaving only Nav or sqrt(Nav) before squaring.
+  Nav=6.022045e+23;
+  Lad=(L[0]/v[0]-L[3]/v[3])*sqrt(Nav);
+  Lbd=(L[1]/v[1]-L[3]/v[3])*sqrt(Nav);
+  Lcd=(L[2]/v[2]-L[3]/v[3])*sqrt(Nav);
+
+  Intg=Lad*Lad*S11+Lbd*Lbd*S22+Lcd*Lcd*S33+2.0*Lad*Lbd*S12+2.0*Lbd*Lcd*S23+2.0*Lad*Lcd*S13;
+
+  //rescale for units of Lij^2 (fm^2 to cm^2)
+  Intg *= 1.0e-26;
+
+  return Intg;
+
+
+/*  Attempts at a new implementation --- supressed for now
+#if 1  // Sasview defaults
+  if (icase <= 1) {
+    N[0]=N[1]=1000.0;
+    Phi[0]=Phi[1]=0.0000001;
+    Kab=Kac=Kad=Kbc=Kbd=-0.0004;
+    L[0]=L[1]=1.0e-12;
+    v[0]=v[1]=100.0;
+    b[0]=b[1]=5.0;
+  } else if (icase <= 4) {
+    Phi[0]=0.0000001;
+    Kab=Kac=Kad=-0.0004;
+    L[0]=1.0e-12;
+    v[0]=100.0;
+    b[0]=5.0;
+  }
+#else
+  if (icase <= 1) {
+    N[0]=N[1]=0.0;
+    Phi[0]=Phi[1]=0.0;
+    Kab=Kac=Kad=Kbc=Kbd=0.0;
+    L[0]=L[1]=L[3];
+    v[0]=v[1]=v[3];
+    b[0]=b[1]=0.0;
+  } else if (icase <= 4) {
+    N[0] = 0.0;
+    Phi[0]=0.0;
+    Kab=Kac=Kad=0.0;
+    L[0]=L[3];
+    v[0]=v[3];
+    b[0]=0.0;
+  }
+#endif
+
+  const double Xa = q*q*b[0]*b[0]*N[0]/6.0;
+  const double Xb = q*q*b[1]*b[1]*N[1]/6.0;
+  const double Xc = q*q*b[2]*b[2]*N[2]/6.0;
+  const double Xd = q*q*b[3]*b[3]*N[3]/6.0;
+
+  // limit as Xa goes to 0 is 1
+  const double Pa = Xa==0 ? 1.0 : -expm1(-Xa)/Xa;
+  const double Pb = Xb==0 ? 1.0 : -expm1(-Xb)/Xb;
+  const double Pc = Xc==0 ? 1.0 : -expm1(-Xc)/Xc;
+  const double Pd = Xd==0 ? 1.0 : -expm1(-Xd)/Xd;
+
+  // limit as Xa goes to 0 is 1
+  const double Paa = Xa==0 ? 1.0 : 2.0*(1.0-Pa)/Xa;
+  const double Pbb = Xb==0 ? 1.0 : 2.0*(1.0-Pb)/Xb;
+  const double Pcc = Xc==0 ? 1.0 : 2.0*(1.0-Pc)/Xc;
+  const double Pdd = Xd==0 ? 1.0 : 2.0*(1.0-Pd)/Xd;
+
+
+  // Note: S0ij only defined for copolymers; otherwise set to zero
+  // 0: C/D     binary mixture
+  // 1: C-D     diblock copolymer
+  // 2: B/C/D   ternery mixture
+  // 3: B/C-D   binary mixture,1 homopolymer, 1 diblock copolymer
+  // 4: B-C-D   triblock copolymer
+  // 5: A/B/C/D quaternary mixture
+  // 6: A/B/C-D ternery mixture, 2 homopolymer, 1 diblock copolymer
+  // 7: A/B-C-D binary mixture, 1 homopolymer, 1 triblock copolymer
+  // 8: A-B/C-D binary mixture, 2 diblock copolymer
+  // 9: A-B-C-D tetra-block copolymer
+#if 0
+  const double S0aa = icase<5
+                      ? 1.0 : N[0]*Phi[0]*v[0]*Paa;
+  const double S0bb = icase<2
+                      ? 1.0 : N[1]*Phi[1]*v[1]*Pbb;
+  const double S0cc = N[2]*Phi[2]*v[2]*Pcc;
+  const double S0dd = N[3]*Phi[3]*v[3]*Pdd;
+  const double S0ab = icase<8
+                      ? 0.0 : sqrt(N[0]*v[0]*Phi[0]*N[1]*v[1]*Phi[1])*Pa*Pb;
+  const double S0ac = icase<9
+                      ? 0.0 : sqrt(N[0]*v[0]*Phi[0]*N[2]*v[2]*Phi[2])*Pa*Pc*exp(-Xb);
+  const double S0ad = icase<9
+                      ? 0.0 : sqrt(N[0]*v[0]*Phi[0]*N[3]*v[3]*Phi[3])*Pa*Pd*exp(-Xb-Xc);
+  const double S0bc = (icase!=4 && icase!=7 && icase!= 9)
+                      ? 0.0 : sqrt(N[1]*v[1]*Phi[1]*N[2]*v[2]*Phi[2])*Pb*Pc;
+  const double S0bd = (icase!=4 && icase!=7 && icase!= 9)
+                      ? 0.0 : sqrt(N[1]*v[1]*Phi[1]*N[3]*v[3]*Phi[3])*Pb*Pd*exp(-Xc);
+  const double S0cd = (icase==0 || icase==2 || icase==5)
+                      ? 0.0 : sqrt(N[2]*v[2]*Phi[2]*N[3]*v[3]*Phi[3])*Pc*Pd;
+#else  // sasview equivalent
+//printf("Xc=%g, S0cc=%g*%g*%g*%g\n",Xc,N[2],Phi[2],v[2],Pcc);
+  double S0aa = N[0]*Phi[0]*v[0]*Paa;
+  double S0bb = N[1]*Phi[1]*v[1]*Pbb;
+  double S0cc = N[2]*Phi[2]*v[2]*Pcc;
+  double S0dd = N[3]*Phi[3]*v[3]*Pdd;
+  double S0ab = sqrt(N[0]*v[0]*Phi[0]*N[1]*v[1]*Phi[1])*Pa*Pb;
+  double S0ac = sqrt(N[0]*v[0]*Phi[0]*N[2]*v[2]*Phi[2])*Pa*Pc*exp(-Xb);
+  double S0ad = sqrt(N[0]*v[0]*Phi[0]*N[3]*v[3]*Phi[3])*Pa*Pd*exp(-Xb-Xc);
+  double S0bc = sqrt(N[1]*v[1]*Phi[1]*N[2]*v[2]*Phi[2])*Pb*Pc;
+  double S0bd = sqrt(N[1]*v[1]*Phi[1]*N[3]*v[3]*Phi[3])*Pb*Pd*exp(-Xc);
+  double S0cd = sqrt(N[2]*v[2]*Phi[2]*N[3]*v[3]*Phi[3])*Pc*Pd;
+switch(icase){
+  case 0:
+    S0aa=0.000001;
+    S0ab=0.000002;
+    S0ac=0.000003;
+    S0ad=0.000004;
+    S0bb=0.000005;
+    S0bc=0.000006;
+    S0bd=0.000007;
+    S0cd=0.000008;
+    break;
+  case 1:
+    S0aa=0.000001;
+    S0ab=0.000002;
+    S0ac=0.000003;
+    S0ad=0.000004;
+    S0bb=0.000005;
+    S0bc=0.000006;
+    S0bd=0.000007;
+    break;
+  case 2:
+    S0aa=0.000001;
+    S0ab=0.000002;
+    S0ac=0.000003;
+    S0ad=0.000004;
+    S0bc=0.000005;
+    S0bd=0.000006;
+    S0cd=0.000007;
+    break;
+  case 3:
+    S0aa=0.000001;
+    S0ab=0.000002;
+    S0ac=0.000003;
+    S0ad=0.000004;
+    S0bc=0.000005;
+    S0bd=0.000006;
+    break;
+  case 4:
+    S0aa=0.000001;
+    S0ab=0.000002;
+    S0ac=0.000003;
+    S0ad=0.000004;
+    break;
+  case 5:
+    S0ab=0.000001;
+    S0ac=0.000002;
+    S0ad=0.000003;
+    S0bc=0.000004;
+    S0bd=0.000005;
+    S0cd=0.000006;
+    break;
+  case 6:
+    S0ab=0.000001;
+    S0ac=0.000002;
+    S0ad=0.000003;
+    S0bc=0.000004;
+    S0bd=0.000005;
+    break;
+  case 7:
+    S0ab=0.000001;
+    S0ac=0.000002;
+    S0ad=0.000003;
+    break;
+  case 8:
+    S0ac=0.000001;
+    S0ad=0.000002;
+    S0bc=0.000003;
+    S0bd=0.000004;
+    break;
+  default : //case 9:
+    break;
+  }
+#endif
+
+  // eq 12a: \kappa_{ij}^F = \chi_{ij}^F - \chi_{i0}^F - \chi_{j0}^F
+  const double Kaa = 0.0;
+  const double Kbb = 0.0;
+  const double Kcc = 0.0;
+  //const double Kdd = 0.0;
+  const double Zaa = Kaa - Kad - Kad;
+  const double Zab = Kab - Kad - Kbd;
+  const double Zac = Kac - Kad - Kcd;
+  const double Zbb = Kbb - Kbd - Kbd;
+  const double Zbc = Kbc - Kbd - Kcd;
+  const double Zcc = Kcc - Kcd - Kcd;
+//printf("Za: %10.5g %10.5g %10.5g\n", Zaa, Zab, Zac);
+//printf("Zb: %10.5g %10.5g %10.5g\n", Zab, Zbb, Zbc);
+//printf("Zc: %10.5g %10.5g %10.5g\n", Zac, Zbc, Zcc);
+
+  // T = inv(S0)
+  const double DenT = (- S0ac*S0bb*S0ac + S0ab*S0bc*S0ac + S0ac*S0ab*S0bc
+                       - S0aa*S0bc*S0bc - S0ab*S0ab*S0cc + S0aa*S0bb*S0cc);
+  const double T11 = (-S0bc*S0bc + S0bb*S0cc)/DenT;
+  const double T12 = ( S0ac*S0bc - S0ab*S0cc)/DenT;
+  const double T13 = (-S0ac*S0bb + S0ab*S0bc)/DenT;
+  const double T22 = (-S0ac*S0ac + S0aa*S0cc)/DenT;
+  const double T23 = ( S0ac*S0ab - S0aa*S0bc)/DenT;
+  const double T33 = (-S0ab*S0ab + S0aa*S0bb)/DenT;
+
+//printf("T1: %10.5g %10.5g %10.5g\n", T11, T12, T13);
+//printf("T2: %10.5g %10.5g %10.5g\n", T12, T22, T23);
+//printf("T3: %10.5g %10.5g %10.5g\n", T13, T23, T33);
+
+  // eq 18e: m = 1/(S0_{dd} - s0^T inv(S0) s0)
+  const double ZZ = S0ad*(T11*S0ad + T12*S0bd + T13*S0cd)
+                  + S0bd*(T12*S0ad + T22*S0bd + T23*S0cd)
+                  + S0cd*(T13*S0ad + T23*S0bd + T33*S0cd);
+
+  const double m=1.0/(S0dd-ZZ);
+
+  // eq 18d: Y = inv(S0)s0 + e
+  const double Y1 = T11*S0ad + T12*S0bd + T13*S0cd + 1.0;
+  const double Y2 = T12*S0ad + T22*S0bd + T23*S0cd + 1.0;
+  const double Y3 = T13*S0ad + T23*S0bd + T33*S0cd + 1.0;
+
+  // N = mYY^T + \kappa^F
+  const double N11 = m*Y1*Y1 + Zaa;
+  const double N12 = m*Y1*Y2 + Zab;
+  const double N13 = m*Y1*Y3 + Zac;
+  const double N22 = m*Y2*Y2 + Zbb;
+  const double N23 = m*Y2*Y3 + Zbc;
+  const double N33 = m*Y3*Y3 + Zcc;
+
+//printf("N1: %10.5g %10.5g %10.5g\n", N11, N12, N13);
+//printf("N2: %10.5g %10.5g %10.5g\n", N12, N22, N23);
+//printf("N3: %10.5g %10.5g %10.5g\n", N13, N23, N33);
+//printf("S0a: %10.5g %10.5g %10.5g\n", S0aa, S0ab, S0ac);
+//printf("S0b: %10.5g %10.5g %10.5g\n", S0ab, S0bb, S0bc);
+//printf("S0c: %10.5g %10.5g %10.5g\n", S0ac, S0bc, S0cc);
+
+  // M = I + S0 N
+  const double Maa = N11*S0aa + N12*S0ab + N13*S0ac + 1.0;
+  const double Mab = N11*S0ab + N12*S0bb + N13*S0bc;
+  const double Mac = N11*S0ac + N12*S0bc + N13*S0cc;
+  const double Mba = N12*S0aa + N22*S0ab + N23*S0ac;
+  const double Mbb = N12*S0ab + N22*S0bb + N23*S0bc + 1.0;
+  const double Mbc = N12*S0ac + N22*S0bc + N23*S0cc;
+  const double Mca = N13*S0aa + N23*S0ab + N33*S0ac;
+  const double Mcb = N13*S0ab + N23*S0bb + N33*S0bc;
+  const double Mcc = N13*S0ac + N23*S0bc + N33*S0cc + 1.0;
+//printf("M1: %10.5g %10.5g %10.5g\n", Maa, Mab, Mac);
+//printf("M2: %10.5g %10.5g %10.5g\n", Mba, Mbb, Mbc);
+//printf("M3: %10.5g %10.5g %10.5g\n", Mca, Mcb, Mcc);
+
+  // Q = inv(M) = inv(I + S0 N)
+  const double DenQ = (+ Maa*Mbb*Mcc - Maa*Mbc*Mcb - Mab*Mba*Mcc
+                       + Mab*Mbc*Mca + Mac*Mba*Mcb - Mac*Mbb*Mca);
+
+  const double Q11 = ( Mbb*Mcc - Mbc*Mcb)/DenQ;
+  const double Q12 = (-Mab*Mcc + Mac*Mcb)/DenQ;
+  const double Q13 = ( Mab*Mbc - Mac*Mbb)/DenQ;
+  //const double Q21 = (-Mba*Mcc + Mbc*Mca)/DenQ;
+  const double Q22 = ( Maa*Mcc - Mac*Mca)/DenQ;
+  const double Q23 = (-Maa*Mbc + Mac*Mba)/DenQ;
+  //const double Q31 = ( Mba*Mcb - Mbb*Mca)/DenQ;
+  //const double Q32 = (-Maa*Mcb + Mab*Mca)/DenQ;
+  const double Q33 = ( Maa*Mbb - Mab*Mba)/DenQ;
+
+//printf("Q1: %10.5g %10.5g %10.5g\n", Q11, Q12, Q13);
+//printf("Q2: %10.5g %10.5g %10.5g\n", Q21, Q22, Q23);
+//printf("Q3: %10.5g %10.5g %10.5g\n", Q31, Q32, Q33);
+  // eq 18c: inv(S) = inv(S0) + mYY^T + \kappa^F
+  // eq A1 in the appendix
+  // To solve for S, use:
+  //      S = inv(inv(S^0) + N) inv(S^0) S^0
+  //        = inv(S^0 inv(S^0) + N) S^0
+  //        = inv(I + S^0 N) S^0
+  //        = Q S^0
+  const double S11 = Q11*S0aa + Q12*S0ab + Q13*S0ac;
+  const double S12 = Q12*S0aa + Q22*S0ab + Q23*S0ac;
+  const double S13 = Q13*S0aa + Q23*S0ab + Q33*S0ac;
+  const double S22 = Q12*S0ab + Q22*S0bb + Q23*S0bc;
+  const double S23 = Q13*S0ab + Q23*S0bb + Q33*S0bc;
+  const double S33 = Q13*S0ac + Q23*S0bc + Q33*S0cc;
+  // If the full S is needed...it isn't since Ldd = (rho_d - rho_d) = 0 below
+  //const double S14=-S11-S12-S13;
+  //const double S24=-S12-S22-S23;
+  //const double S34=-S13-S23-S33;
+  //const double S44=S11+S22+S33 + 2.0*(S12+S13+S23);
+
+  // eq 12 of Akcasu, 1990: I(q) = L^T S L
+  // Note: eliminate cases without A and B polymers by setting Lij to 0
+  // Note: 1e-13 to convert from fm to cm for scattering length
+  const double sqrt_Nav=sqrt(6.022045e+23) * 1.0e-13;
+  const double Lad = icase<5 ? 0.0 : (L[0]/v[0] - L[3]/v[3])*sqrt_Nav;
+  const double Lbd = icase<2 ? 0.0 : (L[1]/v[1] - L[3]/v[3])*sqrt_Nav;
+  const double Lcd = (L[2]/v[2] - L[3]/v[3])*sqrt_Nav;
+
+  const double result=Lad*Lad*S11 + Lbd*Lbd*S22 + Lcd*Lcd*S33
+                    + 2.0*(Lad*Lbd*S12 + Lbd*Lcd*S23 + Lad*Lcd*S13);
+
+  return result;
+*/
+}
+
+

--- a/mcstas-comps/share/sas_sc_paracrystal.c
+++ b/mcstas-comps/share/sas_sc_paracrystal.c
@@ -1,0 +1,892 @@
+#define HAS_Iqabc
+#define HAS_Iq
+#define FORM_VOL
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/sas_3j1x_x.c"
+
+/**
+* Spherical Bessel function 3*j1(x)/x
+*
+* Used for low q to avoid cancellation error.
+* Note that the values differ from sasview ~ 5e-12 rather than 5e-14, but
+* in this case it is likely cancellation errors in the original expression
+* using double precision that are the source.
+*/
+double sas_3j1x_x(double q);
+
+// The choice of the number of terms in the series and the cutoff value for
+// switching between series and direct calculation depends on the numeric
+// precision.
+//
+// Point where direct calculation reaches machine precision:
+//
+//   single machine precision eps 3e-8 at qr=1.1 **
+//   double machine precision eps 4e-16 at qr=1.1
+//
+// Point where Taylor series reaches machine precision (eps), where taylor
+// series matches direct calculation (cross) and the error at that point:
+//
+//   prec   n eps  cross  error
+//   single 3 0.28  0.4   6.2e-7
+//   single 4 0.68  0.7   2.3e-7
+//   single 5 1.18  1.2   7.5e-8
+//   double 3 0.01  0.03  2.3e-13
+//   double 4 0.06  0.1   3.1e-14
+//   double 5 0.16  0.2   5.0e-15
+//
+// ** Note: relative error on single precision starts increase on the direct
+// method at qr=1.1, rising from 3e-8 to 5e-5 by qr=1e3.  This should be
+// safe for the sans range, with objects of 100 nm supported to a q of 0.1
+// while maintaining 5 digits of precision.  For usans/sesans, the objects
+// are larger but the q is smaller, so again it should be fine.
+//
+// See explore/sph_j1c.py for code to explore these ranges.
+
+// Use 4th order series
+#if FLOAT_SIZE>4
+#define SPH_J1C_CUTOFF 0.1
+#else
+#define SPH_J1C_CUTOFF 0.7
+#endif
+#pragma acc routine seq
+double sas_3j1x_x(double q)
+{
+    // 2017-05-18 PAK - support negative q
+    if (fabs(q) < SPH_J1C_CUTOFF) {
+        const double q2 = q*q;
+        return (1.0 + q2*(-3./30. + q2*(3./840. + q2*(-3./45360.))));// + q2*(3./3991680.)))));
+    } else {
+        double sin_q, cos_q;
+        SINCOS(q, sin_q, cos_q);
+        return 3.0*(sin_q/q - cos_q)/(q*q);
+    }
+}
+
+
+#line 1 ".././models/lib/sphere_form.c"
+
+double sphere_volume(double radius);
+double sphere_form(double q, double radius, double sld, double solvent_sld);
+
+    
+#pragma acc routine seq
+double sphere_volume(double radius)
+{
+    return M_4PI_3*cube(radius);
+}
+    
+#pragma acc routine seq
+double sphere_form(double q, double radius, double sld, double solvent_sld)
+{
+    const double fq = sphere_volume(radius) * sas_3j1x_x(q*radius);
+    const double contrast = (sld - solvent_sld);
+    return 1.0e-4*square(contrast * fq);
+}
+
+
+
+#line 1 ".././models/lib/gauss150.c"
+
+// Created by Andrew Jackson on 4/23/07
+
+ #ifdef GAUSS_N
+ # undef GAUSS_N
+ # undef GAUSS_Z
+ # undef GAUSS_W
+ #endif
+ #define GAUSS_N 150
+ #define GAUSS_Z Gauss150Z
+ #define GAUSS_W Gauss150Wt
+
+
+// Note: using array size 152 rather than 150 so that it is a multiple of 4.
+// Some OpenCL devices prefer that vectors start and end on nice boundaries.
+constant double Gauss150Z[152]={
+  	-0.9998723404457334,
+  	-0.9993274305065947,
+  	-0.9983473449340834,
+  	-0.9969322929775997,
+  	-0.9950828645255290,
+  	-0.9927998590434373,
+  	-0.9900842691660192,
+  	-0.9869372772712794,
+  	-0.9833602541697529,
+  	-0.9793547582425894,
+  	-0.9749225346595943,
+  	-0.9700655145738374,
+  	-0.9647858142586956,
+  	-0.9590857341746905,
+  	-0.9529677579610971,
+  	-0.9464345513503147,
+  	-0.9394889610042837,
+  	-0.9321340132728527,
+  	-0.9243729128743136,
+  	-0.9162090414984952,
+  	-0.9076459563329236,
+  	-0.8986873885126239,
+  	-0.8893372414942055,
+  	-0.8795995893549102,
+  	-0.8694786750173527,
+  	-0.8589789084007133,
+  	-0.8481048644991847,
+  	-0.8368612813885015,
+  	-0.8252530581614230,
+  	-0.8132852527930605,
+  	-0.8009630799369827,
+  	-0.7882919086530552,
+  	-0.7752772600680049,
+  	-0.7619248049697269,
+  	-0.7482403613363824,
+  	-0.7342298918013638,
+  	-0.7198995010552305,
+  	-0.7052554331857488,
+  	-0.6903040689571928,
+  	-0.6750519230300931,
+  	-0.6595056411226444,
+  	-0.6436719971150083,
+  	-0.6275578900977726,
+  	-0.6111703413658551,
+  	-0.5945164913591590,
+  	-0.5776035965513142,
+  	-0.5604390262878617,
+  	-0.5430302595752546,
+  	-0.5253848818220803,
+  	-0.5075105815339176,
+  	-0.4894151469632753,
+  	-0.4711064627160663,
+  	-0.4525925063160997,
+  	-0.4338813447290861,
+  	-0.4149811308476706,
+  	-0.3959000999390257,
+  	-0.3766465660565522,
+  	-0.3572289184172501,
+  	-0.3376556177463400,
+  	-0.3179351925907259,
+  	-0.2980762356029071,
+  	-0.2780873997969574,
+  	-0.2579773947782034,
+  	-0.2377549829482451,
+  	-0.2174289756869712,
+  	-0.1970082295132342,
+  	-0.1765016422258567,
+  	-0.1559181490266516,
+  	-0.1352667186271445,
+  	-0.1145563493406956,
+  	-0.0937960651617229,
+  	-0.0729949118337358,
+  	-0.0521619529078925,
+  	-0.0313062657937972,
+  	-0.0104369378042598,
+  	0.0104369378042598,
+  	0.0313062657937972,
+  	0.0521619529078925,
+  	0.0729949118337358,
+  	0.0937960651617229,
+  	0.1145563493406956,
+  	0.1352667186271445,
+  	0.1559181490266516,
+  	0.1765016422258567,
+  	0.1970082295132342,
+  	0.2174289756869712,
+  	0.2377549829482451,
+  	0.2579773947782034,
+  	0.2780873997969574,
+  	0.2980762356029071,
+  	0.3179351925907259,
+  	0.3376556177463400,
+  	0.3572289184172501,
+  	0.3766465660565522,
+  	0.3959000999390257,
+  	0.4149811308476706,
+  	0.4338813447290861,
+  	0.4525925063160997,
+  	0.4711064627160663,
+  	0.4894151469632753,
+  	0.5075105815339176,
+  	0.5253848818220803,
+  	0.5430302595752546,
+  	0.5604390262878617,
+  	0.5776035965513142,
+  	0.5945164913591590,
+  	0.6111703413658551,
+  	0.6275578900977726,
+  	0.6436719971150083,
+  	0.6595056411226444,
+  	0.6750519230300931,
+  	0.6903040689571928,
+  	0.7052554331857488,
+  	0.7198995010552305,
+  	0.7342298918013638,
+  	0.7482403613363824,
+  	0.7619248049697269,
+  	0.7752772600680049,
+  	0.7882919086530552,
+  	0.8009630799369827,
+  	0.8132852527930605,
+  	0.8252530581614230,
+  	0.8368612813885015,
+  	0.8481048644991847,
+  	0.8589789084007133,
+  	0.8694786750173527,
+  	0.8795995893549102,
+  	0.8893372414942055,
+  	0.8986873885126239,
+  	0.9076459563329236,
+  	0.9162090414984952,
+  	0.9243729128743136,
+  	0.9321340132728527,
+  	0.9394889610042837,
+  	0.9464345513503147,
+  	0.9529677579610971,
+  	0.9590857341746905,
+  	0.9647858142586956,
+  	0.9700655145738374,
+  	0.9749225346595943,
+  	0.9793547582425894,
+  	0.9833602541697529,
+  	0.9869372772712794,
+  	0.9900842691660192,
+  	0.9927998590434373,
+  	0.9950828645255290,
+  	0.9969322929775997,
+  	0.9983473449340834,
+  	0.9993274305065947,
+  	0.9998723404457334,
+  	0., // zero padding is ignored
+  	0.  // zero padding is ignored
+};
+
+constant double Gauss150Wt[152]={
+  	0.0003276086705538,
+  	0.0007624720924706,
+  	0.0011976474864367,
+  	0.0016323569986067,
+  	0.0020663664924131,
+  	0.0024994789888943,
+  	0.0029315036836558,
+  	0.0033622516236779,
+  	0.0037915348363451,
+  	0.0042191661429919,
+  	0.0046449591497966,
+  	0.0050687282939456,
+  	0.0054902889094487,
+  	0.0059094573005900,
+  	0.0063260508184704,
+  	0.0067398879387430,
+  	0.0071507883396855,
+  	0.0075585729801782,
+  	0.0079630641773633,
+  	0.0083640856838475,
+  	0.0087614627643580,
+  	0.0091550222717888,
+  	0.0095445927225849,
+  	0.0099300043714212,
+  	0.0103110892851360,
+  	0.0106876814158841,
+  	0.0110596166734735,
+  	0.0114267329968529,
+  	0.0117888704247183,
+  	0.0121458711652067,
+  	0.0124975796646449,
+  	0.0128438426753249,
+  	0.0131845093222756,
+  	0.0135194311690004,
+  	0.0138484622795371,
+  	0.0141714592928592,
+  	0.0144882814685445,
+  	0.0147987907597169,
+  	0.0151028518701744,
+  	0.0154003323133401,
+  	0.0156911024699895,
+  	0.0159750356447283,
+  	0.0162520081211971,
+  	0.0165218992159766,
+  	0.0167845913311726,
+  	0.0170399700056559,
+  	0.0172879239649355,
+  	0.0175283451696437,
+  	0.0177611288626114,
+  	0.0179861736145128,
+  	0.0182033813680609,
+  	0.0184126574807331,
+  	0.0186139107660094,
+  	0.0188070535331042,
+  	0.0189920016251754,
+  	0.0191686744559934,
+  	0.0193369950450545,
+  	0.0194968900511231,
+  	0.0196482898041878,
+  	0.0197911283358190,
+  	0.0199253434079123,
+  	0.0200508765398072,
+  	0.0201676730337687,
+  	0.0202756819988200,
+  	0.0203748563729175,
+  	0.0204651529434560,
+  	0.0205465323660984,
+  	0.0206189591819181,
+  	0.0206824018328499,
+  	0.0207368326754401,
+  	0.0207822279928917,
+  	0.0208185680053983,
+  	0.0208458368787627,
+  	0.0208640227312962,
+  	0.0208731176389954,
+  	0.0208731176389954,
+  	0.0208640227312962,
+  	0.0208458368787627,
+  	0.0208185680053983,
+  	0.0207822279928917,
+  	0.0207368326754401,
+  	0.0206824018328499,
+  	0.0206189591819181,
+  	0.0205465323660984,
+  	0.0204651529434560,
+  	0.0203748563729175,
+  	0.0202756819988200,
+  	0.0201676730337687,
+  	0.0200508765398072,
+  	0.0199253434079123,
+  	0.0197911283358190,
+  	0.0196482898041878,
+  	0.0194968900511231,
+  	0.0193369950450545,
+  	0.0191686744559934,
+  	0.0189920016251754,
+  	0.0188070535331042,
+  	0.0186139107660094,
+  	0.0184126574807331,
+  	0.0182033813680609,
+  	0.0179861736145128,
+  	0.0177611288626114,
+  	0.0175283451696437,
+  	0.0172879239649355,
+  	0.0170399700056559,
+  	0.0167845913311726,
+  	0.0165218992159766,
+  	0.0162520081211971,
+  	0.0159750356447283,
+  	0.0156911024699895,
+  	0.0154003323133401,
+  	0.0151028518701744,
+  	0.0147987907597169,
+  	0.0144882814685445,
+  	0.0141714592928592,
+  	0.0138484622795371,
+  	0.0135194311690004,
+  	0.0131845093222756,
+  	0.0128438426753249,
+  	0.0124975796646449,
+  	0.0121458711652067,
+  	0.0117888704247183,
+  	0.0114267329968529,
+  	0.0110596166734735,
+  	0.0106876814158841,
+  	0.0103110892851360,
+  	0.0099300043714212,
+  	0.0095445927225849,
+  	0.0091550222717888,
+  	0.0087614627643580,
+  	0.0083640856838475,
+  	0.0079630641773633,
+  	0.0075585729801782,
+  	0.0071507883396855,
+  	0.0067398879387430,
+  	0.0063260508184704,
+  	0.0059094573005900,
+  	0.0054902889094487,
+  	0.0050687282939456,
+  	0.0046449591497966,
+  	0.0042191661429919,
+  	0.0037915348363451,
+  	0.0033622516236779,
+  	0.0029315036836558,
+  	0.0024994789888943,
+  	0.0020663664924131,
+  	0.0016323569986067,
+  	0.0011976474864367,
+  	0.0007624720924706,
+  	0.0003276086705538,
+  	0., // zero padding is ignored
+  	0.  // zero padding is ignored
+};
+
+#pragma acc declare copyin( Gauss150Wt[0:150], Gauss150Z[0:150] )
+
+#line 1 ".././models/sc_paracrystal.c"
+
+static double
+sc_Zq(double qa, double qb, double qc, double dnn, double d_factor)
+{
+    // Equations from Matsuoka 9-10-11, multiplied by |q|
+    const double a1 = qa;
+    const double a2 = qb;
+    const double a3 = qc;
+
+    // Matsuoka 13-14-15
+    //     Z_k numerator: 1 - exp(a)^2
+    //     Z_k denominator: 1 - 2 cos(d a_k) exp(a) + exp(2a)
+    // Rewriting numerator
+    //         => -(exp(2a) - 1)
+    //         => -expm1(2a)
+    // Rewriting denominator
+    //         => exp(a)^2 - 2 cos(d ak) exp(a) + 1)
+    //         => (exp(a) - 2 cos(d ak)) * exp(a) + 1
+    const double arg = -0.5*square(dnn*d_factor)*(a1*a1 + a2*a2 + a3*a3);
+    const double exp_arg = exp(arg);
+    const double Zq = -cube(expm1(2.0*arg))
+        / ( ((exp_arg - 2.0*cos(dnn*a1))*exp_arg + 1.0)
+          * ((exp_arg - 2.0*cos(dnn*a2))*exp_arg + 1.0)
+          * ((exp_arg - 2.0*cos(dnn*a3))*exp_arg + 1.0));
+
+    return Zq;
+}
+
+// occupied volume fraction calculated from lattice symmetry and sphere radius
+static double
+sc_volume_fraction(double radius, double dnn)
+{
+    return sphere_volume(radius/dnn);
+}
+
+static double
+form_volume(double radius)
+{
+    return sphere_volume(radius);
+}
+
+
+static double
+Iq(double q, double dnn,
+    double d_factor, double radius,
+    double sld, double solvent_sld)
+{
+    // translate a point in [-1,1] to a point in [0, 2 pi]
+    const double phi_m = M_PI_4;
+    const double phi_b = M_PI_4;
+    // translate a point in [-1,1] to a point in [0, pi]
+    const double theta_m = M_PI_4;
+    const double theta_b = M_PI_4;
+
+
+    double outer_sum = 0.0;
+    for(int i=0; i<GAUSS_N; i++) {
+        double inner_sum = 0.0;
+        const double theta = GAUSS_Z[i]*theta_m + theta_b;
+        double sin_theta, cos_theta;
+        SINCOS(theta, sin_theta, cos_theta);
+        const double qc = q*cos_theta;
+        const double qab = q*sin_theta;
+        for(int j=0;j<GAUSS_N;j++) {
+            const double phi = GAUSS_Z[j]*phi_m + phi_b;
+            double sin_phi, cos_phi;
+            SINCOS(phi, sin_phi, cos_phi);
+            const double qa = qab*cos_phi;
+            const double qb = qab*sin_phi;
+            const double form = sc_Zq(qa, qb, qc, dnn, d_factor);
+            inner_sum += GAUSS_W[j] * form;
+        }
+        inner_sum *= phi_m;  // sum(f(x)dx) = sum(f(x)) dx
+        outer_sum += GAUSS_W[i] * inner_sum * sin_theta;
+    }
+    outer_sum *= theta_m;
+    const double Zq = outer_sum/M_PI_2;
+    const double Pq = sphere_form(q, radius, sld, solvent_sld);
+
+    return sc_volume_fraction(radius, dnn) * Pq * Zq;
+}
+
+static double
+Iqabc(double qa, double qb, double qc,
+    double dnn, double d_factor, double radius,
+    double sld, double solvent_sld)
+{
+    const double q = sqrt(qa*qa + qb*qb + qc*qc);
+    const double Pq = sphere_form(q, radius, sld, solvent_sld);
+    const double Zq = sc_Zq(qa, qb, qc, dnn, d_factor);
+    return sc_volume_fraction(radius, dnn) * Pq * Zq;
+}
+

--- a/mcstas-comps/share/sas_sphere.c
+++ b/mcstas-comps/share/sas_sphere.c
@@ -1,102 +1,390 @@
-// GENERATED CODE --- DO NOT EDIT ---
-// Code is produced by sasmodels.gen from sasmodels/models/MODEL.c
+#define HAS_FQ
+#define FORM_VOL
+#line 1 "../kernel_header.c"
 
 #ifdef __OPENCL_VERSION__
 # define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
 #endif
 
-#define USE_KAHAN_SUMMATION 0
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
 
 // If opencl is not available, then we are compiling a C function
 // Note: if using a C++ compiler, then define kernel as extern "C"
-#ifndef USE_OPENCL
-#  ifdef __cplusplus
-     #include <cstdio>
-     #include <cmath>
-     using namespace std;
-     #if defined(_MSC_VER)
-     #   define kernel extern "C" __declspec( dllexport )
-         inline float trunc(float x) { return x>=0?floor(x):-floor(-x); }
-	 inline float fmin(float x, float y) { return x>y ? y : x; }
-	 inline float fmax(float x, float y) { return x<y ? y : x; }
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
      #else
-     #   define kernel extern "C"
+         #define kernel extern "C"
+         #include <cstdint>
      #endif
-     inline void SINCOS(float angle, float &svar, float &cvar) { svar=sin(angle); cvar=cos(angle); }
-#  else
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
      #include <stdio.h>
-     #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
      // MSVC doesn't support C99, so no need for dllexport on C99 branch
      #define kernel
-     #define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
-#  define global
-#  define local
-#  define constant const
-// OpenCL powr(a,b) = C99 pow(a,b), b >= 0
-// OpenCL pown(a,b) = C99 pow(a,b), b integer
-#  define powr(a,b) pow(a,b)
-#  define pown(a,b) pow(a,b)
-#else
-#  ifdef USE_SINCOS
-#    define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
-#  else
-#    define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
 #endif
 
 // Standard mathematical constants:
 //   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
 //   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
-// OpenCL defines M_constant_F for float constants, and nothing if float
+// OpenCL defines M_constant_F for float constants, and nothing if double
 // is not enabled on the card, which is why these constants may be missing
 #ifndef M_PI
-#  define M_PI 3.141592653589793f
+#  define M_PI 3.141592653589793
 #endif
 #ifndef M_PI_2
-#  define M_PI_2 1.570796326794897f
+#  define M_PI_2 1.570796326794897
 #endif
 #ifndef M_PI_4
-#  define M_PI_4 0.7853981633974483f
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
 #endif
 
-// Non-standard pi/180, used for converting between degrees and radians
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
 #ifndef M_PI_180
-#  define M_PI_180 0.017453292519943295f
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
 #endif
 
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
 
-#define VOLUME_PARAMETERS radius
-#define VOLUME_WEIGHT_PRODUCT radius_w
-#define VOLUME_PARAMETER_DECLARATIONS float radius
-#define IQ_KERNEL_NAME sphere_Iq
-#define IQ_PARAMETERS sld, solvent_sld, radius
-#define IQ_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float sld, \
-    const float solvent_sld
-#define IQ_WEIGHT_PRODUCT radius_w
-#define IQ_DISPERSION_LENGTH_DECLARATIONS const int Nradius
-#define IQ_DISPERSION_LENGTH_SUM Nradius
-#define IQ_OPEN_LOOPS     for (int radius_i=0; radius_i < Nradius; radius_i++) { \
-      const float radius = loops[2*(radius_i)]; \
-      const float radius_w = loops[2*(radius_i)+1];
-#define IQ_CLOSE_LOOPS     }
-#define IQ_PARAMETER_DECLARATIONS float sld, float solvent_sld, float radius
-#define IQXY_KERNEL_NAME sphere_Iqxy
-#define IQXY_PARAMETERS sld, solvent_sld, radius
-#define IQXY_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float sld, \
-    const float solvent_sld
-#define IQXY_WEIGHT_PRODUCT radius_w
-#define IQXY_DISPERSION_LENGTH_DECLARATIONS const int Nradius
-#define IQXY_DISPERSION_LENGTH_SUM Nradius
-#define IQXY_OPEN_LOOPS     for (int radius_i=0; radius_i < Nradius; radius_i++) { \
-      const float radius = loops[2*(radius_i)]; \
-      const float radius_w = loops[2*(radius_i)+1];
-#define IQXY_CLOSE_LOOPS     }
-#define IQXY_PARAMETER_DECLARATIONS float sld, float solvent_sld, float radius
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/sas_3j1x_x.c"
 
 /**
 * Spherical Bessel function 3*j1(x)/x
@@ -104,252 +392,80 @@
 * Used for low q to avoid cancellation error.
 * Note that the values differ from sasview ~ 5e-12 rather than 5e-14, but
 * in this case it is likely cancellation errors in the original expression
-* using float precision that are the source.  Single precision only
-* requires the first 3 terms.  Double precision requires the 4th term.
-* The fifth term is not needed, and is commented out.
-* Taylor expansion:
-*      1.0f + q2*(-3.f/30.f + q2*(3.f/840.f))+ q2*(-3.f/45360.f + q2*(3.f/3991680.f))))
-* Expression returned from Herbie (herbie.uwpise.org/demo):
-*      const float t = ((1.f + 3.f*q2*q2/5600.f) - q2/20.f);
-*      return t*t;
+* using double precision that are the source.
 */
+double sas_3j1x_x(double q);
 
-float sph_j1c(float q);
-float sph_j1c(float q)
+// The choice of the number of terms in the series and the cutoff value for
+// switching between series and direct calculation depends on the numeric
+// precision.
+//
+// Point where direct calculation reaches machine precision:
+//
+//   single machine precision eps 3e-8 at qr=1.1 **
+//   double machine precision eps 4e-16 at qr=1.1
+//
+// Point where Taylor series reaches machine precision (eps), where taylor
+// series matches direct calculation (cross) and the error at that point:
+//
+//   prec   n eps  cross  error
+//   single 3 0.28  0.4   6.2e-7
+//   single 4 0.68  0.7   2.3e-7
+//   single 5 1.18  1.2   7.5e-8
+//   double 3 0.01  0.03  2.3e-13
+//   double 4 0.06  0.1   3.1e-14
+//   double 5 0.16  0.2   5.0e-15
+//
+// ** Note: relative error on single precision starts increase on the direct
+// method at qr=1.1, rising from 3e-8 to 5e-5 by qr=1e3.  This should be
+// safe for the sans range, with objects of 100 nm supported to a q of 0.1
+// while maintaining 5 digits of precision.  For usans/sesans, the objects
+// are larger but the q is smaller, so again it should be fine.
+//
+// See explore/sph_j1c.py for code to explore these ranges.
+
+// Use 4th order series
+#if FLOAT_SIZE>4
+#define SPH_J1C_CUTOFF 0.1
+#else
+#define SPH_J1C_CUTOFF 0.7
+#endif
+#pragma acc routine seq
+double sas_3j1x_x(double q)
 {
-    const float q2 = q*q;
-    float sin_q, cos_q;
-
-    SINCOS(q, sin_q, cos_q);
-
-    const float bessel = (q < 0.384038453352533f)
-        ? (1.0f + q2*(-3.f/30.f + q2*(3.f/840.f)))
-        : 3.0f*(sin_q/q - cos_q)/q2;
-
-    return bessel;
-
- /*
-    // Code to test various expressions
-    if (sizeof(q2) > 4) {
-        return 3.0f*(sin_q/q - cos_q)/q2;
-    } else if (q < 0.384038453352533f) {
-        //const float t = ((1.f + 3.f*q2*q2/5600.f) - q2/20.f); return t*t;
-        return 1.0f + q2*q2*(3.f/840.f) - q2*(3.f/30.f);
-        //return 1.0f + q2*(-3.f/30.f + q2*(3.f/840.f));
-        //return 1.0f + q2*(-3.f/30.f + q2*(3.f/840.f + q2*(-3.f/45360.f)));
-        //return 1.0f + q2*(-3.f/30.f + q2*(3.f/840.f + q2*(-3.f/45360.f + q2*(3.f/3991680.f))));
+    // 2017-05-18 PAK - support negative q
+    if (fabs(q) < SPH_J1C_CUTOFF) {
+        const double q2 = q*q;
+        return (1.0 + q2*(-3./30. + q2*(3./840. + q2*(-3./45360.))));// + q2*(3./3991680.)))));
     } else {
-        return 3.0f*(sin_q/q - cos_q)/q2;
+        double sin_q, cos_q;
+        SINCOS(q, sin_q, cos_q);
+        return 3.0*(sin_q/q - cos_q)/(q*q);
     }
-*/
 }
 
 
-float form_volume(VOLUME_PARAMETER_DECLARATIONS);
-float form_volume(VOLUME_PARAMETER_DECLARATIONS) {
-    
-    return 1.333333333333333f*M_PI*radius*radius*radius;
-    
-}
+#line 1 ".././models/sphere.c"
 
-
-float Iq(float q, IQ_PARAMETER_DECLARATIONS);
-float Iq(float q, IQ_PARAMETER_DECLARATIONS) {
-    
-    const float qr = q*radius;
-    const float bes = sph_j1c(qr);
-    const float fq = bes * (sld - solvent_sld) * form_volume(radius);
-    return 1.0e-4f*fq*fq;
-    
-}
-
-
-float Iqxy(float qx, float qy, IQXY_PARAMETER_DECLARATIONS);
-float Iqxy(float qx, float qy, IQXY_PARAMETER_DECLARATIONS) {
-    
-    // never called since no orientation or magnetic parameters.
-    //return -1.0f;
-    return Iq(sqrt(qx*qx + qy*qy), sld, solvent_sld, radius);
-    
-}
-
-
-/*
-    ##########################################################
-    #                                                        #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #   !!                                              !!   #
-    #   !!  KEEP THIS CODE CONSISTENT WITH KERNELPY.PY  !!   #
-    #   !!                                              !!   #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #                                                        #
-    ##########################################################
-*/
-
-#ifdef IQ_KERNEL_NAME
-kernel void IQ_KERNEL_NAME(
-    global const float *q,
-    global float *result,
-    const int Nq,
-#ifdef IQ_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQ_DISPERSION_LENGTH_DECLARATIONS,
-#endif
-    IQ_FIXED_PARAMETER_DECLARATIONS
-    )
+static double form_volume(double radius)
 {
-#ifdef USE_OPENCL
-  #ifdef IQ_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQ_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
-
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qi = q[i];
-#ifdef IQ_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-  #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-  #endif
-    IQ_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
-
-    const float weight = IQ_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-      const float scattering = Iq(qi, IQ_PARAMETERS);
-      // allow kernels to exclude invalid regions by returning NaN
-      if (!isnan(scattering)) {
-        ret += weight*scattering;
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-        norm_vol += vol_weight;
-      #endif
-      }
-    //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
-    }
-    IQ_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iq(qi, IQ_PARAMETERS) + background;
-#endif
-  }
+    return M_4PI_3*cube(radius);
 }
-#endif
 
-
-#ifdef IQXY_KERNEL_NAME
-kernel void IQXY_KERNEL_NAME(
-    global const float *qx,
-    global const float *qy,
-    global float *result,
-    const int Nq,
-#ifdef IQXY_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQXY_DISPERSION_LENGTH_DECLARATIONS,
-#endif
-    IQXY_FIXED_PARAMETER_DECLARATIONS
-    )
+static double
+radius_effective(int mode, double radius)
 {
-#ifdef USE_OPENCL
-  #ifdef IQXY_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQXY_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
-
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qxi = qx[i];
-    const float qyi = qy[i];
-    #if USE_KAHAN_SUMMATION
-    float accumulated_error = 0.0f;
-    #endif
-#ifdef IQXY_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-    #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-    #endif
-    IQXY_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
-
-    const float weight = IQXY_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-
-      const float scattering = Iqxy(qxi, qyi, IQXY_PARAMETERS);
-      if (!isnan(scattering)) { // if scattering is bad, exclude it from sum
-      //if (scattering >= 0.0f) { // scattering cannot be negative
-        // TODO: use correct angle for spherical correction
-        // Definition of theta and phi are probably reversed relative to the
-        // equation which gave rise to this correction, leading to an
-        // attenuation of the pattern as theta moves through pi/2.f  Either
-        // reverse the meanings of phi and theta in the forms, or use phi
-        // rather than theta in this correction.  Current code uses cos(theta)
-        // so that values match those of sasview.
-      #if defined(IQXY_HAS_THETA) // && 0
-        const float spherical_correction
-          = (Ntheta>1 ? fabs(cos(M_PI_180*theta))*M_PI_2:1.0f);
-        const float next = spherical_correction * weight * scattering;
-      #else
-        const float next = weight * scattering;
-      #endif
-      #if USE_KAHAN_SUMMATION
-        const float y = next - accumulated_error;
-        const float t = ret + y;
-        accumulated_error = (t - ret) - y;
-        ret = t;
-      #else
-        ret += next;
-      #endif
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-      #endif
-        norm_vol += vol_weight;
-      }
-      //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
-    }
-    IQXY_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iqxy(qxi, qyi, IQXY_PARAMETERS) + background;
-#endif
-  }
+    // case 1: radius
+    return radius;
 }
-#endif
+
+static void Fq(double q, double *f1, double *f2, double sld, double sld_solvent, double radius)
+{
+    const double bes = sas_3j1x_x(q*radius);
+    const double contrast = (sld - sld_solvent);
+    const double form = contrast * form_volume(radius) * bes;
+    *f1 = 1.0e-2*form;
+    *f2 = 1.0e-4*form*form;
+}
+
+

--- a/mcstas-comps/share/sas_spherical_sld.c
+++ b/mcstas-comps/share/sas_spherical_sld.c
@@ -1,0 +1,1081 @@
+#define HAS_Iq
+#define FORM_VOL
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/polevl.c"
+
+/*							polevl.c
+ *							p1evl.c
+ *
+ *	Evaluate polynomial
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * int N;
+ * double x, y, coef[N+1], polevl[];
+ *
+ * y = polevl( x, coef, N );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Evaluates polynomial of degree N:
+ *
+ *                     2          N
+ * y  =  C  + C x + C x  +...+ C x
+ *        0    1     2          N
+ *
+ * Coefficients are stored in reverse order:
+ *
+ * coef[0] = C  , ..., coef[N] = C  .
+ *            N                   0
+ *
+ * The function p1evl() assumes that C_N = 1.0 and is
+ * omitted from the array.  Its calling arguments are
+ * otherwise the same as polevl().
+ *
+ *
+ * SPEED:
+ *
+ * In the interest of speed, there are no checks for out
+ * of bounds arithmetic.  This routine is used by most of
+ * the functions in the library.  Depending on available
+ * equipment features, the user may wish to rewrite the
+ * program in microcode or assembly language.
+ *
+ */
+
+
+/*
+Cephes Math Library Release 2.1:  December, 1988
+Copyright 1984, 1987, 1988 by Stephen L. Moshier
+Direct inquiries to 30 Frost Street, Cambridge, MA 02140
+*/
+#pragma acc routine seq
+static
+double polevl( double x, pconstant double *coef, int N )
+{
+
+    int i = 0;
+    double ans = coef[i];
+
+    while (i < N) {
+        i++;
+        ans = ans * x + coef[i];
+    }
+
+    return ans;
+}
+
+/*							p1evl()	*/
+/*                                          N
+ * Evaluate polynomial when coefficient of x  is 1.0.
+ * Otherwise same as polevl.
+ */
+#pragma acc routine seq
+static
+double p1evl( double x, pconstant double *coef, int N )
+{
+    int i=0;
+    double ans = x+coef[i];
+
+    while (i < N-1) {
+        i++;
+        ans = ans*x + coef[i];
+    }
+
+    return ans;
+}
+
+
+#line 1 ".././models/lib/sas_erf.c"
+
+
+/*
+ * Cephes Math Library Release 2.2:  June, 1992
+ * Copyright 1984, 1987, 1988, 1992 by Stephen L. Moshier
+ * Direct inquiries to 30 Frost Street, Cambridge, MA 02140
+ */
+/*
+ *
+ *	Error function
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * double x, y, erf();
+ *
+ * y = erf( x );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * The integral is
+ *
+ *                           x
+ *                            -
+ *                 2         | |          2
+ *   erf(x)  =  --------     |    exp( - t  ) dt.
+ *              sqrt(pi)   | |
+ *                          -
+ *                           0
+ *
+ * For 0 <= |x| < 1, erf(x) = x * P4(x**2)/Q5(x**2); otherwise
+ * erf(x) = 1 - erfc(x).
+ *
+ *
+ *
+ * ACCURACY:
+ *
+ *                      Relative error:
+ * arithmetic   domain     # trials      peak         rms
+ *    IEEE      0,1         30000       3.7e-16     1.0e-16
+ *
+ */
+/*
+ *
+ *	Complementary error function
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * double x, y, erfc();
+ *
+ * y = erfc( x );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ *
+ *  1 - erf(x) =
+ *
+ *                           inf.
+ *                             -
+ *                  2         | |          2
+ *   erfc(x)  =  --------     |    exp( - t  ) dt
+ *               sqrt(pi)   | |
+ *                           -
+ *                            x
+ *
+ *
+ * For small x, erfc(x) = 1 - erf(x); otherwise rational
+ * approximations are computed.
+ *
+ *
+ *
+ * ACCURACY:
+ *
+ *                      Relative error:
+ * arithmetic   domain     # trials      peak         rms
+ *    IEEE      0,26.6417   30000       5.7e-14     1.5e-14
+ */
+
+#ifdef NEED_ERF
+
+#if FLOAT_SIZE>4  // DOUBLE_PRECISION
+
+double cephes_erf(double x);
+double cephes_erfc(double a);
+
+constant double PD[] = {
+    2.46196981473530512524E-10,
+    5.64189564831068821977E-1,
+    7.46321056442269912687E0,
+    4.86371970985681366614E1,
+    1.96520832956077098242E2,
+    5.26445194995477358631E2,
+    9.34528527171957607540E2,
+    1.02755188689515710272E3,
+    5.57535335369399327526E2
+};
+
+constant double QD[] = {
+    /* 1.00000000000000000000E0, */
+    1.32281951154744992508E1,
+    8.67072140885989742329E1,
+    3.54937778887819891062E2,
+    9.75708501743205489753E2,
+    1.82390916687909736289E3,
+    2.24633760818710981792E3,
+    1.65666309194161350182E3,
+    5.57535340817727675546E2
+};
+
+constant double RD[] = {
+    5.64189583547755073984E-1,
+    1.27536670759978104416E0,
+    5.01905042251180477414E0,
+    6.16021097993053585195E0,
+    7.40974269950448939160E0,
+    2.97886665372100240670E0
+};
+
+constant double SD[] = {
+    /* 1.00000000000000000000E0, */
+    2.26052863220117276590E0,
+    9.39603524938001434673E0,
+    1.20489539808096656605E1,
+    1.70814450747565897222E1,
+    9.60896809063285878198E0,
+    3.36907645100081516050E0
+};
+
+constant double TD[] = {
+    9.60497373987051638749E0,
+    9.00260197203842689217E1,
+    2.23200534594684319226E3,
+    7.00332514112805075473E3,
+    5.55923013010394962768E4
+};
+
+constant double UD[] = {
+    /* 1.00000000000000000000E0, */
+    3.35617141647503099647E1,
+    5.21357949780152679795E2,
+    4.59432382970980127987E3,
+    2.26290000613890934246E4,
+    4.92673942608635921086E4
+};
+
+#pragma acc declare copyin(PD[0:1], QD[0:1], RD[0:1], SD[0:1], TD[0:1], UD[0:1])
+
+#pragma acc routine seq
+double cephes_erfc(double a)
+{
+    double MAXLOG = 88.72283905206835;
+    double p, q, x, y, z;
+
+
+    x = fabs(a);
+
+    if (x < 1.0) {
+        // The line below causes problems on the GPU, so inline
+        // the erf function instead and z < 1.0.
+        //return (1.0 - cephes_erf(a));
+        // 2017-05-18 PAK - use erf(a) rather than erf(|a|)
+        z = a * a;
+        y = a * polevl(z, TD, 4) / p1evl(z, UD, 5);
+
+        return 1.0 - y;
+    }
+
+    z = -a * a;
+
+    if (z < -MAXLOG) {
+        if (a < 0)
+            return (2.0);
+        else
+            return (0.0);
+    }
+
+    z = exp(z);
+
+
+    if (x < 8.0) {
+        p = polevl(x, PD, 8);
+        q = p1evl(x, QD, 8);
+    }
+    else {
+        p = polevl(x, RD, 5);
+        q = p1evl(x, SD, 6);
+    }
+    y = (z * p) / q;
+
+    if (a < 0)
+        y = 2.0 - y;
+
+    if (y == 0.0) {
+        if (a < 0)
+            return (2.0);
+        else
+            return (0.0);
+    }
+    return y;
+}
+
+
+double cephes_erf(double x)
+{
+    double y, z;
+
+    if (fabs(x) > 1.0)
+        return (1.0 - cephes_erfc(x));
+
+    z = x * x;
+    y = x * polevl(z, TD, 4) / p1evl(z, UD, 5);
+
+    return y;
+}
+
+#else // SINGLE PRECISION
+
+float cephes_erff(float x);
+float cephes_erfcf(float a);
+
+/* erfc(x) = exp(-x^2) P(1/x), 1 < x < 2 */
+constant float PF[] = {
+    2.326819970068386E-002,
+    -1.387039388740657E-001,
+    3.687424674597105E-001,
+    -5.824733027278666E-001,
+    6.210004621745983E-001,
+    -4.944515323274145E-001,
+    3.404879937665872E-001,
+    -2.741127028184656E-001,
+    5.638259427386472E-001
+};
+
+/* erfc(x) = exp(-x^2) 1/x P(1/x^2), 2 < x < 14 */
+constant float RF[] = {
+    -1.047766399936249E+001,
+    1.297719955372516E+001,
+    -7.495518717768503E+000,
+    2.921019019210786E+000,
+    -1.015265279202700E+000,
+    4.218463358204948E-001,
+    -2.820767439740514E-001,
+    5.641895067754075E-001
+};
+
+/* erf(x) = x P(x^2), 0 < x < 1 */
+ constant float TF[] = {
+    7.853861353153693E-005,
+    -8.010193625184903E-004,
+    5.188327685732524E-003,
+    -2.685381193529856E-002,
+    1.128358514861418E-001,
+    -3.761262582423300E-001,
+    1.128379165726710E+000
+};
+
+#pragma acc declare copyin(PF[0:1], RF[0:1], TF[0:1])
+
+#pragma acc routine seq
+float cephes_erfcf(float a)
+{
+    float MAXLOG = 88.72283905206835;
+    float p, q, x, y, z;
+
+
+    /*if (a < 0.0)
+        x = -a;
+    else
+        x = a;*/
+    // TODO: tinycc does not support fabsf
+    x = fabs(a);
+
+
+    if (x < 1.0) {
+        //The line below is a troublemaker for GPU, so sas_erf function
+        //is explicit here for the case < 1.0
+        //return (1.0 - sas_erf(a));
+        // 2017-05-18 PAK - use erf(a) rather than erf(|a|)
+        z = a * a;
+        y = a * polevl( z, TF, 6 );
+
+        return 1.0 - y;
+    }
+
+    z = -a * a;
+
+    if (z < -MAXLOG) {
+        if (a < 0)
+            return (2.0);
+        else
+            return (0.0);
+    }
+    z = expf(z);
+
+
+    q=1.0/x;
+    y=q*q;
+    if( x < 2.0 ) {
+        p = polevl( y, PF, 8 );
+    } else {
+        p = polevl( y, RF, 7 );
+    }
+    y = z * q * p;
+
+    if (a < 0)
+        y = 2.0 - y;
+
+    if (y == 0.0) {
+        if (a < 0)
+            return (2.0);
+        else
+            return (0.0);
+    }
+    return y;
+}
+
+#pragma acc routine seq
+float cephes_erff(float x)
+{
+    float y, z;
+
+    // TODO: tinycc does not support fabsf
+    if (fabs(x) > 1.0)
+        return (1.0 - cephes_erfcf(x));
+
+    z = x * x;
+    y = x * polevl( z, TF, 6 );
+
+    return y;
+}
+
+#endif // SINGLE_PRECISION
+
+#if FLOAT_SIZE>4
+//static double sas_erf(double x) { return erf(x); }
+//static double sas_erfc(double x) { return erfc(x); }
+#define sas_erf cephes_erf
+#define sas_erfc cephes_erfc
+#else
+#define sas_erf cephes_erff
+#define sas_erfc cephes_erfcf
+#endif
+
+#else // !NEED_ERF
+
+#if FLOAT_SIZE>4
+//static double sas_erf(double x) { return erf(x); }
+//static double sas_erfc(double x) { return erfc(x); }
+#define sas_erf erf
+#define sas_erfc erfc
+#else
+#define sas_erf erff
+#define sas_erfc erfcf
+#endif
+#endif // !NEED_ERF
+
+
+#line 1 ".././models/lib/sas_3j1x_x.c"
+
+/**
+* Spherical Bessel function 3*j1(x)/x
+*
+* Used for low q to avoid cancellation error.
+* Note that the values differ from sasview ~ 5e-12 rather than 5e-14, but
+* in this case it is likely cancellation errors in the original expression
+* using double precision that are the source.
+*/
+double sas_3j1x_x(double q);
+
+// The choice of the number of terms in the series and the cutoff value for
+// switching between series and direct calculation depends on the numeric
+// precision.
+//
+// Point where direct calculation reaches machine precision:
+//
+//   single machine precision eps 3e-8 at qr=1.1 **
+//   double machine precision eps 4e-16 at qr=1.1
+//
+// Point where Taylor series reaches machine precision (eps), where taylor
+// series matches direct calculation (cross) and the error at that point:
+//
+//   prec   n eps  cross  error
+//   single 3 0.28  0.4   6.2e-7
+//   single 4 0.68  0.7   2.3e-7
+//   single 5 1.18  1.2   7.5e-8
+//   double 3 0.01  0.03  2.3e-13
+//   double 4 0.06  0.1   3.1e-14
+//   double 5 0.16  0.2   5.0e-15
+//
+// ** Note: relative error on single precision starts increase on the direct
+// method at qr=1.1, rising from 3e-8 to 5e-5 by qr=1e3.  This should be
+// safe for the sans range, with objects of 100 nm supported to a q of 0.1
+// while maintaining 5 digits of precision.  For usans/sesans, the objects
+// are larger but the q is smaller, so again it should be fine.
+//
+// See explore/sph_j1c.py for code to explore these ranges.
+
+// Use 4th order series
+#if FLOAT_SIZE>4
+#define SPH_J1C_CUTOFF 0.1
+#else
+#define SPH_J1C_CUTOFF 0.7
+#endif
+#pragma acc routine seq
+double sas_3j1x_x(double q)
+{
+    // 2017-05-18 PAK - support negative q
+    if (fabs(q) < SPH_J1C_CUTOFF) {
+        const double q2 = q*q;
+        return (1.0 + q2*(-3./30. + q2*(3./840. + q2*(-3./45360.))));// + q2*(3./3991680.)))));
+    } else {
+        double sin_q, cos_q;
+        SINCOS(q, sin_q, cos_q);
+        return 3.0*(sin_q/q - cos_q)/(q*q);
+    }
+}
+
+
+#line 1 ".././models/spherical_sld.c"
+
+static double
+outer_radius(double fp_n_shells, double thickness[], double interface[])
+{
+    int n_shells= (int)(fp_n_shells + 0.5);
+    double r = 0.0;
+    for (int i=0; i < n_shells; i++) {
+        r += thickness[i] + interface[i];
+    }
+    return r;
+}
+
+static double form_volume(
+    double fp_n_shells,
+    double thickness[],
+    double interface[])
+{
+    return M_4PI_3*cube(outer_radius(fp_n_shells, thickness, interface));
+}
+
+static double
+radius_effective(int mode, double fp_n_shells, double thickness[], double interface[])
+{
+    // case 1: outer radius
+    return outer_radius(fp_n_shells, thickness, interface);
+}
+
+static double blend(int shape, double nu, double z)
+{
+    if (shape==0) {
+        const double num = sas_erf(nu * M_SQRT1_2 * (2.0*z - 1.0));
+        const double denom = 2.0 * sas_erf(nu * M_SQRT1_2);
+        return num/denom + 0.5;
+    } else if (shape==1) {
+        return pow(z, nu);
+    } else if (shape==2) {
+        return 1.0 - pow(1.0 - z, nu);
+    } else if (shape==3) {
+        return expm1(-nu*z)/expm1(-nu);
+    } else if (shape==4) {
+        return expm1(nu*z)/expm1(nu);
+    } else if (shape==5) {
+        return 1.0 - pow(1.0 - z*z, (0.5*nu-2.0));        
+    } else {
+        return NAN;
+    }
+}
+
+static double f_linear(double q, double r, double contrast, double slope)
+{
+    const double qr = q * r;
+    const double qrsq = qr * qr;
+    const double bes = sas_3j1x_x(qr);
+    double sinqr, cosqr;
+    SINCOS(qr, sinqr, cosqr);
+    const double fun = 3.0*r*(2.0*qr*sinqr - (qrsq-2.0)*cosqr)/(qrsq*qrsq);
+    const double vol = M_4PI_3 * cube(r);
+    return vol*(bes*contrast + fun*slope);
+}
+
+static double Iq(
+    double q,
+    double fp_n_shells,
+    double sld_solvent,
+    double sld[],
+    double thickness[],
+    double interface[],
+    double shape[],
+    double nu[],
+    double fp_n_steps)
+{
+    // iteration for # of shells + core + solvent
+    int n_shells = (int)(fp_n_shells + 0.5);
+    int n_steps = (int)(fp_n_steps + 0.5);
+    double f=0.0;
+    double r=0.0;
+    for (int shell=0; shell<n_shells; shell++){
+        const double sld_l = sld[shell];
+
+        // uniform shell; r=0 => r^3=0 => f=0, so works for core as well.
+        f -= M_4PI_3 * cube(r) * sld_l * sas_3j1x_x(q*r);
+        r += thickness[shell];
+        f += M_4PI_3 * cube(r) * sld_l * sas_3j1x_x(q*r);
+
+        // iterate over sub_shells in the interface
+        const double dr = interface[shell]/n_steps;
+        const double delta = (shell==n_shells-1 ? sld_solvent : sld[shell+1]) - sld_l;
+        const double nu_shell = fmax(fabs(nu[shell]), 1.e-14);
+        const int shape_shell = (int)(shape[shell]);
+
+        // if there is no interface the equations don't work
+        if (dr == 0.) continue;
+
+        double sld_in = sld_l;
+        for (int step=1; step <= n_steps; step++) {
+            // find sld_i at the outer boundary of sub-shell step
+            //const double z = (double)step/(double)n_steps;
+            const double z = (double)step/(double)n_steps;
+            const double fraction = blend(shape_shell, nu_shell, z);
+            const double sld_out = fraction*delta + sld_l;
+            // calculate slope
+            const double slope = (sld_out - sld_in)/dr;
+            const double contrast = sld_in - slope*r;
+
+            // iteration for the left and right boundary of the shells
+            f -= f_linear(q, r, contrast, slope);
+            r += dr;
+            f += f_linear(q, r, contrast, slope);
+            sld_in = sld_out;
+        }
+    }
+    // add in solvent effect
+    f -= M_4PI_3 * cube(r) * sld_solvent * sas_3j1x_x(q*r);
+
+    const double f2 = f * f * 1.0e-4;
+    return f2;
+}
+
+static void Fq(
+    double q,
+    double *F1,
+    double *F2,
+    double fp_n_shells,
+    double sld_solvent,
+    double sld[],
+    double thickness[],
+    double interface[],
+    double shape[],
+    double nu[],
+    double fp_n_steps)
+{
+    // iteration for # of shells + core + solvent
+    int n_shells = (int)(fp_n_shells + 0.5);
+    int n_steps = (int)(fp_n_steps + 0.5);
+    double f=0.0;
+    double r=0.0;
+    for (int shell=0; shell<n_shells; shell++){
+        const double sld_l = sld[shell];
+
+        // uniform shell; r=0 => r^3=0 => f=0, so works for core as well.
+        f -= M_4PI_3 * cube(r) * sld_l * sas_3j1x_x(q*r);
+        r += thickness[shell];
+        f += M_4PI_3 * cube(r) * sld_l * sas_3j1x_x(q*r);
+
+        // iterate over sub_shells in the interface
+        const double dr = interface[shell]/n_steps;
+        const double delta = (shell==n_shells-1 ? sld_solvent : sld[shell+1]) - sld_l;
+        const double nu_shell = fmax(fabs(nu[shell]), 1.e-14);
+        const int shape_shell = (int)(shape[shell]);
+
+        // if there is no interface the equations don't work
+        if (dr == 0.) continue;
+
+        double sld_in = sld_l;
+        for (int step=1; step <= n_steps; step++) {
+            // find sld_i at the outer boundary of sub-shell step
+            //const double z = (double)step/(double)n_steps;
+            const double z = (double)step/(double)n_steps;
+            const double fraction = blend(shape_shell, nu_shell, z);
+            const double sld_out = fraction*delta + sld_l;
+            // calculate slope
+            const double slope = (sld_out - sld_in)/dr;
+            const double contrast = sld_in - slope*r;
+
+            // iteration for the left and right boundary of the shells
+            f -= f_linear(q, r, contrast, slope);
+            r += dr;
+            f += f_linear(q, r, contrast, slope);
+            sld_in = sld_out;
+        }
+    }
+    // add in solvent effect
+    f -= M_4PI_3 * cube(r) * sld_solvent * sas_3j1x_x(q*r);
+
+    *F1 = 1e-2*f;
+    *F2 = 1e-4*f*f;
+}
+
+

--- a/mcstas-comps/share/sas_spinodal.c
+++ b/mcstas-comps/share/sas_spinodal.c
@@ -1,0 +1,399 @@
+#define HAS_Iq
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/spinodal.c"
+
+    
+double Iq(double q, double gamma, double q_0);
+
+#pragma acc routine seq
+double Iq(double q, double gamma, double q_0) {
+    double x = q / q_0;
+    double inten = ((1 + gamma / 2) * pow(x, 2)) / (gamma / 2 + pow(x, 2 + gamma));
+    return inten;
+}
+
+
+

--- a/mcstas-comps/share/sas_squarewell.c
+++ b/mcstas-comps/share/sas_squarewell.c
@@ -1,0 +1,434 @@
+#define HAS_Iq
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/squarewell.c"
+
+double Iq(double q, double radius_effective, double volfraction, double welldepth, double wellwidth)
+{
+
+// single precision is very poor at extreme small Q, would need a Taylor series
+	double req,phis,edibkb,lambda,struc;
+	double sigma,eta,eta2,eta3,eta4,etam1,etam14,alpha,beta,gamm;
+	double x,sk,sk2,sk3,sk4,t1,t2,t3,t4,ck;
+	double S,C,SL,CL;
+	x= q;
+
+	req = radius_effective;
+	phis = volfraction;
+	edibkb = welldepth;
+	lambda = wellwidth;
+
+	sigma = req*2.;
+	eta = phis;
+	eta2 = eta*eta;
+	eta3 = eta*eta2;
+	eta4 = eta*eta3;
+	etam1 = 1. - eta;
+	etam14 = etam1*etam1*etam1*etam1;
+	// temp borrow sk for an intermediate calc
+	sk = 1.0 +2.0*eta;
+	sk *= sk;
+	alpha = (  sk + eta3*( eta-4.0 )  )/etam14;
+	beta = -(eta/3.0) * ( 18. + 20.*eta - 12.*eta2 + eta4 )/etam14;
+	gamm = 0.5*eta*( sk + eta3*(eta-4.) )/etam14;
+
+	//  calculate the structure factor
+
+	sk = x*sigma;
+	sk2 = sk*sk;
+	sk3 = sk*sk2;
+	sk4 = sk3*sk;
+	SINCOS(sk,S,C);
+	SINCOS(lambda*sk,SL,CL);
+	t1 = alpha * sk3 * ( S - sk * C );
+	t2 = beta * sk2 * 2.0*( sk*S - (0.5*sk2 - 1.)*C - 1.0 );
+	t3 = gamm*( ( 4.0*sk3 - 24.*sk ) * S - ( sk4 - 12.0*sk2 + 24.0 )*C + 24.0 );
+	t4 = -edibkb*sk3*(SL +sk*(C - lambda*CL) - S );
+	ck =  -24.0*eta*( t1 + t2 + t3 + t4 )/sk3/sk3;
+	struc  = 1./(1.-ck);
+
+	return(struc);
+}
+

--- a/mcstas-comps/share/sas_stacked_disks.c
+++ b/mcstas-comps/share/sas_stacked_disks.c
@@ -1,0 +1,1086 @@
+#define HAS_Iqac
+#define HAS_Iq
+#define FORM_VOL
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/polevl.c"
+
+/*							polevl.c
+ *							p1evl.c
+ *
+ *	Evaluate polynomial
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * int N;
+ * double x, y, coef[N+1], polevl[];
+ *
+ * y = polevl( x, coef, N );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Evaluates polynomial of degree N:
+ *
+ *                     2          N
+ * y  =  C  + C x + C x  +...+ C x
+ *        0    1     2          N
+ *
+ * Coefficients are stored in reverse order:
+ *
+ * coef[0] = C  , ..., coef[N] = C  .
+ *            N                   0
+ *
+ * The function p1evl() assumes that C_N = 1.0 and is
+ * omitted from the array.  Its calling arguments are
+ * otherwise the same as polevl().
+ *
+ *
+ * SPEED:
+ *
+ * In the interest of speed, there are no checks for out
+ * of bounds arithmetic.  This routine is used by most of
+ * the functions in the library.  Depending on available
+ * equipment features, the user may wish to rewrite the
+ * program in microcode or assembly language.
+ *
+ */
+
+
+/*
+Cephes Math Library Release 2.1:  December, 1988
+Copyright 1984, 1987, 1988 by Stephen L. Moshier
+Direct inquiries to 30 Frost Street, Cambridge, MA 02140
+*/
+#pragma acc routine seq
+static
+double polevl( double x, pconstant double *coef, int N )
+{
+
+    int i = 0;
+    double ans = coef[i];
+
+    while (i < N) {
+        i++;
+        ans = ans * x + coef[i];
+    }
+
+    return ans;
+}
+
+/*							p1evl()	*/
+/*                                          N
+ * Evaluate polynomial when coefficient of x  is 1.0.
+ * Otherwise same as polevl.
+ */
+#pragma acc routine seq
+static
+double p1evl( double x, pconstant double *coef, int N )
+{
+    int i=0;
+    double ans = x+coef[i];
+
+    while (i < N-1) {
+        i++;
+        ans = ans*x + coef[i];
+    }
+
+    return ans;
+}
+
+
+#line 1 ".././models/lib/sas_J1.c"
+
+/*							j1.c
+ *
+ *	Bessel function of order one
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * double x, y, j1();
+ *
+ * y = j1( x );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Returns Bessel function of order one of the argument.
+ *
+ * The domain is divided into the intervals [0, 8] and
+ * (8, infinity). In the first interval a 24 term Chebyshev
+ * expansion is used. In the second, the asymptotic
+ * trigonometric representation is employed using two
+ * rational functions of degree 5/5.
+ *
+ *
+ *
+ * ACCURACY:
+ *
+ *                      Absolute error:
+ * arithmetic   domain      # trials      peak         rms
+ *    DEC       0, 30       10000       4.0e-17     1.1e-17
+ *    IEEE      0, 30       30000       2.6e-16     1.1e-16
+ *
+ *
+ */
+
+/*
+Cephes Math Library Release 2.8:  June, 2000
+Copyright 1984, 1987, 1989, 2000 by Stephen L. Moshier
+*/
+
+#if FLOAT_SIZE>4
+//Cephes double pression function
+
+constant double RPJ1[8] = {
+    -8.99971225705559398224E8,
+    4.52228297998194034323E11,
+    -7.27494245221818276015E13,
+    3.68295732863852883286E15,
+    0.0,
+    0.0,
+    0.0,
+    0.0 };
+
+constant double RQJ1[8] = {
+    6.20836478118054335476E2,
+    2.56987256757748830383E5,
+    8.35146791431949253037E7,
+    2.21511595479792499675E10,
+    4.74914122079991414898E12,
+    7.84369607876235854894E14,
+    8.95222336184627338078E16,
+    5.32278620332680085395E18
+    };
+
+constant double PPJ1[8] = {
+    7.62125616208173112003E-4,
+    7.31397056940917570436E-2,
+    1.12719608129684925192E0,
+    5.11207951146807644818E0,
+    8.42404590141772420927E0,
+    5.21451598682361504063E0,
+    1.00000000000000000254E0,
+    0.0} ;
+
+
+constant double PQJ1[8] = {
+    5.71323128072548699714E-4,
+    6.88455908754495404082E-2,
+    1.10514232634061696926E0,
+    5.07386386128601488557E0,
+    8.39985554327604159757E0,
+    5.20982848682361821619E0,
+    9.99999999999999997461E-1,
+    0.0 };
+
+constant double QPJ1[8] = {
+    5.10862594750176621635E-2,
+    4.98213872951233449420E0,
+    7.58238284132545283818E1,
+    3.66779609360150777800E2,
+    7.10856304998926107277E2,
+    5.97489612400613639965E2,
+    2.11688757100572135698E2,
+    2.52070205858023719784E1 };
+
+constant double QQJ1[8] = {
+    7.42373277035675149943E1,
+    1.05644886038262816351E3,
+    4.98641058337653607651E3,
+    9.56231892404756170795E3,
+    7.99704160447350683650E3,
+    2.82619278517639096600E3,
+    3.36093607810698293419E2,
+    0.0 };
+
+#pragma acc declare copyin( RPJ1[0:8], RQJ1[0:8], PPJ1[0:8], PQJ1[0:8], QPJ1[0:8], QQJ1[0:8])
+
+#pragma acc routine seq
+static
+double cephes_j1(double x)
+{
+
+    double w, z, p, q, abs_x, sign_x;
+
+    const double Z1 = 1.46819706421238932572E1;
+    const double Z2 = 4.92184563216946036703E1;
+
+    // 2017-05-18 PAK - mathematica and mpmath use J1(-x) = -J1(x)
+    if (x < 0) {
+        abs_x = -x;
+        sign_x = -1.0;
+    } else {
+        abs_x = x;
+        sign_x = 1.0;
+    }
+
+    if( abs_x <= 5.0 ) {
+        z = abs_x * abs_x;
+        w = polevl( z, RPJ1, 3 ) / p1evl( z, RQJ1, 8 );
+        w = w * abs_x * (z - Z1) * (z - Z2);
+        return( sign_x * w );
+    }
+
+    w = 5.0/abs_x;
+    z = w * w;
+    p = polevl( z, PPJ1, 6)/polevl( z, PQJ1, 6 );
+    q = polevl( z, QPJ1, 7)/p1evl( z, QQJ1, 7 );
+
+    // 2017-05-19 PAK improve accuracy using trig identies
+    // original:
+    //    const double THPIO4 =  2.35619449019234492885;
+    //    const double SQ2OPI = 0.79788456080286535588;
+    //    double sin_xn, cos_xn;
+    //    SINCOS(abs_x - THPIO4, sin_xn, cos_xn);
+    //    p = p * cos_xn - w * q * sin_xn;
+    //    return( sign_x * p * SQ2OPI / sqrt(abs_x) );
+    // expanding p*cos(a - 3 pi/4) - wq sin(a - 3 pi/4)
+    //    [ p(sin(a) - cos(a)) + wq(sin(a) + cos(a)) / sqrt(2)
+    // note that sqrt(1/2) * sqrt(2/pi) = sqrt(1/pi)
+    const double SQRT1_PI = 0.56418958354775628;
+    double sin_x, cos_x;
+    SINCOS(abs_x, sin_x, cos_x);
+    p = p*(sin_x - cos_x) + w*q*(sin_x + cos_x);
+    return( sign_x * p * SQRT1_PI / sqrt(abs_x) );
+}
+
+#else
+//Single precission version of cephes
+
+constant float JPJ1[8] = {
+    -4.878788132172128E-009,
+    6.009061827883699E-007,
+    -4.541343896997497E-005,
+    1.937383947804541E-003,
+    -3.405537384615824E-002,
+    0.0,
+    0.0,
+    0.0
+    };
+
+constant float MO1J1[8] = {
+    6.913942741265801E-002,
+    -2.284801500053359E-001,
+    3.138238455499697E-001,
+    -2.102302420403875E-001,
+    5.435364690523026E-003,
+    1.493389585089498E-001,
+    4.976029650847191E-006,
+    7.978845453073848E-001
+    };
+
+constant float PH1J1[8] = {
+    -4.497014141919556E+001,
+    5.073465654089319E+001,
+    -2.485774108720340E+001,
+    7.222973196770240E+000,
+    -1.544842782180211E+000,
+    3.503787691653334E-001,
+    -1.637986776941202E-001,
+    3.749989509080821E-001
+    };
+
+#pragma acc declare copyin( JPJ1[0:8], MO1J1[0:8], PH1J1[0:8])
+
+#pragma acc routine seq
+static
+float cephes_j1f(float xx)
+{
+
+    float x, w, z, p, q, xn;
+
+    const float Z1 = 1.46819706421238932572E1;
+
+
+    // 2017-05-18 PAK - mathematica and mpmath use J1(-x) = -J1(x)
+    x = xx;
+    if( x < 0 )
+        x = -xx;
+
+    if( x <= 2.0 ) {
+        z = x * x;
+        p = (z-Z1) * x * polevl( z, JPJ1, 4 );
+        return( xx < 0. ? -p : p );
+    }
+
+    q = 1.0/x;
+    w = sqrt(q);
+
+    p = w * polevl( q, MO1J1, 7);
+    w = q*q;
+    // 2017-05-19 PAK improve accuracy using trig identies
+    // original:
+    //    const float THPIO4F =  2.35619449019234492885;    /* 3*pi/4 */
+    //    xn = q * polevl( w, PH1J1, 7) - THPIO4F;
+    //    p = p * cos(xn + x);
+    //    return( xx < 0. ? -p : p );
+    // expanding cos(a + b - 3 pi/4) is
+    //    [sin(a)sin(b) + sin(a)cos(b) + cos(a)sin(b)-cos(a)cos(b)] / sqrt(2)
+    xn = q * polevl( w, PH1J1, 7);
+    float cos_xn, sin_xn;
+    float cos_x, sin_x;
+    SINCOS(xn, sin_xn, cos_xn);  // about xn and 1
+    SINCOS(x, sin_x, cos_x);
+    p *= M_SQRT1_2*(sin_xn*(sin_x+cos_x) + cos_xn*(sin_x-cos_x));
+
+    return( xx < 0. ? -p : p );
+}
+#endif
+
+#if FLOAT_SIZE>4
+#define sas_J1 cephes_j1
+#else
+#define sas_J1 cephes_j1f
+#endif
+
+//Finally J1c function that equals 2*J1(x)/x
+    
+#pragma acc routine seq
+static
+double sas_2J1x_x(double x)
+{
+    return (x != 0.0 ) ? 2.0*sas_J1(x)/x : 1.0;
+}
+
+
+#line 1 ".././models/lib/gauss76.c"
+
+// Created by Andrew Jackson on 4/23/07
+
+ #ifdef GAUSS_N
+ # undef GAUSS_N
+ # undef GAUSS_Z
+ # undef GAUSS_W
+ #endif
+ #define GAUSS_N 76
+ #define GAUSS_Z Gauss76Z
+ #define GAUSS_W Gauss76Wt
+
+// Gaussians
+constant double Gauss76Wt[76] = {
+	.00126779163408536,		//0
+	.00294910295364247,
+	.00462793522803742,
+	.00629918049732845,
+	.00795984747723973,
+	.00960710541471375,
+	.0112381685696677,
+	.0128502838475101,
+	.0144407317482767,
+	.0160068299122486,
+	.0175459372914742,		//10
+	.0190554584671906,
+	.020532847967908,
+	.0219756145344162,
+	.0233813253070112,
+	.0247476099206597,
+	.026072164497986,
+	.0273527555318275,
+	.028587223650054,
+	.029773487255905,
+	.0309095460374916,		//20
+	.0319934843404216,
+	.0330234743977917,
+	.0339977794120564,
+	.0349147564835508,
+	.0357728593807139,
+	.0365706411473296,
+	.0373067565423816,
+	.0379799643084053,
+	.0385891292645067,
+	.0391332242205184,		//30
+	.0396113317090621,
+	.0400226455325968,
+	.040366472122844,
+	.0406422317102947,
+	.0408494593018285,
+	.040987805464794,
+	.0410570369162294,
+	.0410570369162294,
+	.040987805464794,
+	.0408494593018285,		//40
+	.0406422317102947,
+	.040366472122844,
+	.0400226455325968,
+	.0396113317090621,
+	.0391332242205184,
+	.0385891292645067,
+	.0379799643084053,
+	.0373067565423816,
+	.0365706411473296,
+	.0357728593807139,		//50
+	.0349147564835508,
+	.0339977794120564,
+	.0330234743977917,
+	.0319934843404216,
+	.0309095460374916,
+	.029773487255905,
+	.028587223650054,
+	.0273527555318275,
+	.026072164497986,
+	.0247476099206597,		//60
+	.0233813253070112,
+	.0219756145344162,
+	.020532847967908,
+	.0190554584671906,
+	.0175459372914742,
+	.0160068299122486,
+	.0144407317482767,
+	.0128502838475101,
+	.0112381685696677,
+	.00960710541471375,		//70
+	.00795984747723973,
+	.00629918049732845,
+	.00462793522803742,
+	.00294910295364247,
+	.00126779163408536		//75 (indexed from 0)
+};
+
+constant double Gauss76Z[76] = {
+	-.999505948362153,		//0
+	-.997397786355355,
+	-.993608772723527,
+	-.988144453359837,
+	-.981013938975656,
+	-.972229228520377,
+	-.961805126758768,
+	-.949759207710896,
+	-.936111781934811,
+	-.92088586125215,
+	-.904107119545567,		//10
+	-.885803849292083,
+	-.866006913771982,
+	-.844749694983342,
+	-.822068037328975,
+	-.7980001871612,
+	-.77258672828181,
+	-.74587051350361,
+	-.717896592387704,
+	-.688712135277641,
+	-.658366353758143,		//20
+	-.626910417672267,
+	-.594397368836793,
+	-.560882031601237,
+	-.526420920401243,
+	-.491072144462194,
+	-.454895309813726,
+	-.417951418780327,
+	-.380302767117504,
+	-.342012838966962,
+	-.303146199807908,		//30
+	-.263768387584994,
+	-.223945802196474,
+	-.183745593528914,
+	-.143235548227268,
+	-.102483975391227,
+	-.0615595913906112,
+	-.0205314039939986,
+	.0205314039939986,
+	.0615595913906112,
+	.102483975391227,			//40
+	.143235548227268,
+	.183745593528914,
+	.223945802196474,
+	.263768387584994,
+	.303146199807908,
+	.342012838966962,
+	.380302767117504,
+	.417951418780327,
+	.454895309813726,
+	.491072144462194,		//50
+	.526420920401243,
+	.560882031601237,
+	.594397368836793,
+	.626910417672267,
+	.658366353758143,
+	.688712135277641,
+	.717896592387704,
+	.74587051350361,
+	.77258672828181,
+	.7980001871612,	//60
+	.822068037328975,
+	.844749694983342,
+	.866006913771982,
+	.885803849292083,
+	.904107119545567,
+	.92088586125215,
+	.936111781934811,
+	.949759207710896,
+	.961805126758768,
+	.972229228520377,		//70
+	.981013938975656,
+	.988144453359837,
+	.993608772723527,
+	.997397786355355,
+	.999505948362153		//75
+};
+
+
+#pragma acc declare copyin(Gauss76Wt[0:76], Gauss76Z[0:76])
+
+#line 1 ".././models/stacked_disks.c"
+
+static double
+stacked_disks_kernel(
+    double qab,
+    double qc,
+    double halfheight,
+    double thick_layer,
+    double radius,
+    int n_stacking,
+    double sigma_dnn,
+    double core_sld,
+    double layer_sld,
+    double solvent_sld,
+    double d)
+
+{
+    // q is the q-value for the calculation (1/A)
+    // radius is the core radius of the cylinder (A)
+    // *_sld are the respective SLD's
+    // halfheight is the *Half* CORE-LENGTH of the cylinder = L (A)
+    // zi is the dummy variable for the integration (x in Feigin's notation)
+
+    const double besarg1 = radius*qab;
+    //const double besarg2 = radius*qab;
+
+    const double sinarg1 = halfheight*qc;
+    const double sinarg2 = (halfheight+thick_layer)*qc;
+
+    const double be1 = sas_2J1x_x(besarg1);
+    //const double be2 = sas_2J1x_x(besarg2);
+    const double be2 = be1;
+    const double si1 = sas_sinx_x(sinarg1);
+    const double si2 = sas_sinx_x(sinarg2);
+
+    const double dr1 = core_sld - solvent_sld;
+    const double dr2 = layer_sld - solvent_sld;
+    const double area = M_PI*radius*radius;
+    const double totald = 2.0*(thick_layer + halfheight);
+
+    const double t1 = area * (2.0*halfheight) * dr1 * si1 * be1;
+    const double t2 = area * dr2 * (totald*si2 - 2.0*halfheight*si1) * be2;
+
+    double pq = square(t1 + t2);
+
+    // loop for the structure factor S(q)
+    double qd_cos_alpha = d*qc;
+    //d*cos_alpha is the projection of d onto q (in other words the component
+    //of d that is parallel to q.
+    double debye_arg = -0.5*square(qd_cos_alpha*sigma_dnn);
+    double sq=0.0;
+    for (int kk=1; kk<n_stacking; kk++) {
+        sq += (n_stacking-kk) * cos(qd_cos_alpha*kk) * exp(debye_arg*kk);
+    }
+    // end of loop for S(q)
+    sq = 1.0 + 2.0*sq/n_stacking;
+
+    return pq * sq * n_stacking;
+    // volume normalization should be per disk not per stack but form_volume
+    // is per stack so correct here for now.  Could change form_volume but
+    // if one ever wants to use P*S we need the ER based on the total volume
+}
+
+
+static double
+stacked_disks_1d(
+    double q,
+    double thick_core,
+    double thick_layer,
+    double radius,
+    int n_stacking,
+    double sigma_dnn,
+    double core_sld,
+    double layer_sld,
+    double solvent_sld)
+{
+/*    StackedDiscsX  :  calculates the form factor of a stacked "tactoid" of core shell disks
+like clay platelets that are not exfoliated
+*/
+    double summ = 0.0;    //initialize integral
+
+    double d = 2.0*thick_layer+thick_core;
+    double halfheight = 0.5*thick_core;
+
+    for(int i=0; i<GAUSS_N; i++) {
+        double zi = (GAUSS_Z[i] + 1.0)*M_PI_4;
+        double sin_alpha, cos_alpha; // slots to hold sincos function output
+        SINCOS(zi, sin_alpha, cos_alpha);
+        double yyy = stacked_disks_kernel(q*sin_alpha, q*cos_alpha,
+                           halfheight,
+                           thick_layer,
+                           radius,
+                           n_stacking,
+                           sigma_dnn,
+                           core_sld,
+                           layer_sld,
+                           solvent_sld,
+                           d);
+        summ += GAUSS_W[i] * yyy * sin_alpha;
+    }
+
+    double answer = M_PI_4*summ;
+
+    //Convert to [cm-1]
+    return 1.0e-4*answer;
+}
+
+static double
+form_volume(
+    double thick_core,
+    double thick_layer,
+    double radius,
+    double fp_n_stacking)
+{
+    int n_stacking = (int)(fp_n_stacking + 0.5);
+    double d = 2.0 * thick_layer + thick_core;
+    return M_PI * radius * radius * d * n_stacking;
+}
+
+static double
+Iq(
+    double q,
+    double thick_core,
+    double thick_layer,
+    double radius,
+    double fp_n_stacking,
+    double sigma_dnn,
+    double core_sld,
+    double layer_sld,
+    double solvent_sld)
+{
+    int n_stacking = (int)(fp_n_stacking + 0.5);
+    return stacked_disks_1d(q,
+                    thick_core,
+                    thick_layer,
+                    radius,
+                    n_stacking,
+                    sigma_dnn,
+                    core_sld,
+                    layer_sld,
+                    solvent_sld);
+}
+
+
+static double
+Iqac(double qab, double qc,
+    double thick_core,
+    double thick_layer,
+    double radius,
+    double fp_n_stacking,
+    double sigma_dnn,
+    double core_sld,
+    double layer_sld,
+    double solvent_sld)
+{
+    int n_stacking = (int)(fp_n_stacking + 0.5);
+    double d = 2.0 * thick_layer + thick_core;
+    double halfheight = 0.5*thick_core;
+    double answer = stacked_disks_kernel(qab, qc,
+                     halfheight,
+                     thick_layer,
+                     radius,
+                     n_stacking,
+                     sigma_dnn,
+                     core_sld,
+                     layer_sld,
+                     solvent_sld,
+                     d);
+
+    //convert to [cm-1]
+    answer *= 1.0e-4;
+
+    return answer;
+}
+
+
+

--- a/mcstas-comps/share/sas_star_polymer.c
+++ b/mcstas-comps/share/sas_star_polymer.c
@@ -1,299 +1,416 @@
-// GENERATED CODE --- DO NOT EDIT ---
-// Code is produced by sasmodels.gen from sasmodels/models/MODEL.c
+#define HAS_Iq
+#define FORM_VOL
+#line 1 "../kernel_header.c"
 
 #ifdef __OPENCL_VERSION__
 # define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
 #endif
 
-#define USE_KAHAN_SUMMATION 0
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
 
 // If opencl is not available, then we are compiling a C function
 // Note: if using a C++ compiler, then define kernel as extern "C"
-#ifndef USE_OPENCL
-#  ifdef __cplusplus
-     #include <cstdio>
-     #include <cmath>
-     using namespace std;
-     #if defined(_MSC_VER)
-     #   define kernel extern "C" __declspec( dllexport )
-         inline float trunc(float x) { return x>=0?floor(x):-floor(-x); }
-	 inline float fmin(float x, float y) { return x>y ? y : x; }
-	 inline float fmax(float x, float y) { return x<y ? y : x; }
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
      #else
-     #   define kernel extern "C"
+         #define kernel extern "C"
+         #include <cstdint>
      #endif
-     inline void SINCOS(float angle, float &svar, float &cvar) { svar=sin(angle); cvar=cos(angle); }
-#  else
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
      #include <stdio.h>
-     #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
      // MSVC doesn't support C99, so no need for dllexport on C99 branch
      #define kernel
-     #define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
-#  define global
-#  define local
-#  define constant const
-// OpenCL powr(a,b) = C99 pow(a,b), b >= 0
-// OpenCL pown(a,b) = C99 pow(a,b), b integer
-#  define powr(a,b) pow(a,b)
-#  define pown(a,b) pow(a,b)
-#else
-#  ifdef USE_SINCOS
-#    define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
-#  else
-#    define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
 #endif
 
 // Standard mathematical constants:
 //   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
 //   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
-// OpenCL defines M_constant_F for float constants, and nothing if float
+// OpenCL defines M_constant_F for float constants, and nothing if double
 // is not enabled on the card, which is why these constants may be missing
 #ifndef M_PI
-#  define M_PI 3.141592653589793f
+#  define M_PI 3.141592653589793
 #endif
 #ifndef M_PI_2
-#  define M_PI_2 1.570796326794897f
+#  define M_PI_2 1.570796326794897
 #endif
 #ifndef M_PI_4
-#  define M_PI_4 0.7853981633974483f
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
 #endif
 
-// Non-standard pi/180, used for converting between degrees and radians
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
 #ifndef M_PI_180
-#  define M_PI_180 0.017453292519943295f
+#  define M_PI_180 0.017453292519943295
 #endif
-
-
-#define IQ_KERNEL_NAME star_polymer_Iq
-#define IQ_PARAMETERS radius2, arms
-#define IQ_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float radius2, \
-    const float arms
-#define IQXY_KERNEL_NAME star_polymer_Iqxy
-#define IQXY_PARAMETERS radius2, arms
-#define IQXY_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float radius2, \
-    const float arms
-
-float form_volume(void);
-
-float Iq(float q, float radius2, float arms);
-
-float Iqxy(float qx, float qy, float radius2, float arms);
-
-
-static float _mass_fractal_kernel(float q, float radius2, float arms)
-{
-
-    float u_2 = radius2 * pow(q,2);
-    float v = u_2 * arms / (3.0f * arms - 2.0f);
-
-    float term1 = v - 1.0f + exp(-v);
-    float term2 = ((arms - 1.0f)/2.0f)* pow((1.0f - exp(-v)),2.0f);
-
-    return (2.0f * (term1 + term2)) / (arms * pow(v,2.0f));
-
-}
-
-float form_volume(void)
-{
-    return 1.0f;
-}
-
-float Iq(float q, float radius2, float arms)
-{
-    return _mass_fractal_kernel(q, radius2, arms);
-}
-
-// Iqxy is never called since no orientation or magnetic parameters.
-float Iqxy(float qx, float qy, float radius2, float arms)
-{
-    float q = sqrt(qx*qx + qy*qy);
-    return _mass_fractal_kernel(q, radius2, arms);
-}
-
-
-
-/*
-    ##########################################################
-    #                                                        #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #   !!                                              !!   #
-    #   !!  KEEP THIS CODE CONSISTENT WITH KERNELPY.PY  !!   #
-    #   !!                                              !!   #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #                                                        #
-    ##########################################################
-*/
-
-#ifdef IQ_KERNEL_NAME
-kernel void IQ_KERNEL_NAME(
-    global const float *q,
-    global float *result,
-    const int Nq,
-#ifdef IQ_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQ_DISPERSION_LENGTH_DECLARATIONS,
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
 #endif
-    IQ_FIXED_PARAMETER_DECLARATIONS
-    )
-{
-#ifdef USE_OPENCL
-  #ifdef IQ_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQ_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
 
-  int i = get_global_id(0);
-  if (i < Nq)
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
 #else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
 #endif
-  {
-    const float qi = q[i];
-#ifdef IQ_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-  #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-  #endif
-    IQ_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
 
-    const float weight = IQ_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-      const float scattering = Iq(qi, IQ_PARAMETERS);
-      // allow kernels to exclude invalid regions by returning NaN
-      if (!isnan(scattering)) {
-        ret += weight*scattering;
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-        norm_vol += vol_weight;
-      #endif
-      }
-    //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
-    }
-    IQ_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
 #else
-    result[i] = scale*Iq(qi, IQ_PARAMETERS) + background;
-#endif
-  }
-}
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
 #endif
 
+//# Beginning of rotational operation definitions
 
-#ifdef IQXY_KERNEL_NAME
-kernel void IQXY_KERNEL_NAME(
-    global const float *qx,
-    global const float *qy,
-    global float *result,
-    const int Nq,
-#ifdef IQXY_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQXY_DISPERSION_LENGTH_DECLARATIONS,
-#endif
-    IQXY_FIXED_PARAMETER_DECLARATIONS
-    )
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
 {
-#ifdef USE_OPENCL
-  #ifdef IQXY_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQXY_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
 
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qxi = qx[i];
-    const float qyi = qy[i];
-    #if USE_KAHAN_SUMMATION
-    float accumulated_error = 0.0f;
-    #endif
-#ifdef IQXY_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-    #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-    #endif
-    IQXY_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
 
-    const float weight = IQXY_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
 
-      const float scattering = Iqxy(qxi, qyi, IQXY_PARAMETERS);
-      if (!isnan(scattering)) { // if scattering is bad, exclude it from sum
-      //if (scattering >= 0.0f) { // scattering cannot be negative
-        // TODO: use correct angle for spherical correction
-        // Definition of theta and phi are probably reversed relative to the
-        // equation which gave rise to this correction, leading to an
-        // attenuation of the pattern as theta moves through pi/2.f  Either
-        // reverse the meanings of phi and theta in the forms, or use phi
-        // rather than theta in this correction.  Current code uses cos(theta)
-        // so that values match those of sasview.
-      #if defined(IQXY_HAS_THETA) // && 0
-        const float spherical_correction
-          = (Ntheta>1 ? fabs(cos(M_PI_180*theta))*M_PI_2:1.0f);
-        const float next = spherical_correction * weight * scattering;
-      #else
-        const float next = weight * scattering;
-      #endif
-      #if USE_KAHAN_SUMMATION
-        const float y = next - accumulated_error;
-        const float t = ret + y;
-        accumulated_error = (t - ret) - y;
-        ret = t;
-      #else
-        ret += next;
-      #endif
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-      #endif
-        norm_vol += vol_weight;
-      }
-      //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
-    }
-    IQXY_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iqxy(qxi, qyi, IQXY_PARAMETERS) + background;
-#endif
-  }
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
 }
-#endif
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/star_polymer.c"
+
+double form_volume(void);
+
+double Iq(double q, double radius2, double arms);
+
+static double star_polymer_kernel(double q, double radius2, double arms)
+{
+
+    double u_2 = radius2 * q * q;
+    double v = u_2 * arms / (3.0 * arms - 2.0);
+
+    double term1 = v + expm1(-v);
+    double term2 = ((arms - 1.0)/2.0) * square(expm1(-v));
+
+    return (2.0 * (term1 + term2)) / (arms * v * v);
+
+}
+
+double form_volume(void)
+{
+    return 1.0;
+}
+
+double Iq(double q, double radius2, double arms)
+{
+    return star_polymer_kernel(q, radius2, arms);
+}
+
+

--- a/mcstas-comps/share/sas_superball.c
+++ b/mcstas-comps/share/sas_superball.c
@@ -1,0 +1,773 @@
+#define HAS_Iqabc
+#define HAS_FQ
+#define FORM_VOL
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/gauss20.c"
+
+// Created by Andrew Jackson on 4/23/07
+
+ #ifdef GAUSS_N
+ # undef GAUSS_N
+ # undef GAUSS_Z
+ # undef GAUSS_W
+ #endif
+ #define GAUSS_N 20
+ #define GAUSS_Z Gauss20Z
+ #define GAUSS_W Gauss20Wt
+
+// Gaussians
+constant double Gauss20Wt[20]={
+	.0176140071391521,
+	.0406014298003869,
+	.0626720483341091,
+	.0832767415767047,
+	.10193011981724,
+	.118194531961518,
+	.131688638449177,
+	.142096109318382,
+	.149172986472604,
+	.152753387130726,
+	.152753387130726,
+	.149172986472604,
+	.142096109318382,
+	.131688638449177,
+	.118194531961518,
+	.10193011981724,
+	.0832767415767047,
+	.0626720483341091,
+	.0406014298003869,
+	.0176140071391521
+};
+
+constant double Gauss20Z[20]={
+	-.993128599185095,
+	-.963971927277914,
+	-.912234428251326,
+	-.839116971822219,
+	-.746331906460151,
+	-.636053680726515,
+	-.510867001950827,
+	-.37370608871542,
+	-.227785851141645,
+	-.076526521133497,
+	.0765265211334973,
+	.227785851141645,
+	.37370608871542,
+	.510867001950827,
+	.636053680726515,
+	.746331906460151,
+	.839116971822219,
+	.912234428251326,
+	.963971927277914,
+	.993128599185095
+};
+
+#pragma acc declare copyin( Gauss20Wt[0:20], Gauss20Z[0:20] )
+
+#line 1 ".././models/lib/sas_gamma.c"
+
+/*
+The wrapper for gamma function from OpenCL and standard libraries
+The OpenCL gamma function fails miserably on values lower than 1.0
+while works fine on larger values.
+We use gamma definition Gamma(t + 1) = t * Gamma(t) to compute
+to function for values lower than 1.0. Namely Gamma(t) = 1/t * Gamma(t + 1)
+For t < 0, we use Gamma(t) = pi / ( Gamma(1 - t) * sin(pi * t) )
+*/
+
+#if defined(NEED_TGAMMA)
+#pragma acc routine seq
+static double cephes_stirf(double x)
+{
+	const double MAXSTIR=143.01608;
+	const double SQTPI=2.50662827463100050242E0;
+	double y, w, v;
+
+	w = 1.0 / x;
+
+	w = ((((
+		7.87311395793093628397E-4*w
+		- 2.29549961613378126380E-4)*w
+		- 2.68132617805781232825E-3)*w
+		+ 3.47222221605458667310E-3)*w
+		+ 8.33333333333482257126E-2)*w
+		+ 1.0;
+	y = exp(x);
+	if (x > MAXSTIR)
+	{ /* Avoid overflow in pow() */
+		v = pow(x, 0.5 * x - 0.25);
+		y = v * (v / y);
+	}
+	else
+	{
+		y = pow(x, x - 0.5) / y;
+	}
+	y = SQTPI * y * w;
+	return(y);
+}
+
+#pragma acc routine seq
+static double tgamma(double x) {
+	double p, q, z;
+	int sgngam;
+	int i;
+
+	sgngam = 1;
+	if (isnan(x))
+		return(x);
+	q = fabs(x);
+
+	if (q > 33.0)
+	{
+		if (x < 0.0)
+		{
+			p = floor(q);
+			if (p == q)
+			{
+				return (NAN);
+			}
+			i = p;
+			if ((i & 1) == 0)
+				sgngam = -1;
+			z = q - p;
+			if (z > 0.5)
+			{
+				p += 1.0;
+				z = q - p;
+			}
+			z = q * sin(M_PI * z);
+			if (z == 0.0)
+			{
+				return(NAN);
+			}
+			z = fabs(z);
+			z = M_PI / (z * cephes_stirf(q));
+		}
+		else
+		{
+			z = cephes_stirf(x);
+		}
+		return(sgngam * z);
+	}
+
+	z = 1.0;
+	while (x >= 3.0)
+	{
+		x -= 1.0;
+		z *= x;
+	}
+
+	while (x < 0.0)
+	{
+		if (x > -1.E-9)
+			goto small;
+		z /= x;
+		x += 1.0;
+	}
+
+	while (x < 2.0)
+	{
+		if (x < 1.e-9)
+			goto small;
+		z /= x;
+		x += 1.0;
+	}
+
+	if (x == 2.0)
+		return(z);
+
+	x -= 2.0;
+	p = (((((
+		+1.60119522476751861407E-4*x
+		+ 1.19135147006586384913E-3)*x
+		+ 1.04213797561761569935E-2)*x
+		+ 4.76367800457137231464E-2)*x
+		+ 2.07448227648435975150E-1)*x
+		+ 4.94214826801497100753E-1)*x
+		+ 9.99999999999999996796E-1;
+	q = ((((((
+		-2.31581873324120129819E-5*x
+		+ 5.39605580493303397842E-4)*x
+		- 4.45641913851797240494E-3)*x
+		+ 1.18139785222060435552E-2)*x
+		+ 3.58236398605498653373E-2)*x
+		- 2.34591795718243348568E-1)*x
+		+ 7.14304917030273074085E-2)*x
+		+ 1.00000000000000000320E0;
+	return(z * p / q);
+
+small:
+	if (x == 0.0)
+	{
+		return (NAN);
+	}
+	else
+		return(z / ((1.0 + 0.5772156649015329 * x) * x));
+}
+#endif // NEED_TGAMMA
+
+#pragma acc routine seq
+inline double sas_gamma(double x)
+{
+    // Note: the builtin tgamma can give slow and unreliable results for x<1.
+    // The following transform extends it to zero and to negative values.
+    // It should return NaN for zero and negative integers but doesn't.
+    // The accuracy is okay but not wonderful for negative numbers, maybe
+    // one or two digits lost in the calculation. If higher accuracy is
+    // needed, you could test the following loop:
+    //    double norm = 1.;
+    //    while (x<1.) { norm*=x; x+=1.; }
+    //    return tgamma(x)/norm;
+    return (x<0. ? M_PI/tgamma(1.-x)/sin(M_PI*x) : tgamma(x+1)/x);
+}
+
+
+#line 1 ".././models/superball.c"
+
+static double
+form_volume(double length_a, double exponent_p)
+{
+  double g1 = sas_gamma(1.0 / (2.0 * exponent_p));
+  double g3 = sas_gamma(3.0 / (2.0 * exponent_p));
+  return cube(length_a) / 12.0 / square(exponent_p) * cube(g1) / g3;
+}
+
+static double
+radius_from_excluded_volume(double length_a, double exponent_p)
+{
+  double g1 = sas_gamma(1.0 / (2.0 * exponent_p));
+  double g3 = sas_gamma(3.0 / (2.0 * exponent_p));
+  double g5 = sas_gamma(5.0 / (2.0 * exponent_p));
+
+  return length_a * g3 * sqrt(3.0 / 10.0 / g1 / g5);
+}
+
+static double
+
+radius_effective(int mode, double length_a, double exponent_p)
+
+{
+  switch (mode)
+  {
+  default:
+  case 1: // radius of gyration
+    return radius_from_excluded_volume(length_a, exponent_p);
+  case 2: // equivalent volume sphere
+    return cbrt(form_volume(length_a, exponent_p) / M_4PI_3);
+  case 3: // half length_a
+    return 0.5 * length_a;
+  }
+}
+
+static double oriented_superball(
+    double qx,
+    double qy,
+    double qz,
+    double length_a,
+    double exponent_p)
+{
+  // oriented superball form factor
+
+  // outer integral for x
+  const double radius = length_a / 2.0; // superball radius
+  const double inverse_2p = 1.0 / (2.0 * exponent_p);
+
+  double outer_integral = 0.0; //initialize integral
+
+  for (int i_x = 0; i_x < GAUSS_N; i_x++)
+  {
+    const double x = 0.5 * (GAUSS_Z[i_x] + 1.0); // integrate 0, 1
+    const double x2p = pow(x, 2.0 * exponent_p);
+    const double gamma = pow(1.0 - x2p, inverse_2p);
+
+    // inner integral for y
+    double inner_integral = 0.0; //initialize integral
+    for (int i_y = 0; i_y < GAUSS_N; i_y++)
+    {
+      const double y = 0.5 * gamma * (GAUSS_Z[i_y] + 1.0); // integrate 0, gamma
+      const double y2p = pow(y, 2.0 * exponent_p);
+      const double zeta = pow(1.0 - x2p - y2p, inverse_2p);
+      const double cos1 = cos(radius * qy * y);
+      const double sinc2 = qz == 0 ? radius * zeta : sin(radius * qz * zeta) / qz;
+      const double fq = cos1 * sinc2;
+      inner_integral += GAUSS_W[i_y] * fq;
+    }
+
+    const double co = cos(radius * qx * x);
+
+    // integration factor for -1,1 quadrature to 0, gamma: gamma/2
+    const double integration_factor = 0.5 * gamma;
+
+    // Eq. 21 in [Dresen2021]
+    outer_integral += GAUSS_W[i_x] * integration_factor * inner_integral * co * 2.0 * square(length_a);
+
+  }
+// Needed to normalise the oriented form factor, but would be reverted later with s = SLD contrast * volume
+// outer_integral /= form_volume(length_a, exponent_p); 
+
+  // integration factor for -1,1 quadrature to 0, 1: 1/2
+  return 0.5 * outer_integral;
+}
+
+static void
+Fq(double q,
+   double *F1,
+   double *F2,
+   double sld,
+   double solvent_sld,
+   double length_a,
+   double exponent_p)
+{
+
+  // translate a point in [-1,1] to a point in [0, pi/2]
+  const double zm = M_PI_4;
+  const double zb = M_PI_4;
+
+  double orient_averaged_outer_total_F1 = 0.0; //initialize integral
+  double orient_averaged_outer_total_F2 = 0.0; //initialize integral
+  // phi integral
+  for (int i_phi = 0; i_phi < GAUSS_N; i_phi++)
+  {
+
+    const double phi = GAUSS_Z[i_phi]*zm +zb; // integrate 0 .. pi/2
+
+    double sin_phi, cos_phi;
+    SINCOS(phi, sin_phi, cos_phi);
+
+    double orient_averaged_inner_total_F1 = 0.0; //initialize integral
+    double orient_averaged_inner_total_F2 = 0.0; //initialize integral
+    // theta integral
+    for (int i_theta = 0; i_theta < GAUSS_N; i_theta++)
+    {
+
+      const double cos_theta = GAUSS_Z[i_theta]*0.5 + 0.5; // integrate 0, 1
+      const double sin_theta = sqrt( 1.0 - square(cos_theta) );
+
+
+      const double qx = q * cos_phi * sin_theta;
+      const double qy = q * sin_phi * sin_theta;
+      const double qz = q * cos_theta;
+
+      const double f_oriented = oriented_superball(qx, qy, qz, length_a, exponent_p);
+
+
+      orient_averaged_inner_total_F1 += GAUSS_W[i_theta] * f_oriented;
+      orient_averaged_inner_total_F2 += GAUSS_W[i_theta] * square(f_oriented);
+
+    }
+    orient_averaged_outer_total_F1 += GAUSS_W[i_phi] * orient_averaged_inner_total_F1;
+    orient_averaged_outer_total_F2 += GAUSS_W[i_phi] * orient_averaged_inner_total_F2;
+  }
+
+
+  // integration factors for phi and theta integral, divided by solid angle of pi/2
+  orient_averaged_outer_total_F1 *= 0.25;
+  orient_averaged_outer_total_F2 *= 0.25;
+  // Multiply by contrast^2 and convert from [1e-12 A-1] to [cm-1]
+  const double s =  (sld - solvent_sld) ;
+
+  *F1 = 1.0e-2 * s * orient_averaged_outer_total_F1;
+  *F2 = 1.0e-4 * s * s * orient_averaged_outer_total_F2;
+}
+
+static double
+Iqabc(double qa, double qb, double qc,
+      double sld,
+      double solvent_sld,
+      double length_a,
+      double exponent_p)
+{
+  const double f_oriented = oriented_superball(qa, qb, qc, length_a, exponent_p);
+
+  const double s = (sld - solvent_sld); 
+
+
+  const double form = square(s * f_oriented);
+  // Square and convert from [1e-12 A-1] to [cm-1]
+  return 1.0e-4 * form;
+}
+
+

--- a/mcstas-comps/share/sas_surface_fractal.c
+++ b/mcstas-comps/share/sas_surface_fractal.c
@@ -1,0 +1,656 @@
+#define HAS_Iq
+#define FORM_VOL
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/sas_3j1x_x.c"
+
+/**
+* Spherical Bessel function 3*j1(x)/x
+*
+* Used for low q to avoid cancellation error.
+* Note that the values differ from sasview ~ 5e-12 rather than 5e-14, but
+* in this case it is likely cancellation errors in the original expression
+* using double precision that are the source.
+*/
+double sas_3j1x_x(double q);
+
+// The choice of the number of terms in the series and the cutoff value for
+// switching between series and direct calculation depends on the numeric
+// precision.
+//
+// Point where direct calculation reaches machine precision:
+//
+//   single machine precision eps 3e-8 at qr=1.1 **
+//   double machine precision eps 4e-16 at qr=1.1
+//
+// Point where Taylor series reaches machine precision (eps), where taylor
+// series matches direct calculation (cross) and the error at that point:
+//
+//   prec   n eps  cross  error
+//   single 3 0.28  0.4   6.2e-7
+//   single 4 0.68  0.7   2.3e-7
+//   single 5 1.18  1.2   7.5e-8
+//   double 3 0.01  0.03  2.3e-13
+//   double 4 0.06  0.1   3.1e-14
+//   double 5 0.16  0.2   5.0e-15
+//
+// ** Note: relative error on single precision starts increase on the direct
+// method at qr=1.1, rising from 3e-8 to 5e-5 by qr=1e3.  This should be
+// safe for the sans range, with objects of 100 nm supported to a q of 0.1
+// while maintaining 5 digits of precision.  For usans/sesans, the objects
+// are larger but the q is smaller, so again it should be fine.
+//
+// See explore/sph_j1c.py for code to explore these ranges.
+
+// Use 4th order series
+#if FLOAT_SIZE>4
+#define SPH_J1C_CUTOFF 0.1
+#else
+#define SPH_J1C_CUTOFF 0.7
+#endif
+#pragma acc routine seq
+double sas_3j1x_x(double q)
+{
+    // 2017-05-18 PAK - support negative q
+    if (fabs(q) < SPH_J1C_CUTOFF) {
+        const double q2 = q*q;
+        return (1.0 + q2*(-3./30. + q2*(3./840. + q2*(-3./45360.))));// + q2*(3./3991680.)))));
+    } else {
+        double sin_q, cos_q;
+        SINCOS(q, sin_q, cos_q);
+        return 3.0*(sin_q/q - cos_q)/(q*q);
+    }
+}
+
+
+#line 1 ".././models/lib/sas_gamma.c"
+
+/*
+The wrapper for gamma function from OpenCL and standard libraries
+The OpenCL gamma function fails miserably on values lower than 1.0
+while works fine on larger values.
+We use gamma definition Gamma(t + 1) = t * Gamma(t) to compute
+to function for values lower than 1.0. Namely Gamma(t) = 1/t * Gamma(t + 1)
+For t < 0, we use Gamma(t) = pi / ( Gamma(1 - t) * sin(pi * t) )
+*/
+
+#if defined(NEED_TGAMMA)
+#pragma acc routine seq
+static double cephes_stirf(double x)
+{
+	const double MAXSTIR=143.01608;
+	const double SQTPI=2.50662827463100050242E0;
+	double y, w, v;
+
+	w = 1.0 / x;
+
+	w = ((((
+		7.87311395793093628397E-4*w
+		- 2.29549961613378126380E-4)*w
+		- 2.68132617805781232825E-3)*w
+		+ 3.47222221605458667310E-3)*w
+		+ 8.33333333333482257126E-2)*w
+		+ 1.0;
+	y = exp(x);
+	if (x > MAXSTIR)
+	{ /* Avoid overflow in pow() */
+		v = pow(x, 0.5 * x - 0.25);
+		y = v * (v / y);
+	}
+	else
+	{
+		y = pow(x, x - 0.5) / y;
+	}
+	y = SQTPI * y * w;
+	return(y);
+}
+
+#pragma acc routine seq
+static double tgamma(double x) {
+	double p, q, z;
+	int sgngam;
+	int i;
+
+	sgngam = 1;
+	if (isnan(x))
+		return(x);
+	q = fabs(x);
+
+	if (q > 33.0)
+	{
+		if (x < 0.0)
+		{
+			p = floor(q);
+			if (p == q)
+			{
+				return (NAN);
+			}
+			i = p;
+			if ((i & 1) == 0)
+				sgngam = -1;
+			z = q - p;
+			if (z > 0.5)
+			{
+				p += 1.0;
+				z = q - p;
+			}
+			z = q * sin(M_PI * z);
+			if (z == 0.0)
+			{
+				return(NAN);
+			}
+			z = fabs(z);
+			z = M_PI / (z * cephes_stirf(q));
+		}
+		else
+		{
+			z = cephes_stirf(x);
+		}
+		return(sgngam * z);
+	}
+
+	z = 1.0;
+	while (x >= 3.0)
+	{
+		x -= 1.0;
+		z *= x;
+	}
+
+	while (x < 0.0)
+	{
+		if (x > -1.E-9)
+			goto small;
+		z /= x;
+		x += 1.0;
+	}
+
+	while (x < 2.0)
+	{
+		if (x < 1.e-9)
+			goto small;
+		z /= x;
+		x += 1.0;
+	}
+
+	if (x == 2.0)
+		return(z);
+
+	x -= 2.0;
+	p = (((((
+		+1.60119522476751861407E-4*x
+		+ 1.19135147006586384913E-3)*x
+		+ 1.04213797561761569935E-2)*x
+		+ 4.76367800457137231464E-2)*x
+		+ 2.07448227648435975150E-1)*x
+		+ 4.94214826801497100753E-1)*x
+		+ 9.99999999999999996796E-1;
+	q = ((((((
+		-2.31581873324120129819E-5*x
+		+ 5.39605580493303397842E-4)*x
+		- 4.45641913851797240494E-3)*x
+		+ 1.18139785222060435552E-2)*x
+		+ 3.58236398605498653373E-2)*x
+		- 2.34591795718243348568E-1)*x
+		+ 7.14304917030273074085E-2)*x
+		+ 1.00000000000000000320E0;
+	return(z * p / q);
+
+small:
+	if (x == 0.0)
+	{
+		return (NAN);
+	}
+	else
+		return(z / ((1.0 + 0.5772156649015329 * x) * x));
+}
+#endif // NEED_TGAMMA
+
+#pragma acc routine seq
+inline double sas_gamma(double x)
+{
+    // Note: the builtin tgamma can give slow and unreliable results for x<1.
+    // The following transform extends it to zero and to negative values.
+    // It should return NaN for zero and negative integers but doesn't.
+    // The accuracy is okay but not wonderful for negative numbers, maybe
+    // one or two digits lost in the calculation. If higher accuracy is
+    // needed, you could test the following loop:
+    //    double norm = 1.;
+    //    while (x<1.) { norm*=x; x+=1.; }
+    //    return tgamma(x)/norm;
+    return (x<0. ? M_PI/tgamma(1.-x)/sin(M_PI*x) : tgamma(x+1)/x);
+}
+
+
+#line 1 ".././models/surface_fractal.c"
+
+
+double form_volume(double radius);
+
+double Iq(double q,
+          double radius,
+          double fractal_dim_surf,
+          double cutoff_length);
+
+static double _surface_fractal_kernel(double q,
+    double radius,
+    double fractal_dim_surf,
+    double cutoff_length)
+{
+    // calculate P(q)
+    const double pq = square(sas_3j1x_x(q*radius));
+
+    // calculate S(q)
+    // Note: lim q->0 S(q) = -gamma(mmo) cutoff_length^mmo (mmo cutoff_length)
+    // however, the surface fractal formula is invalid outside the range
+    const double mmo = 5.0 - fractal_dim_surf;
+    const double sq = sas_gamma(mmo) * pow(cutoff_length, mmo)
+           * pow(1.0 + square(q*cutoff_length), -0.5*mmo)
+           * sin(-mmo * atan(q*cutoff_length)) / q;
+
+    // Empirically determined that the results are valid within this range.
+    // Above 1/r, the form starts to oscillate;  below
+    //const double result = (q > 5./(3-fractal_dim_surf)/cutoff_length) && q < 1./radius
+    //                      ? pq * sq : 0.);
+
+    double result = pq * sq;
+
+    // exclude negative results
+    return result > 0. ? result : 0.;
+}
+double form_volume(double radius)
+{
+    return M_4PI_3*cube(radius);
+}
+
+double Iq(double q,
+    double radius,
+    double fractal_dim_surf,
+    double cutoff_length
+    )
+{
+    return _surface_fractal_kernel(q, radius, fractal_dim_surf, cutoff_length);
+}
+
+

--- a/mcstas-comps/share/sas_teubner_strey.c
+++ b/mcstas-comps/share/sas_teubner_strey.c
@@ -1,0 +1,406 @@
+#define HAS_Iq
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/teubner_strey.c"
+
+#include <math.h>
+
+#define PI 3.14159265358979323846
+
+double Iq(double q, double volfraction_a, double sld_a, double sld_b, double d, double xi);
+
+#pragma acc routine seq
+double Iq(double q, double volfraction_a, double sld_a, double sld_b, double d, double xi) {
+    double drho = sld_a - sld_b;
+    double k = 2.0 * PI * xi / d;
+    double a2 = pow(1.0 + k * k, 2.0);
+    double c1 = 2.0 * xi * xi * (1.0 - k * k);
+    double c2 = xi * xi * xi * xi;
+    double prefactor = 8.0 * PI * volfraction_a * (1.0 - volfraction_a) * drho * drho * c2 / xi;
+    return 1.0e-4 * prefactor / (c2 * q * q + c1 * q + a2);
+}
+
+
+

--- a/mcstas-comps/share/sas_triaxial_ellipsoid.c
+++ b/mcstas-comps/share/sas_triaxial_ellipsoid.c
@@ -1,175 +1,391 @@
-// GENERATED CODE --- DO NOT EDIT ---
-// Code is produced by sasmodels.gen from sasmodels/models/MODEL.c
+#define HAS_Iqabc
+#define HAS_FQ
+#define FORM_VOL
+#line 1 "../kernel_header.c"
 
 #ifdef __OPENCL_VERSION__
 # define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
 #endif
 
-#define USE_KAHAN_SUMMATION 0
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
 
 // If opencl is not available, then we are compiling a C function
 // Note: if using a C++ compiler, then define kernel as extern "C"
-#ifndef USE_OPENCL
-#  ifdef __cplusplus
-     #include <cstdio>
-     #include <cmath>
-     using namespace std;
-     #if defined(_MSC_VER)
-     #   define kernel extern "C" __declspec( dllexport )
-         inline float trunc(float x) { return x>=0?floor(x):-floor(-x); }
-	 inline float fmin(float x, float y) { return x>y ? y : x; }
-	 inline float fmax(float x, float y) { return x<y ? y : x; }
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
      #else
-     #   define kernel extern "C"
+         #define kernel extern "C"
+         #include <cstdint>
      #endif
-     inline void SINCOS(float angle, float &svar, float &cvar) { svar=sin(angle); cvar=cos(angle); }
-#  else
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
      #include <stdio.h>
-     #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
      // MSVC doesn't support C99, so no need for dllexport on C99 branch
      #define kernel
-     #define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
-#  define global
-#  define local
-#  define constant const
-// OpenCL powr(a,b) = C99 pow(a,b), b >= 0
-// OpenCL pown(a,b) = C99 pow(a,b), b integer
-#  define powr(a,b) pow(a,b)
-#  define pown(a,b) pow(a,b)
-#else
-#  ifdef USE_SINCOS
-#    define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
-#  else
-#    define SINCOS(angle,svar,cvar) do {const float _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
-#  endif
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
 #endif
 
 // Standard mathematical constants:
 //   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
 //   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
-// OpenCL defines M_constant_F for float constants, and nothing if float
+// OpenCL defines M_constant_F for float constants, and nothing if double
 // is not enabled on the card, which is why these constants may be missing
 #ifndef M_PI
-#  define M_PI 3.141592653589793f
+#  define M_PI 3.141592653589793
 #endif
 #ifndef M_PI_2
-#  define M_PI_2 1.570796326794897f
+#  define M_PI_2 1.570796326794897
 #endif
 #ifndef M_PI_4
-#  define M_PI_4 0.7853981633974483f
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
 #endif
 
-// Non-standard pi/180, used for converting between degrees and radians
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
 #ifndef M_PI_180
-#  define M_PI_180 0.017453292519943295f
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
 #endif
 
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
 
-#define VOLUME_PARAMETERS req_minor,req_major,rpolar
-#define VOLUME_WEIGHT_PRODUCT req_minor_w*req_major_w*rpolar_w
-#define IQ_KERNEL_NAME triaxial_ellipsoid_Iq
-#define IQ_PARAMETERS sld, solvent_sld, req_minor, req_major, rpolar
-#define IQ_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float sld, \
-    const float solvent_sld
-#define IQ_WEIGHT_PRODUCT req_minor_w*req_major_w*rpolar_w
-#define IQ_DISPERSION_LENGTH_DECLARATIONS const int Nreq_minor, \
-    const int Nreq_major, \
-    const int Nrpolar
-#define IQ_DISPERSION_LENGTH_SUM Nreq_minor+Nreq_major+Nrpolar
-#define IQ_OPEN_LOOPS     for (int req_minor_i=0; req_minor_i < Nreq_minor; req_minor_i++) { \
-      const float req_minor = loops[2*(req_minor_i)]; \
-      const float req_minor_w = loops[2*(req_minor_i)+1]; \
-      for (int req_major_i=0; req_major_i < Nreq_major; req_major_i++) { \
-        const float req_major = loops[2*(req_major_i+Nreq_minor)]; \
-        const float req_major_w = loops[2*(req_major_i+Nreq_minor)+1]; \
-        for (int rpolar_i=0; rpolar_i < Nrpolar; rpolar_i++) { \
-          const float rpolar = loops[2*(rpolar_i+Nreq_minor+Nreq_major)]; \
-          const float rpolar_w = loops[2*(rpolar_i+Nreq_minor+Nreq_major)+1];
-#define IQ_CLOSE_LOOPS         } \
-      } \
-    }
-#define IQXY_KERNEL_NAME triaxial_ellipsoid_Iqxy
-#define IQXY_PARAMETERS sld, solvent_sld, req_minor, req_major, rpolar, theta, phi, psi
-#define IQXY_FIXED_PARAMETER_DECLARATIONS const float scale, \
-    const float background, \
-    const float sld, \
-    const float solvent_sld
-#define IQXY_WEIGHT_PRODUCT req_minor_w*req_major_w*rpolar_w*theta_w*phi_w*psi_w
-#define IQXY_DISPERSION_LENGTH_DECLARATIONS const int Nreq_minor, \
-    const int Nreq_major, \
-    const int Nrpolar, \
-    const int Ntheta, \
-    const int Nphi, \
-    const int Npsi
-#define IQXY_DISPERSION_LENGTH_SUM Nreq_minor+Nreq_major+Nrpolar+Ntheta+Nphi+Npsi
-#define IQXY_OPEN_LOOPS     for (int req_minor_i=0; req_minor_i < Nreq_minor; req_minor_i++) { \
-      const float req_minor = loops[2*(req_minor_i)]; \
-      const float req_minor_w = loops[2*(req_minor_i)+1]; \
-      for (int req_major_i=0; req_major_i < Nreq_major; req_major_i++) { \
-        const float req_major = loops[2*(req_major_i+Nreq_minor)]; \
-        const float req_major_w = loops[2*(req_major_i+Nreq_minor)+1]; \
-        for (int rpolar_i=0; rpolar_i < Nrpolar; rpolar_i++) { \
-          const float rpolar = loops[2*(rpolar_i+Nreq_minor+Nreq_major)]; \
-          const float rpolar_w = loops[2*(rpolar_i+Nreq_minor+Nreq_major)+1]; \
-          for (int theta_i=0; theta_i < Ntheta; theta_i++) { \
-            const float theta = loops[2*(theta_i+Nreq_minor+Nreq_major+Nrpolar)]; \
-            const float theta_w = loops[2*(theta_i+Nreq_minor+Nreq_major+Nrpolar)+1]; \
-            for (int phi_i=0; phi_i < Nphi; phi_i++) { \
-              const float phi = loops[2*(phi_i+Nreq_minor+Nreq_major+Nrpolar+Ntheta)]; \
-              const float phi_w = loops[2*(phi_i+Nreq_minor+Nreq_major+Nrpolar+Ntheta)+1]; \
-              for (int psi_i=0; psi_i < Npsi; psi_i++) { \
-                const float psi = loops[2*(psi_i+Nreq_minor+Nreq_major+Nrpolar+Ntheta+Nphi)]; \
-                const float psi_w = loops[2*(psi_i+Nreq_minor+Nreq_major+Nrpolar+Ntheta+Nphi)+1];
-#define IQXY_CLOSE_LOOPS               } \
-            } \
-          } \
-        } \
-      } \
-    }
-#define IQXY_HAS_THETA 1
+//# Beginning of rotational operation definitions
 
-float J1(float x);
-float J1(float x)
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
 {
-  const float ax = fabs(x);
-  if (ax < 8.0f) {
-    const float y = x*x;
-    const float ans1 = x*(72362614232.0f
-              + y*(-7895059235.0f
-              + y*(242396853.1f
-              + y*(-2972611.439f
-              + y*(15704.48260f
-              + y*(-30.16036606f))))));
-    const float ans2 = 144725228442.0f
-              + y*(2300535178.0f
-              + y*(18583304.74f
-              + y*(99447.43394f
-              + y*(376.9991397f
-              + y))));
-    return ans1/ans2;
-  } else {
-    const float y = 64.0f/(ax*ax);
-    const float xx = ax - 2.356194491f;
-    const float ans1 = 1.0f
-              + y*(0.183105e-2f
-              + y*(-0.3516396496e-4f
-              + y*(0.2457520174e-5f
-              + y*-0.240337019e-6f)));
-    const float ans2 = 0.04687499995f
-              + y*(-0.2002690873e-3f
-              + y*(0.8449199096e-5f
-              + y*(-0.88228987e-6f
-              + y*0.105787412e-6f)));
-    float sn,cn;
-    SINCOS(xx, sn, cn);
-    const float ans = sqrt(0.636619772f/ax) * (cn*ans1 - (8.0f/ax)*sn*ans2);
-    return (x < 0.0f) ? -ans : ans;
-  }
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
 }
 
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/sas_3j1x_x.c"
 
 /**
 * Spherical Bessel function 3*j1(x)/x
@@ -177,481 +393,390 @@ float J1(float x)
 * Used for low q to avoid cancellation error.
 * Note that the values differ from sasview ~ 5e-12 rather than 5e-14, but
 * in this case it is likely cancellation errors in the original expression
-* using float precision that are the source.  Single precision only
-* requires the first 3 terms.  Double precision requires the 4th term.
-* The fifth term is not needed, and is commented out.
-* Taylor expansion:
-*      1.0f + q2*(-3.f/30.f + q2*(3.f/840.f))+ q2*(-3.f/45360.f + q2*(3.f/3991680.f))))
-* Expression returned from Herbie (herbie.uwpise.org/demo):
-*      const float t = ((1.f + 3.f*q2*q2/5600.f) - q2/20.f);
-*      return t*t;
+* using double precision that are the source.
 */
+double sas_3j1x_x(double q);
 
-float sph_j1c(float q);
-float sph_j1c(float q)
+// The choice of the number of terms in the series and the cutoff value for
+// switching between series and direct calculation depends on the numeric
+// precision.
+//
+// Point where direct calculation reaches machine precision:
+//
+//   single machine precision eps 3e-8 at qr=1.1 **
+//   double machine precision eps 4e-16 at qr=1.1
+//
+// Point where Taylor series reaches machine precision (eps), where taylor
+// series matches direct calculation (cross) and the error at that point:
+//
+//   prec   n eps  cross  error
+//   single 3 0.28  0.4   6.2e-7
+//   single 4 0.68  0.7   2.3e-7
+//   single 5 1.18  1.2   7.5e-8
+//   double 3 0.01  0.03  2.3e-13
+//   double 4 0.06  0.1   3.1e-14
+//   double 5 0.16  0.2   5.0e-15
+//
+// ** Note: relative error on single precision starts increase on the direct
+// method at qr=1.1, rising from 3e-8 to 5e-5 by qr=1e3.  This should be
+// safe for the sans range, with objects of 100 nm supported to a q of 0.1
+// while maintaining 5 digits of precision.  For usans/sesans, the objects
+// are larger but the q is smaller, so again it should be fine.
+//
+// See explore/sph_j1c.py for code to explore these ranges.
+
+// Use 4th order series
+#if FLOAT_SIZE>4
+#define SPH_J1C_CUTOFF 0.1
+#else
+#define SPH_J1C_CUTOFF 0.7
+#endif
+#pragma acc routine seq
+double sas_3j1x_x(double q)
 {
-    const float q2 = q*q;
-    float sin_q, cos_q;
-
-    SINCOS(q, sin_q, cos_q);
-
-    const float bessel = (q < 0.384038453352533f)
-        ? (1.0f + q2*(-3.f/30.f + q2*(3.f/840.f)))
-        : 3.0f*(sin_q/q - cos_q)/q2;
-
-    return bessel;
-
- /*
-    // Code to test various expressions
-    if (sizeof(q2) > 4) {
-        return 3.0f*(sin_q/q - cos_q)/q2;
-    } else if (q < 0.384038453352533f) {
-        //const float t = ((1.f + 3.f*q2*q2/5600.f) - q2/20.f); return t*t;
-        return 1.0f + q2*q2*(3.f/840.f) - q2*(3.f/30.f);
-        //return 1.0f + q2*(-3.f/30.f + q2*(3.f/840.f));
-        //return 1.0f + q2*(-3.f/30.f + q2*(3.f/840.f + q2*(-3.f/45360.f)));
-        //return 1.0f + q2*(-3.f/30.f + q2*(3.f/840.f + q2*(-3.f/45360.f + q2*(3.f/3991680.f))));
+    // 2017-05-18 PAK - support negative q
+    if (fabs(q) < SPH_J1C_CUTOFF) {
+        const double q2 = q*q;
+        return (1.0 + q2*(-3./30. + q2*(3./840. + q2*(-3./45360.))));// + q2*(3./3991680.)))));
     } else {
-        return 3.0f*(sin_q/q - cos_q)/q2;
+        double sin_q, cos_q;
+        SINCOS(q, sin_q, cos_q);
+        return 3.0*(sin_q/q - cos_q)/(q*q);
     }
-*/
 }
 
 
-/*
- *  GaussWeights.c
- *  SANSAnalysis
- *
- *  Created by Andrew Jackson on 4/23/07.f
- *  Copyright 2007 __MyCompanyName__. All rights reserved.
- *
- */
+#line 1 ".././models/lib/gauss76.c"
+
+// Created by Andrew Jackson on 4/23/07
+
+ #ifdef GAUSS_N
+ # undef GAUSS_N
+ # undef GAUSS_Z
+ # undef GAUSS_W
+ #endif
+ #define GAUSS_N 76
+ #define GAUSS_Z Gauss76Z
+ #define GAUSS_W Gauss76Wt
 
 // Gaussians
-constant float Gauss76Wt[]={
-	.00126779163408536f,		//0
-	.00294910295364247f,
-	.00462793522803742f,
-	.00629918049732845f,
-	.00795984747723973f,
-	.00960710541471375f,
-	.0112381685696677f,
-	.0128502838475101f,
-	.0144407317482767f,
-	.0160068299122486f,
-	.0175459372914742f,		//10
-	.0190554584671906f,
-	.020532847967908f,
-	.0219756145344162f,
-	.0233813253070112f,
-	.0247476099206597f,
-	.026072164497986f,
-	.0273527555318275f,
-	.028587223650054f,
-	.029773487255905f,
-	.0309095460374916f,		//20
-	.0319934843404216f,
-	.0330234743977917f,
-	.0339977794120564f,
-	.0349147564835508f,
-	.0357728593807139f,
-	.0365706411473296f,
-	.0373067565423816f,
-	.0379799643084053f,
-	.0385891292645067f,
-	.0391332242205184f,		//30
-	.0396113317090621f,
-	.0400226455325968f,
-	.040366472122844f,
-	.0406422317102947f,
-	.0408494593018285f,
-	.040987805464794f,
-	.0410570369162294f,
-	.0410570369162294f,
-	.040987805464794f,
-	.0408494593018285f,		//40
-	.0406422317102947f,
-	.040366472122844f,
-	.0400226455325968f,
-	.0396113317090621f,
-	.0391332242205184f,
-	.0385891292645067f,
-	.0379799643084053f,
-	.0373067565423816f,
-	.0365706411473296f,
-	.0357728593807139f,		//50
-	.0349147564835508f,
-	.0339977794120564f,
-	.0330234743977917f,
-	.0319934843404216f,
-	.0309095460374916f,
-	.029773487255905f,
-	.028587223650054f,
-	.0273527555318275f,
-	.026072164497986f,
-	.0247476099206597f,		//60
-	.0233813253070112f,
-	.0219756145344162f,
-	.020532847967908f,
-	.0190554584671906f,
-	.0175459372914742f,
-	.0160068299122486f,
-	.0144407317482767f,
-	.0128502838475101f,
-	.0112381685696677f,
-	.00960710541471375f,		//70
-	.00795984747723973f,
-	.00629918049732845f,
-	.00462793522803742f,
-	.00294910295364247f,
-	.00126779163408536f		//75 (indexed from 0)
+constant double Gauss76Wt[76] = {
+	.00126779163408536,		//0
+	.00294910295364247,
+	.00462793522803742,
+	.00629918049732845,
+	.00795984747723973,
+	.00960710541471375,
+	.0112381685696677,
+	.0128502838475101,
+	.0144407317482767,
+	.0160068299122486,
+	.0175459372914742,		//10
+	.0190554584671906,
+	.020532847967908,
+	.0219756145344162,
+	.0233813253070112,
+	.0247476099206597,
+	.026072164497986,
+	.0273527555318275,
+	.028587223650054,
+	.029773487255905,
+	.0309095460374916,		//20
+	.0319934843404216,
+	.0330234743977917,
+	.0339977794120564,
+	.0349147564835508,
+	.0357728593807139,
+	.0365706411473296,
+	.0373067565423816,
+	.0379799643084053,
+	.0385891292645067,
+	.0391332242205184,		//30
+	.0396113317090621,
+	.0400226455325968,
+	.040366472122844,
+	.0406422317102947,
+	.0408494593018285,
+	.040987805464794,
+	.0410570369162294,
+	.0410570369162294,
+	.040987805464794,
+	.0408494593018285,		//40
+	.0406422317102947,
+	.040366472122844,
+	.0400226455325968,
+	.0396113317090621,
+	.0391332242205184,
+	.0385891292645067,
+	.0379799643084053,
+	.0373067565423816,
+	.0365706411473296,
+	.0357728593807139,		//50
+	.0349147564835508,
+	.0339977794120564,
+	.0330234743977917,
+	.0319934843404216,
+	.0309095460374916,
+	.029773487255905,
+	.028587223650054,
+	.0273527555318275,
+	.026072164497986,
+	.0247476099206597,		//60
+	.0233813253070112,
+	.0219756145344162,
+	.020532847967908,
+	.0190554584671906,
+	.0175459372914742,
+	.0160068299122486,
+	.0144407317482767,
+	.0128502838475101,
+	.0112381685696677,
+	.00960710541471375,		//70
+	.00795984747723973,
+	.00629918049732845,
+	.00462793522803742,
+	.00294910295364247,
+	.00126779163408536		//75 (indexed from 0)
 };
 
-#pragma acc declare create ( Gauss76Wt )
-
-constant float Gauss76Z[]={
-	-.999505948362153f,		//0
-	-.997397786355355f,
-	-.993608772723527f,
-	-.988144453359837f,
-	-.981013938975656f,
-	-.972229228520377f,
-	-.961805126758768f,
-	-.949759207710896f,
-	-.936111781934811f,
-	-.92088586125215f,
-	-.904107119545567f,		//10
-	-.885803849292083f,
-	-.866006913771982f,
-	-.844749694983342f,
-	-.822068037328975f,
-	-.7980001871612f,
-	-.77258672828181f,
-	-.74587051350361f,
-	-.717896592387704f,
-	-.688712135277641f,
-	-.658366353758143f,		//20
-	-.626910417672267f,
-	-.594397368836793f,
-	-.560882031601237f,
-	-.526420920401243f,
-	-.491072144462194f,
-	-.454895309813726f,
-	-.417951418780327f,
-	-.380302767117504f,
-	-.342012838966962f,
-	-.303146199807908f,		//30
-	-.263768387584994f,
-	-.223945802196474f,
-	-.183745593528914f,
-	-.143235548227268f,
-	-.102483975391227f,
-	-.0615595913906112f,
-	-.0205314039939986f,
-	.0205314039939986f,
-	.0615595913906112f,
-	.102483975391227f,			//40
-	.143235548227268f,
-	.183745593528914f,
-	.223945802196474f,
-	.263768387584994f,
-	.303146199807908f,
-	.342012838966962f,
-	.380302767117504f,
-	.417951418780327f,
-	.454895309813726f,
-	.491072144462194f,		//50
-	.526420920401243f,
-	.560882031601237f,
-	.594397368836793f,
-	.626910417672267f,
-	.658366353758143f,
-	.688712135277641f,
-	.717896592387704f,
-	.74587051350361f,
-	.77258672828181f,
-	.7980001871612f,	//60
-	.822068037328975f,
-	.844749694983342f,
-	.866006913771982f,
-	.885803849292083f,
-	.904107119545567f,
-	.92088586125215f,
-	.936111781934811f,
-	.949759207710896f,
-	.961805126758768f,
-	.972229228520377f,		//70
-	.981013938975656f,
-	.988144453359837f,
-	.993608772723527f,
-	.997397786355355f,
-	.999505948362153f		//75
+constant double Gauss76Z[76] = {
+	-.999505948362153,		//0
+	-.997397786355355,
+	-.993608772723527,
+	-.988144453359837,
+	-.981013938975656,
+	-.972229228520377,
+	-.961805126758768,
+	-.949759207710896,
+	-.936111781934811,
+	-.92088586125215,
+	-.904107119545567,		//10
+	-.885803849292083,
+	-.866006913771982,
+	-.844749694983342,
+	-.822068037328975,
+	-.7980001871612,
+	-.77258672828181,
+	-.74587051350361,
+	-.717896592387704,
+	-.688712135277641,
+	-.658366353758143,		//20
+	-.626910417672267,
+	-.594397368836793,
+	-.560882031601237,
+	-.526420920401243,
+	-.491072144462194,
+	-.454895309813726,
+	-.417951418780327,
+	-.380302767117504,
+	-.342012838966962,
+	-.303146199807908,		//30
+	-.263768387584994,
+	-.223945802196474,
+	-.183745593528914,
+	-.143235548227268,
+	-.102483975391227,
+	-.0615595913906112,
+	-.0205314039939986,
+	.0205314039939986,
+	.0615595913906112,
+	.102483975391227,			//40
+	.143235548227268,
+	.183745593528914,
+	.223945802196474,
+	.263768387584994,
+	.303146199807908,
+	.342012838966962,
+	.380302767117504,
+	.417951418780327,
+	.454895309813726,
+	.491072144462194,		//50
+	.526420920401243,
+	.560882031601237,
+	.594397368836793,
+	.626910417672267,
+	.658366353758143,
+	.688712135277641,
+	.717896592387704,
+	.74587051350361,
+	.77258672828181,
+	.7980001871612,	//60
+	.822068037328975,
+	.844749694983342,
+	.866006913771982,
+	.885803849292083,
+	.904107119545567,
+	.92088586125215,
+	.936111781934811,
+	.949759207710896,
+	.961805126758768,
+	.972229228520377,		//70
+	.981013938975656,
+	.988144453359837,
+	.993608772723527,
+	.997397786355355,
+	.999505948362153		//75
 };
 
-#pragma acc declare create ( Gauss76Z )
 
-float form_volume(float req_minor, float req_major, float rpolar);
-float Iq(float q, float sld, float solvent_sld,
-    float req_minor, float req_major, float rpolar);
-float Iqxy(float qx, float qy, float sld, float solvent_sld,
-    float req_minor, float req_major, float rpolar, float theta, float phi, float psi);
+#pragma acc declare copyin(Gauss76Wt[0:76], Gauss76Z[0:76])
 
-float form_volume(float req_minor, float req_major, float rpolar)
+#line 1 ".././models/triaxial_ellipsoid.c"
+
+static double
+form_volume(double radius_equat_minor, double radius_equat_major, double radius_polar)
 {
-    return 1.333333333333333f*M_PI*req_minor*req_major*rpolar;
+    return M_4PI_3*radius_equat_minor*radius_equat_major*radius_polar;
 }
 
-float Iq(float q,
-    float sld,
-    float solvent_sld,
-    float req_minor,
-    float req_major,
-    float rpolar)
+static double
+radius_from_curvature(double radius_equat_minor, double radius_equat_major, double radius_polar)
 {
-    // if (req_minor > req_major || req_major > rpolar) return NAN;  // Exclude invalid region
+    // Trivial cases
+    if (radius_equat_minor == radius_equat_major == radius_polar) return radius_polar;
+    if (radius_equat_minor * radius_equat_major * radius_polar == 0.)  return 0.;
 
-    float sn, cn;
-    //float st, ct;
-    //const float lower = 0.0f;
-    //const float upper = 1.0f;
-    float outer = 0.0f;
-    for (int i=0;i<76;i++) {
-        //const float cos_alpha = (Gauss76Z[i]*(upper-lower) + upper + lower)/2;
-        const float x = 0.5f*(Gauss76Z[i] + 1.0f);
-        SINCOS(M_PI_2*x, sn, cn);
-        const float acosx2 = req_minor*req_minor*cn*cn;
-        const float bsinx2 = req_major*req_major*sn*sn;
-        const float c2 = rpolar*rpolar;
 
-        float inner = 0.0f;
-        for (int j=0;j<76;j++) {
-            const float y = 0.5f*(Gauss76Z[j] + 1.0f);
-            const float t = q*sqrt(acosx2 + bsinx2*(1.0f-y*y) + c2*y*y);
-            const float fq = sph_j1c(t);
-            inner += Gauss76Wt[j] * fq * fq ;
+    double r_equat_equiv, r_polar_equiv;
+    double radii[3] = {radius_equat_minor, radius_equat_major, radius_polar};
+    double radmax = fmax(radii[0],fmax(radii[1],radii[2]));
+
+    double radius_1 = radmax;
+    double radius_2 = radmax;
+    double radius_3 = radmax;
+
+    for(int irad=0; irad<3; irad++) {
+        if (radii[irad] < radius_1) {
+            radius_3 = radius_2;
+            radius_2 = radius_1;
+            radius_1 = radii[irad];
+            } else {
+                if (radii[irad] < radius_2) {
+                        radius_2 = radii[irad];
+                }
+            }
+    }
+    if(radius_2-radius_1 > radius_3-radius_2) {
+        r_equat_equiv = sqrt(radius_2*radius_3);
+        r_polar_equiv = radius_1;
+    } else  {
+        r_equat_equiv = sqrt(radius_1*radius_2);
+        r_polar_equiv = radius_3;
+    }
+
+    // see equation (26) in A.Isihara, J.Chem.Phys. 18(1950)1446-1449
+    const double ratio = (r_polar_equiv < r_equat_equiv
+                          ? r_polar_equiv / r_equat_equiv
+                          : r_equat_equiv / r_polar_equiv);
+    const double e1 = sqrt(1.0 - ratio*ratio);
+    const double b1 = 1.0 + asin(e1) / (e1 * ratio);
+    const double bL = (1.0 + e1) / (1.0 - e1);
+    const double b2 = 1.0 + 0.5 * ratio * ratio / e1 * log(bL);
+    const double delta = 0.75 * b1 * b2;
+    const double ddd = 2.0 * (delta + 1.0) * r_polar_equiv * r_equat_equiv * r_equat_equiv;
+    return 0.5 * cbrt(ddd);
+}
+
+static double
+radius_from_volume(double radius_equat_minor, double radius_equat_major, double radius_polar)
+{
+    return cbrt(radius_equat_minor*radius_equat_major*radius_polar);
+}
+
+static double
+radius_from_min_dimension(double radius_equat_minor, double radius_equat_major, double radius_polar)
+{
+    const double rad_equat_min = (radius_equat_minor < radius_equat_major ? radius_equat_minor : radius_equat_major);
+    return (rad_equat_min < radius_polar ? rad_equat_min : radius_polar);
+}
+
+static double
+radius_from_max_dimension(double radius_equat_minor, double radius_equat_major, double radius_polar)
+{
+    const double rad_equat_max = (radius_equat_minor < radius_equat_major ? radius_equat_major : radius_equat_minor);
+    return (rad_equat_max > radius_polar ? rad_equat_max : radius_polar);
+}
+
+static double
+radius_effective(int mode, double radius_equat_minor, double radius_equat_major, double radius_polar)
+{
+    switch (mode) {
+    default:
+    case 1: // equivalent biaxial ellipsoid average curvature
+        return radius_from_curvature(radius_equat_minor,radius_equat_major, radius_polar);
+    case 2: // equivalent volume sphere
+        return radius_from_volume(radius_equat_minor,radius_equat_major, radius_polar);
+    case 3: // min radius
+        return radius_from_min_dimension(radius_equat_minor,radius_equat_major, radius_polar);
+    case 4: // max radius
+        return radius_from_max_dimension(radius_equat_minor,radius_equat_major, radius_polar);
+    }
+}
+
+static void
+Fq(double q,
+    double *F1,
+    double *F2,
+    double sld,
+    double sld_solvent,
+    double radius_equat_minor,
+    double radius_equat_major,
+    double radius_polar)
+{
+    const double pa = square(radius_equat_minor/radius_equat_major) - 1.0;
+    const double pc = square(radius_polar/radius_equat_major) - 1.0;
+    // translate a point in [-1,1] to a point in [0, pi/2]
+    const double zm = M_PI_4;
+    const double zb = M_PI_4;
+    double outer_sum_F1 = 0.0;
+    double outer_sum_F2 = 0.0;
+    for (int i=0;i<GAUSS_N;i++) {
+        //const double u = GAUSS_Z[i]*(upper-lower)/2 + (upper + lower)/2;
+        const double phi = GAUSS_Z[i]*zm + zb;
+        const double pa_sinsq_phi = pa*square(sin(phi));
+
+        double inner_sum_F1 = 0.0;
+        double inner_sum_F2 = 0.0;
+        const double um = 0.5;
+        const double ub = 0.5;
+        for (int j=0;j<GAUSS_N;j++) {
+            // translate a point in [-1,1] to a point in [0, 1]
+            const double usq = square(GAUSS_Z[j]*um + ub);
+            const double r = radius_equat_major*sqrt(pa_sinsq_phi*(1.0-usq) + 1.0 + pc*usq);
+            const double fq = sas_3j1x_x(q*r);
+            inner_sum_F1 += GAUSS_W[j] * fq;
+            inner_sum_F2 += GAUSS_W[j] * fq * fq;
         }
-        outer += Gauss76Wt[i] * 0.5f * inner;
+        outer_sum_F1 += GAUSS_W[i] * inner_sum_F1;  // correcting for dx later
+        outer_sum_F2 += GAUSS_W[i] * inner_sum_F2;  // correcting for dx later
     }
-    //const float fq2 = (upper-lower)/2*outer;
-    const float fq2 = 0.5f*outer;
-    const float s = (sld - solvent_sld) * form_volume(req_minor, req_major, rpolar);
-    return 1.0e-4f * fq2 * s * s;
+    // translate integration ranges from [-1,1] to [lower,upper] and normalize by 4 pi
+    outer_sum_F1 *= 0.25;  // = outer*um*zm*8.0/(4.0*M_PI);
+    outer_sum_F2 *= 0.25;  // = outer*um*zm*8.0/(4.0*M_PI);
+
+    const double volume = form_volume(radius_equat_minor, radius_equat_major, radius_polar);
+    const double contrast = (sld - sld_solvent);
+    *F1 = 1.0e-2 * contrast * volume * outer_sum_F1;
+    *F2 = 1.0e-4 * square(contrast * volume) * outer_sum_F2;
 }
 
-float Iqxy(float qx, float qy,
-    float sld,
-    float solvent_sld,
-    float req_minor,
-    float req_major,
-    float rpolar,
-    float theta,
-    float phi,
-    float psi)
+
+static double
+Iqabc(double qa, double qb, double qc,
+    double sld,
+    double sld_solvent,
+    double radius_equat_minor,
+    double radius_equat_major,
+    double radius_polar)
 {
-    // if (req_minor > req_major || req_major > rpolar) return NAN;  // Exclude invalid region
+    const double qr = sqrt(square(radius_equat_minor*qa)
+                           + square(radius_equat_major*qb)
+                           + square(radius_polar*qc));
+    const double fq = sas_3j1x_x(qr);
+    const double vol = form_volume(radius_equat_minor, radius_equat_major, radius_polar);
+    const double drho = (sld - sld_solvent);
 
-    float stheta, ctheta;
-    float sphi, cphi;
-    float spsi, cpsi;
-    float st, ct;
-
-    const float q = sqrt(qx*qx + qy*qy);
-    const float qxhat = qx/q;
-    const float qyhat = qy/q;
-    SINCOS(theta*M_PI_180, stheta, ctheta);
-    SINCOS(phi*M_PI_180, sphi, cphi);
-    SINCOS(psi*M_PI_180, spsi, cpsi);
-    const float calpha = ctheta*cphi*qxhat + stheta*qyhat;
-    const float cnu = (-cphi*spsi*stheta + sphi*cpsi)*qxhat + spsi*ctheta*qyhat;
-    const float cmu = (-stheta*cpsi*cphi - spsi*sphi)*qxhat + ctheta*cpsi*qyhat;
-    const float t = q*sqrt(req_minor*req_minor*cnu*cnu
-                          + req_major*req_major*cmu*cmu
-                          + rpolar*rpolar*calpha*calpha);
-    SINCOS(t, st, ct);
-    const float fq = ( t==0.0f ? 1.0f : 3.0f*(st-t*ct)/(t*t*t) );
-    const float s = (sld - solvent_sld) * form_volume(req_minor, req_major, rpolar);
-
-    return 1.0e-4f * fq * fq * s * s;
+    return 1.0e-4 * square(vol * drho * fq);
 }
 
 
-
-/*
-    ##########################################################
-    #                                                        #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #   !!                                              !!   #
-    #   !!  KEEP THIS CODE CONSISTENT WITH KERNELPY.PY  !!   #
-    #   !!                                              !!   #
-    #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!   #
-    #                                                        #
-    ##########################################################
-*/
-
-#ifdef IQ_KERNEL_NAME
-kernel void IQ_KERNEL_NAME(
-    global const float *q,
-    global float *result,
-    const int Nq,
-#ifdef IQ_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQ_DISPERSION_LENGTH_DECLARATIONS,
-#endif
-    IQ_FIXED_PARAMETER_DECLARATIONS
-    )
-{
-#ifdef USE_OPENCL
-  #ifdef IQ_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQ_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
-
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qi = q[i];
-#ifdef IQ_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-  #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-  #endif
-    IQ_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
-
-    const float weight = IQ_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-      const float scattering = Iq(qi, IQ_PARAMETERS);
-      // allow kernels to exclude invalid regions by returning NaN
-      if (!isnan(scattering)) {
-        ret += weight*scattering;
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-        norm_vol += vol_weight;
-      #endif
-      }
-    //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
-    }
-    IQ_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iq(qi, IQ_PARAMETERS) + background;
-#endif
-  }
-}
-#endif
-
-
-#ifdef IQXY_KERNEL_NAME
-kernel void IQXY_KERNEL_NAME(
-    global const float *qx,
-    global const float *qy,
-    global float *result,
-    const int Nq,
-#ifdef IQXY_OPEN_LOOPS
-  #ifdef USE_OPENCL
-    global float *loops_g,
-  #endif
-    local float *loops,
-    const float cutoff,
-    IQXY_DISPERSION_LENGTH_DECLARATIONS,
-#endif
-    IQXY_FIXED_PARAMETER_DECLARATIONS
-    )
-{
-#ifdef USE_OPENCL
-  #ifdef IQXY_OPEN_LOOPS
-  // copy loops info to local memory
-  event_t e = async_work_group_copy(loops, loops_g, (IQXY_DISPERSION_LENGTH_SUM)*2, 0);
-  wait_group_events(1, &e);
-  #endif
-
-  int i = get_global_id(0);
-  if (i < Nq)
-#else
-  #pragma omp parallel for
-  for (int i=0; i < Nq; i++)
-#endif
-  {
-    const float qxi = qx[i];
-    const float qyi = qy[i];
-    #if USE_KAHAN_SUMMATION
-    float accumulated_error = 0.0f;
-    #endif
-#ifdef IQXY_OPEN_LOOPS
-    float ret=0.0f, norm=0.0f;
-    #ifdef VOLUME_PARAMETERS
-    float vol=0.0f, norm_vol=0.0f;
-    #endif
-    IQXY_OPEN_LOOPS
-    //for (int radius_i=0; radius_i < Nradius; radius_i++) {
-    //  const float radius = loops[2*(radius_i)];
-    //  const float radius_w = loops[2*(radius_i)+1];
-
-    const float weight = IQXY_WEIGHT_PRODUCT;
-    if (weight > cutoff) {
-
-      const float scattering = Iqxy(qxi, qyi, IQXY_PARAMETERS);
-      if (!isnan(scattering)) { // if scattering is bad, exclude it from sum
-      //if (scattering >= 0.0f) { // scattering cannot be negative
-        // TODO: use correct angle for spherical correction
-        // Definition of theta and phi are probably reversed relative to the
-        // equation which gave rise to this correction, leading to an
-        // attenuation of the pattern as theta moves through pi/2.f  Either
-        // reverse the meanings of phi and theta in the forms, or use phi
-        // rather than theta in this correction.  Current code uses cos(theta)
-        // so that values match those of sasview.
-      #if defined(IQXY_HAS_THETA) // && 0
-        const float spherical_correction
-          = (Ntheta>1 ? fabs(cos(M_PI_180*theta))*M_PI_2:1.0f);
-        const float next = spherical_correction * weight * scattering;
-      #else
-        const float next = weight * scattering;
-      #endif
-      #if USE_KAHAN_SUMMATION
-        const float y = next - accumulated_error;
-        const float t = ret + y;
-        accumulated_error = (t - ret) - y;
-        ret = t;
-      #else
-        ret += next;
-      #endif
-        norm += weight;
-      #ifdef VOLUME_PARAMETERS
-        const float vol_weight = VOLUME_WEIGHT_PRODUCT;
-        vol += vol_weight*form_volume(VOLUME_PARAMETERS);
-      #endif
-        norm_vol += vol_weight;
-      }
-      //else { printf("exclude qx,qy,I:%g,%g,%g\n",qi,scattering); }
-    }
-    IQXY_CLOSE_LOOPS
-  #ifdef VOLUME_PARAMETERS
-    if (vol*norm_vol != 0.0f) {
-      ret *= norm_vol/vol;
-    }
-  #endif
-    result[i] = scale*ret/norm+background;
-#else
-    result[i] = scale*Iqxy(qxi, qyi, IQXY_PARAMETERS) + background;
-#endif
-  }
-}
-#endif

--- a/mcstas-comps/share/sas_two_lorentzian.c
+++ b/mcstas-comps/share/sas_two_lorentzian.c
@@ -1,0 +1,412 @@
+#define HAS_Iq
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/two_lorentzian.c"
+
+#include <math.h>
+
+double Iq(double q,
+          double lorentz_scale_1,
+          double lorentz_length_1,
+          double lorentz_exp_1,
+          double lorentz_scale_2,
+          double lorentz_length_2,
+          double lorentz_exp_2);
+
+#pragma acc routine seq
+double Iq(double q,
+          double lorentz_scale_1,
+          double lorentz_length_1,
+          double lorentz_exp_1,
+          double lorentz_scale_2,
+          double lorentz_length_2,
+          double lorentz_exp_2) {
+    double intensity = lorentz_scale_1 / (1.0 + pow(q * lorentz_length_1, lorentz_exp_1));
+    intensity += lorentz_scale_2 / (1.0 + pow(q * lorentz_length_2, lorentz_exp_2));
+    return intensity;
+}
+
+
+

--- a/mcstas-comps/share/sas_two_power_law.c
+++ b/mcstas-comps/share/sas_two_power_law.c
@@ -1,0 +1,406 @@
+#define HAS_Iq
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/two_power_law.c"
+
+#include <math.h>
+#include <stdio.h>
+    
+double Iq(double q, double coefficent_1, double crossover, double power_1, double power_2);
+
+#pragma acc routine seq
+double Iq(double q, double coefficent_1, double crossover, double power_1, double power_2) {
+    double result;
+    if (q <= crossover) {
+        result = coefficent_1 * pow(q, -power_1);
+    } else {
+        double coefficent_2 = coefficent_1 * pow(crossover, power_2 - power_1);
+        result = coefficent_2 * pow(q, -power_2);
+    }
+    return result;
+}
+
+
+

--- a/mcstas-comps/share/sas_vesicle.c
+++ b/mcstas-comps/share/sas_vesicle.c
@@ -1,0 +1,512 @@
+#define HAS_FQ
+#define FORM_VOL
+#line 1 "../kernel_header.c"
+
+#ifdef __OPENCL_VERSION__
+# define USE_OPENCL
+#elif defined(__CUDACC__)
+# define USE_CUDA
+#elif defined(_OPENMP)
+# define USE_OPENMP
+#endif
+
+// Use SAS_DOUBLE to force the use of double even for float kernels
+#define SAS_DOUBLE double
+
+// If opencl is not available, then we are compiling a C function
+// Note: if using a C++ compiler, then define kernel as extern "C"
+#ifdef USE_OPENCL
+
+   #define USE_GPU
+   #define pglobal global
+   #define pconstant constant
+
+   typedef int int32_t;
+
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) svar=sincos(angle,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+   // Intel CPU on Mac gives strange values for erf(); on the verified
+   // platforms (intel, nvidia, amd), the cephes erf() is significantly
+   // faster than that available in the native OpenCL.
+   #define NEED_ERF
+   // OpenCL only has type generic math
+   #define expf exp
+   #ifndef NEED_ERF
+   #  define erff erf
+   #  define erfcf erfc
+   #endif
+
+#elif defined(USE_CUDA)
+
+   #define USE_GPU
+   #define local __shared__
+   #define pglobal
+   #define constant __constant__
+   #define pconstant const
+   #define kernel extern "C" __global__
+
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+   //typedef int int32_t;
+   #if defined(USE_SINCOS)
+   #  define SINCOS(angle,svar,cvar) sincos(angle,&svar,&cvar)
+   #else
+   #  define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif
+
+#else // !USE_OPENCL && !USE_CUDA
+
+   #define local
+   #define pglobal
+   #define constant const
+   #define pconstant const
+
+   #ifdef __cplusplus
+      #include <cstdio>
+      #include <cmath>
+      using namespace std;
+      #if defined(_MSC_VER)
+         #include <limits>
+         #include <float.h>
+         #define kernel extern "C" __declspec( dllexport )
+         inline double trunc(double x) { return x>=0?floor(x):-floor(-x); }
+         inline double fmin(double x, double y) { return x>y ? y : x; }
+         inline double fmax(double x, double y) { return x<y ? y : x; }
+         #define isnan(x) _isnan(x)
+         #define isinf(x) (!_finite(x))
+         #define isfinite(x) _finite(x)
+         #define NAN (std::numeric_limits<double>::quiet_NaN()) // non-signalling NaN
+         #define INFINITY (std::numeric_limits<double>::infinity())
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+     #else
+         #define kernel extern "C"
+         #include <cstdint>
+     #endif
+     inline void SINCOS(double angle, double &svar, double &cvar) { svar=sin(angle); cvar=cos(angle); }
+   #else // !__cplusplus
+     #include <inttypes.h>  // C99 guarantees that int32_t types is here
+     #include <stdio.h>
+     #if defined(__TINYC__)
+         typedef int int32_t;
+         #include <math.h>
+         // TODO: check isnan is correct
+         inline double _isnan(double x) { return x != x; } // hope this doesn't optimize away!
+         #undef isnan
+         #define isnan(x) _isnan(x)
+         // Defeat the double->float conversion since we don't have tgmath
+         inline SAS_DOUBLE trunc(SAS_DOUBLE x) { return x>=0?floor(x):-floor(-x); }
+         inline SAS_DOUBLE fmin(SAS_DOUBLE x, SAS_DOUBLE y) { return x>y ? y : x; }
+         inline SAS_DOUBLE fmax(SAS_DOUBLE x, SAS_DOUBLE y) { return x<y ? y : x; }
+         #define NEED_ERF
+         #define NEED_EXPM1
+         #define NEED_TGAMMA
+         #define NEED_CBRT
+         // expf missing from windows?
+         #define expf exp
+     #else
+         #include <tgmath.h> // C99 type-generic math, so sin(float) => sinf
+     #endif
+     // MSVC doesn't support C99, so no need for dllexport on C99 branch
+     #define kernel
+     #define SINCOS(angle,svar,cvar) do {const double _t_=angle; svar=sin(_t_);cvar=cos(_t_);} while (0)
+   #endif  // !__cplusplus
+   // OpenCL powr(a,b) = C99 pow(a,b), b >= 0
+   // OpenCL pown(a,b) = C99 pow(a,b), b integer
+   #define powr(a,b) pow(a,b)
+   #define pown(a,b) pow(a,b)
+
+#endif // !USE_OPENCL
+
+#if defined(NEED_CBRT)
+   #define cbrt(_x) pow(_x, 0.33333333333333333333333)
+#endif
+
+#if defined(NEED_EXPM1)
+   // TODO: precision is a half digit lower than numpy on mac in [1e-7, 0.5]
+   // Run "explore/precision.py sas_expm1" to see this (may have to fiddle
+   // the xrange for log to see the complete range).
+   static SAS_DOUBLE expm1(SAS_DOUBLE x_in) {
+      double x = (double)x_in;  // go back to float for single precision kernels
+      // Adapted from the cephes math library.
+      // Copyright 1984 - 1992 by Stephen L. Moshier
+      if (x != x || x == 0.0) {
+         return x; // NaN and +/- 0
+      } else if (x < -0.5 || x > 0.5) {
+         return exp(x) - 1.0;
+      } else {
+         const double xsq = x*x;
+         const double p = (((
+            +1.2617719307481059087798E-4)*xsq
+            +3.0299440770744196129956E-2)*xsq
+            +9.9999999999999999991025E-1);
+         const double q = ((((
+            +3.0019850513866445504159E-6)*xsq
+            +2.5244834034968410419224E-3)*xsq
+            +2.2726554820815502876593E-1)*xsq
+            +2.0000000000000000000897E0);
+         double r = x * p;
+         r =  r / (q - r);
+         return r+r;
+       }
+   }
+#endif
+
+// Standard mathematical constants:
+//   M_E, M_LOG2E, M_LOG10E, M_LN2, M_LN10, M_PI, M_PI_2=pi/2, M_PI_4=pi/4,
+//   M_1_PI=1/pi, M_2_PI=2/pi, M_2_SQRTPI=2/sqrt(pi), SQRT2, SQRT1_2=sqrt(1/2)
+// OpenCL defines M_constant_F for float constants, and nothing if double
+// is not enabled on the card, which is why these constants may be missing
+#ifndef M_PI
+#  define M_PI 3.141592653589793
+#endif
+#ifndef M_PI_2
+#  define M_PI_2 1.570796326794897
+#endif
+#ifndef M_PI_4
+#  define M_PI_4 0.7853981633974483
+#endif
+#ifndef M_E
+#  define M_E 2.718281828459045091
+#endif
+#ifndef M_SQRT1_2
+#  define M_SQRT1_2 0.70710678118654746
+#endif
+
+// Non-standard function library
+// pi/180, used for converting between degrees and radians
+// 4/3 pi for computing sphere volumes
+// square and cube for computing squares and cubes
+#ifndef M_PI_180
+#  define M_PI_180 0.017453292519943295
+#endif
+#ifndef M_4PI_3
+#  define M_4PI_3 4.18879020478639
+#endif
+double square(double x) { return x*x; }
+double cube(double x) { return x*x*x; }
+double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif
+
+//# Beginning of rotational operation definitions
+
+typedef struct {
+          double R31, R32;
+      } QACRotation;
+
+typedef struct {
+    double R11, R12;
+    double R21, R22;
+    double R31, R32;
+} QABCRotation;
+
+// Fill in the rotation matrix R from the view angles (theta, phi) and the
+// jitter angles (dtheta, dphi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qc]'
+static void
+qac_rotation(
+    QACRotation *rotation,
+    double theta, double phi,
+    double dtheta, double dphi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    const double V11 = cos_phi*cos_theta;
+    const double V12 = sin_phi*cos_theta;
+    const double V21 = -sin_phi;
+    const double V22 = cos_phi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qac_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qc]'
+static void
+qac_apply(
+    QACRotation *rotation,
+    double qx, double qy,
+    double *qab_out, double *qc_out)
+{
+    // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
+    *qc_out = dqc;
+}
+
+// Fill in the rotation matrix R from the view angles (theta, phi, psi) and the
+// jitter angles (dtheta, dphi, dpsi).  This matrix can be applied to all of the
+// (qx, qy) points in the image to produce R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_rotation(
+    QABCRotation *rotation,
+    double theta, double phi, double psi,
+    double dtheta, double dphi, double dpsi)
+{
+    double sin_theta, cos_theta;
+    double sin_phi, cos_phi;
+    double sin_psi, cos_psi;
+
+    // reverse view matrix
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi);
+    const double V11 = -sin_phi*sin_psi + cos_phi*cos_psi*cos_theta;
+    const double V12 = sin_phi*cos_psi*cos_theta + sin_psi*cos_phi;
+    const double V21 = -sin_phi*cos_psi - sin_psi*cos_phi*cos_theta;
+    const double V22 = -sin_phi*sin_psi*cos_theta + cos_phi*cos_psi;
+    const double V31 = sin_theta*cos_phi;
+    const double V32 = sin_phi*sin_theta;
+
+    // reverse jitter matrix
+    SINCOS(dtheta*M_PI_180, sin_theta, cos_theta);
+    SINCOS(dphi*M_PI_180, sin_phi, cos_phi);
+    SINCOS(dpsi*M_PI_180, sin_psi, cos_psi);
+    const double J11 = cos_psi*cos_theta;
+    const double J12 = sin_phi*sin_theta*cos_psi + sin_psi*cos_phi;
+    const double J13 = sin_phi*sin_psi - sin_theta*cos_phi*cos_psi;
+    const double J21 = -sin_psi*cos_theta;
+    const double J22 = -sin_phi*sin_psi*sin_theta + cos_phi*cos_psi;
+    const double J23 = sin_phi*cos_psi + sin_psi*sin_theta*cos_phi;
+    const double J31 = sin_theta;
+    const double J32 = -sin_phi*cos_theta;
+    const double J33 = cos_phi*cos_theta;
+
+    // reverse matrix
+    rotation->R11 = J11*V11 + J12*V21 + J13*V31;
+    rotation->R12 = J11*V12 + J12*V22 + J13*V32;
+    rotation->R21 = J21*V11 + J22*V21 + J23*V31;
+    rotation->R22 = J21*V12 + J22*V22 + J23*V32;
+    rotation->R31 = J31*V11 + J32*V21 + J33*V31;
+    rotation->R32 = J31*V12 + J32*V22 + J33*V32;
+}
+
+// Apply the rotation matrix returned from qabc_rotation to the point (qx,qy),
+// returning R*[qx,qy]' = [qa,qb,qc]'
+static void
+qabc_apply(
+    QABCRotation *rotation,
+    double qx, double qy,
+    double *qa_out, double *qb_out, double *qc_out)
+{
+    *qa_out = rotation->R11*qx + rotation->R12*qy;
+    *qb_out = rotation->R21*qx + rotation->R22*qy;
+    *qc_out = rotation->R31*qx + rotation->R32*qy;
+}
+
+// ##### End of rotation operation definitions ######
+
+#line 1 ".././models/lib/sas_3j1x_x.c"
+
+/**
+* Spherical Bessel function 3*j1(x)/x
+*
+* Used for low q to avoid cancellation error.
+* Note that the values differ from sasview ~ 5e-12 rather than 5e-14, but
+* in this case it is likely cancellation errors in the original expression
+* using double precision that are the source.
+*/
+double sas_3j1x_x(double q);
+
+// The choice of the number of terms in the series and the cutoff value for
+// switching between series and direct calculation depends on the numeric
+// precision.
+//
+// Point where direct calculation reaches machine precision:
+//
+//   single machine precision eps 3e-8 at qr=1.1 **
+//   double machine precision eps 4e-16 at qr=1.1
+//
+// Point where Taylor series reaches machine precision (eps), where taylor
+// series matches direct calculation (cross) and the error at that point:
+//
+//   prec   n eps  cross  error
+//   single 3 0.28  0.4   6.2e-7
+//   single 4 0.68  0.7   2.3e-7
+//   single 5 1.18  1.2   7.5e-8
+//   double 3 0.01  0.03  2.3e-13
+//   double 4 0.06  0.1   3.1e-14
+//   double 5 0.16  0.2   5.0e-15
+//
+// ** Note: relative error on single precision starts increase on the direct
+// method at qr=1.1, rising from 3e-8 to 5e-5 by qr=1e3.  This should be
+// safe for the sans range, with objects of 100 nm supported to a q of 0.1
+// while maintaining 5 digits of precision.  For usans/sesans, the objects
+// are larger but the q is smaller, so again it should be fine.
+//
+// See explore/sph_j1c.py for code to explore these ranges.
+
+// Use 4th order series
+#if FLOAT_SIZE>4
+#define SPH_J1C_CUTOFF 0.1
+#else
+#define SPH_J1C_CUTOFF 0.7
+#endif
+#pragma acc routine seq
+double sas_3j1x_x(double q)
+{
+    // 2017-05-18 PAK - support negative q
+    if (fabs(q) < SPH_J1C_CUTOFF) {
+        const double q2 = q*q;
+        return (1.0 + q2*(-3./30. + q2*(3./840. + q2*(-3./45360.))));// + q2*(3./3991680.)))));
+    } else {
+        double sin_q, cos_q;
+        SINCOS(q, sin_q, cos_q);
+        return 3.0*(sin_q/q - cos_q)/(q*q);
+    }
+}
+
+
+#line 1 ".././models/vesicle.c"
+
+static double
+shell_volume(double radius, double thickness)
+{
+    return M_4PI_3 * (cube(radius+thickness) - cube(radius));
+}
+
+static double
+form_volume(double radius, double thickness)
+{
+    return M_4PI_3 * cube(radius+thickness);
+}
+
+
+static double
+radius_effective(int mode, double radius, double thickness)
+{
+    // case 1: outer radius
+    return radius + thickness;
+}
+
+static void
+Fq(double q,
+    double *F1,
+    double *F2,
+    double sld,
+    double sld_solvent,
+    double volfraction,
+    double radius,
+    double thickness)
+
+/*
+   scattering from a unilamellar vesicle.
+   same functional form as the core-shell sphere, but more intuitive for
+   a vesicle
+*/
+
+{
+    double vol,contrast,f;
+
+    // core first, then add in shell
+    contrast = sld_solvent-sld;
+    vol = M_4PI_3*cube(radius);
+    f = vol * sas_3j1x_x(q*radius) * contrast;
+
+    //now the shell. No volume normalization as this is done by the caller
+    contrast = sld-sld_solvent;
+    vol = M_4PI_3*cube(radius+thickness);
+    f += vol * sas_3j1x_x(q*(radius+thickness)) * contrast;
+
+    //rescale to [cm-1].
+    // With volume fraction as part of the model in the dilute limit need
+    // to return F2 = Vf <fq^2>.  In order for beta approx. to work correctly
+    // need F1^2/F2 equal to <fq>^2 / <fq^2>.  By returning F1 = sqrt(Vf) <fq>
+    // and F2 = Vf <fq^2> both conditions are satisfied.
+    // Since Vf is the volume fraction of vesicles of all radii, it is
+    // constant when averaging F1 and F2 over radii and so pops out of the
+    // polydispersity loop, so it is safe to apply it inside the model
+    // (albeit conceptually ugly).
+    *F1 = 1e-2 * sqrt(volfraction) * f;
+    *F2 = 1.0e-4 * volfraction * f * f;
+}
+
+

--- a/mcstas-comps/share/sasview_proxy.c
+++ b/mcstas-comps/share/sasview_proxy.c
@@ -1,534 +1,1084 @@
-  #if SASmodel_index == 1
-    %include "sas_barbell.c"
-  #endif
-  #if SASmodel_index == 2
-    %include "sas_barbell.c"
-  #endif
-  #if SASmodel_index == 3
-    %include "sas_bcc_paracrystal.c"
-  #endif
-  #if SASmodel_index == 4
-    %include "sas_bcc_paracrystal.c"
-  #endif
-  #if SASmodel_index == 5
-    %include "sas_capped_cylinder.c"
-  #endif
-  #if SASmodel_index == 6
-    %include "sas_capped_cylinder.c"
-  #endif
-  #if SASmodel_index == 7
-    %include "sas_core_shell_cylinder.c"
-  #endif
-  #if SASmodel_index == 8
-    %include "sas_core_shell_cylinder.c"
-  #endif
-  #if SASmodel_index == 9
-    %include "sas_cylinder.c"
-  #endif
-  #if SASmodel_index == 10
-    %include "sas_cylinder.c"
-  #endif
-  #if SASmodel_index == 11
-    %include "sas_dab.c"
-  #endif
-  #if SASmodel_index == 12
-    %include "sas_dab.c"
-  #endif
-  #if SASmodel_index == 13
-    %include "sas_ellipsoid.c"
-  #endif
-  #if SASmodel_index == 14
-    %include "sas_ellipsoid.c"
-  #endif
-  #if SASmodel_index == 15
-    %include "sas_fcc_paracrystal.c"
-  #endif
-  #if SASmodel_index == 16
-    %include "sas_fcc_paracrystal.c"
-  #endif
-  #if SASmodel_index == 17
-    %include "sas_flexible_cylinder_ex.c"
-  #endif
-  #if SASmodel_index == 18
-    %include "sas_flexible_cylinder_ex.c"
-  #endif
-  #if SASmodel_index == 19
-    %include "sas_gaussian_peak.c"
-  #endif
-  #if SASmodel_index == 20
-    %include "sas_gaussian_peak.c"
-  #endif
-  #if SASmodel_index == 21
-    %include "sas_guinier.c"
-  #endif
-  #if SASmodel_index == 22
-    %include "sas_guinier.c"
-  #endif
-  #if SASmodel_index == 23
-    %include "sas_hardsphere.c"
-  #endif
-  #if SASmodel_index == 24
-    %include "sas_hardsphere.c"
-  #endif
-  #if SASmodel_index == 25
-    %include "sas_HayterMSAsq.c"
-  #endif
-  #if SASmodel_index == 26
-    %include "sas_HayterMSAsq.c"
-  #endif
-  #if SASmodel_index == 27
-    %include "sas_hollow_cylinder.c"
-  #endif
-  #if SASmodel_index == 28
-    %include "sas_hollow_cylinder.c"
-  #endif
-  #if SASmodel_index == 29
-    %include "sas_lamellar.c"
-  #endif
-  #if SASmodel_index == 30
-    %include "sas_lamellar.c"
-  #endif
-  #if SASmodel_index == 31
-    %include "sas_lamellar_FFHG.c"
-  #endif
-  #if SASmodel_index == 32
-    %include "sas_lamellar_FFHG.c"
-  #endif
-  #if SASmodel_index == 33
-    %include "sas_lamellarCailleHG.c"
-  #endif
-  #if SASmodel_index == 34
-    %include "sas_lamellarCailleHG.c"
-  #endif
-  #if SASmodel_index == 35
-    %include "sas_lamellarPC.c"
-  #endif
-  #if SASmodel_index == 36
-    %include "sas_lamellarPC.c"
-  #endif
-  #if SASmodel_index == 37
-    %include "sas_lamellarPS.c"
-  #endif
-  #if SASmodel_index == 38
-    %include "sas_lamellarPS.c"
-  #endif
-  #if SASmodel_index == 39
-    %include "sas_linear_pearls.c"
-  #endif
-  #if SASmodel_index == 40
-    %include "sas_linear_pearls.c"
-  #endif
-  #if SASmodel_index == 41
+#define FLOAT_SIZE 8
+#if SASmodel_index == 1
+    // lorentz : Iq
     %include "sas_lorentz.c"
   #endif
-  #if SASmodel_index == 42
-    %include "sas_lorentz.c"
+#if SASmodel_index == 2
+    // ellipsoid : Fq
+    %include "sas_ellipsoid.c"
   #endif
-  #if SASmodel_index == 43
-    %include "sas_mass_fractal.c"
+#if SASmodel_index == 3
+    // ellipsoid : Iqac
+    %include "sas_ellipsoid.c"
   #endif
-  #if SASmodel_index == 44
-    %include "sas_mass_fractal.c"
+#if SASmodel_index == 4
+    // spinodal : Iq
+    %include "sas_spinodal.c"
   #endif
-  #if SASmodel_index == 45
-    %include "sas_mass_surface_fractal.c"
+#if SASmodel_index == 5
+    // lamellar_hg_stack_caille : Iq
+    %include "sas_lamellar_hg_stack_caille.c"
   #endif
-  #if SASmodel_index == 46
-    %include "sas_mass_surface_fractal.c"
+#if SASmodel_index == 6
+    // fractal_core_shell : Iq
+    %include "sas_fractal_core_shell.c"
   #endif
-  #if SASmodel_index == 47
-    %include "sas_parallelepiped.c"
+#if SASmodel_index == 7
+    // dab : Iq
+    %include "sas_dab.c"
   #endif
-  #if SASmodel_index == 48
-    %include "sas_parallelepiped.c"
+#if SASmodel_index == 8
+    // peak_lorentz : Iq
+    %include "sas_peak_lorentz.c"
   #endif
-  #if SASmodel_index == 49
-    %include "sas_pearl_necklace.c"
+#if SASmodel_index == 9
+    // core_shell_bicelle_elliptical_belt_rough : Fq
+    %include "sas_core_shell_bicelle_elliptical_belt_rough.c"
   #endif
-  #if SASmodel_index == 50
-    %include "sas_pearl_necklace.c"
+#if SASmodel_index == 10
+    // core_shell_bicelle_elliptical_belt_rough : Iqabc
+    %include "sas_core_shell_bicelle_elliptical_belt_rough.c"
   #endif
-  #if SASmodel_index == 51
-    %include "sas_sphere.c"
+#if SASmodel_index == 11
+    // binary_hard_sphere : Iq
+    %include "sas_binary_hard_sphere.c"
   #endif
-  #if SASmodel_index == 52
-    %include "sas_sphere.c"
+#if SASmodel_index == 12
+    // correlation_length : Iq
+    %include "sas_correlation_length.c"
   #endif
-  #if SASmodel_index == 53
-    %include "sas_star_polymer.c"
+#if SASmodel_index == 13
+    // hollow_rectangular_prism_thin_walls : Fq
+    %include "sas_hollow_rectangular_prism_thin_walls.c"
   #endif
-  #if SASmodel_index == 54
-    %include "sas_star_polymer.c"
+#if SASmodel_index == 14
+    // superball : Fq
+    %include "sas_superball.c"
   #endif
-  #if SASmodel_index == 55
+#if SASmodel_index == 15
+    // superball : Iqabc
+    %include "sas_superball.c"
+  #endif
+#if SASmodel_index == 16
+    // gaussian_peak : Iq
+    %include "sas_gaussian_peak.c"
+  #endif
+#if SASmodel_index == 17
+    // vesicle : Fq
+    %include "sas_vesicle.c"
+  #endif
+#if SASmodel_index == 18
+    // flexible_cylinder_elliptical : Iq
+    %include "sas_flexible_cylinder_elliptical.c"
+  #endif
+#if SASmodel_index == 19
+    // lamellar_stack_caille : Iq
+    %include "sas_lamellar_stack_caille.c"
+  #endif
+#if SASmodel_index == 20
+    // guinier_porod : Iq
+    %include "sas_guinier_porod.c"
+  #endif
+#if SASmodel_index == 21
+    // spherical_sld : Iq
+    %include "sas_spherical_sld.c"
+  #endif
+#if SASmodel_index == 22
+    // capped_cylinder : Fq
+    %include "sas_capped_cylinder.c"
+  #endif
+#if SASmodel_index == 23
+    // capped_cylinder : Iqac
+    %include "sas_capped_cylinder.c"
+  #endif
+#if SASmodel_index == 24
+    // adsorbed_layer : Iq
+    %include "sas_adsorbed_layer.c"
+  #endif
+#if SASmodel_index == 25
+    // core_multi_shell : Fq
+    %include "sas_core_multi_shell.c"
+  #endif
+#if SASmodel_index == 26
+    // poly_gauss_coil : Iq
+    %include "sas_poly_gauss_coil.c"
+  #endif
+#if SASmodel_index == 27
+    // line : Iq
+    %include "sas_line.c"
+  #endif
+#if SASmodel_index == 28
+    // stacked_disks : Iq
+    %include "sas_stacked_disks.c"
+  #endif
+#if SASmodel_index == 29
+    // stacked_disks : Iqac
+    %include "sas_stacked_disks.c"
+  #endif
+#if SASmodel_index == 30
+    // porod : Iq
+    %include "sas_porod.c"
+  #endif
+#if SASmodel_index == 31
+    // hardsphere : Iq
+    %include "sas_hardsphere.c"
+  #endif
+#if SASmodel_index == 32
+    // core_shell_bicelle : Fq
+    %include "sas_core_shell_bicelle.c"
+  #endif
+#if SASmodel_index == 33
+    // core_shell_bicelle : Iqac
+    %include "sas_core_shell_bicelle.c"
+  #endif
+#if SASmodel_index == 34
+    // cylinder : Fq
+    %include "sas_cylinder.c"
+  #endif
+#if SASmodel_index == 35
+    // cylinder : Iqac
+    %include "sas_cylinder.c"
+  #endif
+#if SASmodel_index == 36
+    // polymer_excl_volume : Iq
+    %include "sas_polymer_excl_volume.c"
+  #endif
+#if SASmodel_index == 37
+    // fcc_paracrystal : Iq
+    %include "sas_fcc_paracrystal.c"
+  #endif
+#if SASmodel_index == 38
+    // fcc_paracrystal : Iqabc
+    %include "sas_fcc_paracrystal.c"
+  #endif
+#if SASmodel_index == 39
+    // fractal : Iq
+    %include "sas_fractal.c"
+  #endif
+#if SASmodel_index == 40
+    // power_law : Iq
+    %include "sas_power_law.c"
+  #endif
+#if SASmodel_index == 41
+    // guinier : Iq
+    %include "sas_guinier.c"
+  #endif
+#if SASmodel_index == 42
+    // two_lorentzian : Iq
+    %include "sas_two_lorentzian.c"
+  #endif
+#if SASmodel_index == 43
+    // stickyhardsphere : Iq
     %include "sas_stickyhardsphere.c"
   #endif
-  #if SASmodel_index == 56
-    %include "sas_stickyhardsphere.c"
+#if SASmodel_index == 44
+    // gauss_lorentz_gel : Iq
+    %include "sas_gauss_lorentz_gel.c"
   #endif
-  #if SASmodel_index == 57
+#if SASmodel_index == 45
+    // mass_surface_fractal : Iq
+    %include "sas_mass_surface_fractal.c"
+  #endif
+#if SASmodel_index == 46
+    // polymer_micelle : Iq
+    %include "sas_polymer_micelle.c"
+  #endif
+#if SASmodel_index == 47
+    // flexible_cylinder : Iq
+    %include "sas_flexible_cylinder.c"
+  #endif
+#if SASmodel_index == 48
+    // parallelepiped : Fq
+    %include "sas_parallelepiped.c"
+  #endif
+#if SASmodel_index == 49
+    // parallelepiped : Iqabc
+    %include "sas_parallelepiped.c"
+  #endif
+#if SASmodel_index == 50
+    // hollow_rectangular_prism : Fq
+    %include "sas_hollow_rectangular_prism.c"
+  #endif
+#if SASmodel_index == 51
+    // hollow_rectangular_prism : Iqabc
+    %include "sas_hollow_rectangular_prism.c"
+  #endif
+#if SASmodel_index == 52
+    // rectangular_prism : Iq
+    %include "sas_rectangular_prism.c"
+  #endif
+#if SASmodel_index == 53
+    // rectangular_prism : Iqabc
+    %include "sas_rectangular_prism.c"
+  #endif
+#if SASmodel_index == 54
+    // core_shell_parallelepiped : Fq
+    %include "sas_core_shell_parallelepiped.c"
+  #endif
+#if SASmodel_index == 55
+    // core_shell_parallelepiped : Iqabc
+    %include "sas_core_shell_parallelepiped.c"
+  #endif
+#if SASmodel_index == 56
+    // lamellar_hg : Iq
+    %include "sas_lamellar_hg.c"
+  #endif
+#if SASmodel_index == 57
+    // triaxial_ellipsoid : Fq
     %include "sas_triaxial_ellipsoid.c"
   #endif
-  #if SASmodel_index == 58
+#if SASmodel_index == 58
+    // triaxial_ellipsoid : Iqabc
     %include "sas_triaxial_ellipsoid.c"
+  #endif
+#if SASmodel_index == 59
+    // sc_paracrystal : Iq
+    %include "sas_sc_paracrystal.c"
+  #endif
+#if SASmodel_index == 60
+    // sc_paracrystal : Iqabc
+    %include "sas_sc_paracrystal.c"
+  #endif
+#if SASmodel_index == 61
+    // core_shell_sphere : Fq
+    %include "sas_core_shell_sphere.c"
+  #endif
+#if SASmodel_index == 62
+    // fuzzy_sphere : Fq
+    %include "sas_fuzzy_sphere.c"
+  #endif
+#if SASmodel_index == 63
+    // hollow_cylinder : Fq
+    %include "sas_hollow_cylinder.c"
+  #endif
+#if SASmodel_index == 64
+    // hollow_cylinder : Iqac
+    %include "sas_hollow_cylinder.c"
+  #endif
+#if SASmodel_index == 65
+    // gel_fit : Iq
+    %include "sas_gel_fit.c"
+  #endif
+#if SASmodel_index == 66
+    // broad_peak : Iq
+    %include "sas_broad_peak.c"
+  #endif
+#if SASmodel_index == 67
+    // core_shell_ellipsoid : Fq
+    %include "sas_core_shell_ellipsoid.c"
+  #endif
+#if SASmodel_index == 68
+    // core_shell_ellipsoid : Iqac
+    %include "sas_core_shell_ellipsoid.c"
+  #endif
+#if SASmodel_index == 69
+    // raspberry : Iq
+    %include "sas_raspberry.c"
+  #endif
+#if SASmodel_index == 70
+    // star_polymer : Iq
+    %include "sas_star_polymer.c"
+  #endif
+#if SASmodel_index == 71
+    // mass_fractal : Iq
+    %include "sas_mass_fractal.c"
+  #endif
+#if SASmodel_index == 72
+    // hayter_msa : Iq
+    %include "sas_hayter_msa.c"
+  #endif
+#if SASmodel_index == 73
+    // bcc_paracrystal : Iq
+    %include "sas_bcc_paracrystal.c"
+  #endif
+#if SASmodel_index == 74
+    // bcc_paracrystal : Iqabc
+    %include "sas_bcc_paracrystal.c"
+  #endif
+#if SASmodel_index == 75
+    // barbell : Fq
+    %include "sas_barbell.c"
+  #endif
+#if SASmodel_index == 76
+    // barbell : Iqac
+    %include "sas_barbell.c"
+  #endif
+#if SASmodel_index == 77
+    // multilayer_vesicle : Fq
+    %include "sas_multilayer_vesicle.c"
+  #endif
+#if SASmodel_index == 78
+    // squarewell : Iq
+    %include "sas_squarewell.c"
+  #endif
+#if SASmodel_index == 79
+    // core_shell_cylinder : Fq
+    %include "sas_core_shell_cylinder.c"
+  #endif
+#if SASmodel_index == 80
+    // core_shell_cylinder : Iqac
+    %include "sas_core_shell_cylinder.c"
+  #endif
+#if SASmodel_index == 81
+    // mono_gauss_coil : Iq
+    %include "sas_mono_gauss_coil.c"
+  #endif
+#if SASmodel_index == 82
+    // lamellar_stack_paracrystal : Iq
+    %include "sas_lamellar_stack_paracrystal.c"
+  #endif
+#if SASmodel_index == 83
+    // surface_fractal : Iq
+    %include "sas_surface_fractal.c"
+  #endif
+#if SASmodel_index == 84
+    // sphere : Fq
+    %include "sas_sphere.c"
+  #endif
+#if SASmodel_index == 85
+    // rpa : Iq
+    %include "sas_rpa.c"
+  #endif
+#if SASmodel_index == 86
+    // teubner_strey : Iq
+    %include "sas_teubner_strey.c"
+  #endif
+#if SASmodel_index == 87
+    // two_power_law : Iq
+    %include "sas_two_power_law.c"
+  #endif
+#if SASmodel_index == 88
+    // pearl_necklace : Iq
+    %include "sas_pearl_necklace.c"
+  #endif
+#if SASmodel_index == 89
+    // pringle : Iq
+    %include "sas_pringle.c"
+  #endif
+#if SASmodel_index == 90
+    // core_shell_bicelle_elliptical : Fq
+    %include "sas_core_shell_bicelle_elliptical.c"
+  #endif
+#if SASmodel_index == 91
+    // core_shell_bicelle_elliptical : Iqabc
+    %include "sas_core_shell_bicelle_elliptical.c"
+  #endif
+#if SASmodel_index == 92
+    // onion : Fq
+    %include "sas_onion.c"
+  #endif
+#if SASmodel_index == 93
+    // elliptical_cylinder : Fq
+    %include "sas_elliptical_cylinder.c"
+  #endif
+#if SASmodel_index == 94
+    // elliptical_cylinder : Iqabc
+    %include "sas_elliptical_cylinder.c"
+  #endif
+#if SASmodel_index == 95
+    // linear_pearls : Iq
+    %include "sas_linear_pearls.c"
   #endif
 
-  float getIq(float q, float qx, float qy, double pars[8])
-  {
-    float Iq_out = 1;
+float getIq(float q, float qx, float qy, double pars[15])
+{
+    float Iq_out = 0;
+    int i, last_non_zero_index;
+    for (i= 15; i>=0; i--){
+        if (pars[i] !=0){
+        last_non_zero_index = i;
+        break;
+        }
+    }
+
+    #ifdef HAS_FQ
+        double F1=0.0, F2=0.0;
+    #endif
+
+    #ifdef HAS_Iqac
+        double qab=0.0, qc=0.0;
+        double theta, phi, Psi;
+        QACRotation rotation;
+
+        theta = pars[last_non_zero_index-1]* M_PI_180;
+        phi = pars[last_non_zero_index]* M_PI_180;
+        qac_rotation(&rotation, theta, phi, 0, 0);
+        qac_apply(&rotation, qx, qy, &qab, &qc);
+    #endif
+
+    #ifdef HAS_Iqabc
+        double qa=0.0, qb=0.0, qc=0.0;
+        double theta, phi, Psi;
+        QABCRotation rotation;
+        theta = pars[last_non_zero_index-2] * M_PI_180;
+        phi = pars[last_non_zero_index=1]*M_PI_180;
+        Psi = pars[last_non_zero_index]*M_PI_180;
+        qabc_rotation(&rotation, theta, phi, Psi, 0, 0, 0);
+        qabc_apply(&rotation, qx, qy, &qa, &qb, &qc);
+    #endif
     #if SASmodel_index == 1
-      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4]);
+    // lorentz : Iq, with 1 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0]);
     #endif
     #if SASmodel_index == 2
-      Iq_out = Iqxy(qx, qy, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6]);
+    // ellipsoid : Fq, with 4 sample parameters and 2 orientation parameters.
+      Fq(q, &F1, &F2, pars[0], pars[1], pars[2], pars[3]);
+    Iq_out = F2;
     #endif
     #if SASmodel_index == 3
-      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4]);
+    // ellipsoid : Iqac, with 4 sample parameters and 2 orientation parameters.
+      Iq_out = Iqac(qab, qc, pars[0], pars[1], pars[2], pars[3]);
     #endif
     #if SASmodel_index == 4
-      Iq_out = Iqxy(qx, qy, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6], pars[7]);
+    // spinodal : Iq, with 2 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1]);
     #endif
     #if SASmodel_index == 5
-      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4]);
-    #endif
-    #if SASmodel_index == 6
-      Iq_out = Iqxy(qx, qy, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6]);
-    #endif
-    #if SASmodel_index == 7
-      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5]);
-    #endif
-    #if SASmodel_index == 8
-      Iq_out = Iqxy(qx, qy, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6], pars[7]);
-    #endif
-    #if SASmodel_index == 9
-      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3]);
-    #endif
-    #if SASmodel_index == 10
-      Iq_out = Iqxy(qx, qy, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5]);
-    #endif
-    #if SASmodel_index == 11
-      Iq_out = Iq(q, pars[0]);
-    #endif
-    #if SASmodel_index == 12
-      Iq_out = Iqxy(qx, qy, pars[0]);
-    #endif
-    #if SASmodel_index == 13
-      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3]);
-    #endif
-    #if SASmodel_index == 14
-      Iq_out = Iqxy(qx, qy, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5]);
-    #endif
-    #if SASmodel_index == 15
-      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4]);
-    #endif
-    #if SASmodel_index == 16
-      Iq_out = Iqxy(qx, qy, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6], pars[7]);
-    #endif
-    #if SASmodel_index == 17
-      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5]);
-    #endif
-    #if SASmodel_index == 18
-      Iq_out = Iqxy(qx, qy, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5]);
-    #endif
-    #if SASmodel_index == 19
-      Iq_out = Iq(q, pars[0], pars[1]);
-    #endif
-    #if SASmodel_index == 20
-      Iq_out = Iqxy(qx, qy, pars[0], pars[1]);
-    #endif
-    #if SASmodel_index == 21
-      Iq_out = Iq(q, pars[0]);
-    #endif
-    #if SASmodel_index == 22
-      Iq_out = Iqxy(qx, qy, pars[0]);
-    #endif
-    #if SASmodel_index == 23
-      Iq_out = Iq(q, pars[0], pars[1]);
-    #endif
-    #if SASmodel_index == 24
-      Iq_out = Iqxy(qx, qy, pars[0], pars[1]);
-    #endif
-    #if SASmodel_index == 25
-      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5]);
-    #endif
-    #if SASmodel_index == 26
-      Iq_out = Iqxy(qx, qy, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5]);
-    #endif
-    #if SASmodel_index == 27
-      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4]);
-    #endif
-    #if SASmodel_index == 28
-      Iq_out = Iqxy(qx, qy, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6]);
-    #endif
-    #if SASmodel_index == 29
-      Iq_out = Iq(q, pars[0], pars[1], pars[2]);
-    #endif
-    #if SASmodel_index == 30
-      Iq_out = Iqxy(qx, qy, pars[0], pars[1], pars[2]);
-    #endif
-    #if SASmodel_index == 31
-      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4]);
-    #endif
-    #if SASmodel_index == 32
-      Iq_out = Iqxy(qx, qy, pars[0], pars[1], pars[2], pars[3], pars[4]);
-    #endif
-    #if SASmodel_index == 33
+    // lamellar_hg_stack_caille : Iq, with 8 sample parameters and 0 orientation parameters.
       Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6], pars[7]);
     #endif
-    #if SASmodel_index == 34
-      Iq_out = Iqxy(qx, qy, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6], pars[7]);
+    #if SASmodel_index == 6
+    // fractal_core_shell : Iq, with 8 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6], pars[7]);
     #endif
-    #if SASmodel_index == 35
-      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5]);
+    #if SASmodel_index == 7
+    // dab : Iq, with 1 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0]);
     #endif
-    #if SASmodel_index == 36
-      Iq_out = Iqxy(qx, qy, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5]);
+    #if SASmodel_index == 8
+    // peak_lorentz : Iq, with 2 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1]);
     #endif
-    #if SASmodel_index == 37
-      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5]);
+    #if SASmodel_index == 9
+    // core_shell_bicelle_elliptical_belt_rough : Fq, with 10 sample parameters and 3 orientation parameters.
+      Fq(q, &F1, &F2, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6], pars[7], pars[8], pars[9]);
+    Iq_out = F2;
     #endif
-    #if SASmodel_index == 38
-      Iq_out = Iqxy(qx, qy, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5]);
+    #if SASmodel_index == 10
+    // core_shell_bicelle_elliptical_belt_rough : Iqabc, with 10 sample parameters and 3 orientation parameters.
+      Iq_out = Iqabc(qa, qb, qc, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6], pars[7], pars[8], pars[9]);
     #endif
-    #if SASmodel_index == 39
+    #if SASmodel_index == 11
+    // binary_hard_sphere : Iq, with 7 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6]);
+    #endif
+    #if SASmodel_index == 12
+    // correlation_length : Iq, with 5 sample parameters and 0 orientation parameters.
       Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4]);
     #endif
+    #if SASmodel_index == 13
+    // hollow_rectangular_prism_thin_walls : Fq, with 5 sample parameters and 0 orientation parameters.
+      Fq(q, &F1, &F2, pars[0], pars[1], pars[2], pars[3], pars[4]);
+    Iq_out = F2;
+    #endif
+    #if SASmodel_index == 14
+    // superball : Fq, with 4 sample parameters and 3 orientation parameters.
+      Fq(q, &F1, &F2, pars[0], pars[1], pars[2], pars[3]);
+    Iq_out = F2;
+    #endif
+    #if SASmodel_index == 15
+    // superball : Iqabc, with 4 sample parameters and 3 orientation parameters.
+      Iq_out = Iqabc(qa, qb, qc, pars[0], pars[1], pars[2], pars[3]);
+    #endif
+    #if SASmodel_index == 16
+    // gaussian_peak : Iq, with 2 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1]);
+    #endif
+    #if SASmodel_index == 17
+    // vesicle : Fq, with 5 sample parameters and 0 orientation parameters.
+      Fq(q, &F1, &F2, pars[0], pars[1], pars[2], pars[3], pars[4]);
+    Iq_out = F2;
+    #endif
+    #if SASmodel_index == 18
+    // flexible_cylinder_elliptical : Iq, with 6 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5]);
+    #endif
+    #if SASmodel_index == 19
+    // lamellar_stack_caille : Iq, with 6 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5]);
+    #endif
+    #if SASmodel_index == 20
+    // guinier_porod : Iq, with 3 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1], pars[2]);
+    #endif
+    #if SASmodel_index == 21
+    // spherical_sld : Iq, with 8 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6], pars[7]);
+    #endif
+    #if SASmodel_index == 22
+    // capped_cylinder : Fq, with 5 sample parameters and 2 orientation parameters.
+      Fq(q, &F1, &F2, pars[0], pars[1], pars[2], pars[3], pars[4]);
+    Iq_out = F2;
+    #endif
+    #if SASmodel_index == 23
+    // capped_cylinder : Iqac, with 5 sample parameters and 2 orientation parameters.
+      Iq_out = Iqac(qab, qc, pars[0], pars[1], pars[2], pars[3], pars[4]);
+    #endif
+    #if SASmodel_index == 24
+    // adsorbed_layer : Iq, with 7 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6]);
+    #endif
+    #if SASmodel_index == 25
+    // core_multi_shell : Fq, with 6 sample parameters and 0 orientation parameters.
+      Fq(q, &F1, &F2, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5]);
+    Iq_out = F2;
+    #endif
+    #if SASmodel_index == 26
+    // poly_gauss_coil : Iq, with 3 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1], pars[2]);
+    #endif
+    #if SASmodel_index == 27
+    // line : Iq, with 2 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1]);
+    #endif
+    #if SASmodel_index == 28
+    // stacked_disks : Iq, with 8 sample parameters and 2 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6], pars[7]);
+    #endif
+    #if SASmodel_index == 29
+    // stacked_disks : Iqac, with 8 sample parameters and 2 orientation parameters.
+      Iq_out = Iqac(qab, qc, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6], pars[7]);
+    #endif
+    #if SASmodel_index == 30
+    // porod : Iq, with 0 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q);
+    #endif
+    #if SASmodel_index == 31
+    // hardsphere : Iq, with 2 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1]);
+    #endif
+    #if SASmodel_index == 32
+    // core_shell_bicelle : Fq, with 8 sample parameters and 2 orientation parameters.
+      Fq(q, &F1, &F2, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6], pars[7]);
+    Iq_out = F2;
+    #endif
+    #if SASmodel_index == 33
+    // core_shell_bicelle : Iqac, with 8 sample parameters and 2 orientation parameters.
+      Iq_out = Iqac(qab, qc, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6], pars[7]);
+    #endif
+    #if SASmodel_index == 34
+    // cylinder : Fq, with 4 sample parameters and 2 orientation parameters.
+      Fq(q, &F1, &F2, pars[0], pars[1], pars[2], pars[3]);
+    Iq_out = F2;
+    #endif
+    #if SASmodel_index == 35
+    // cylinder : Iqac, with 4 sample parameters and 2 orientation parameters.
+      Iq_out = Iqac(qab, qc, pars[0], pars[1], pars[2], pars[3]);
+    #endif
+    #if SASmodel_index == 36
+    // polymer_excl_volume : Iq, with 2 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1]);
+    #endif
+    #if SASmodel_index == 37
+    // fcc_paracrystal : Iq, with 5 sample parameters and 3 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4]);
+    #endif
+    #if SASmodel_index == 38
+    // fcc_paracrystal : Iqabc, with 5 sample parameters and 3 orientation parameters.
+      Iq_out = Iqabc(qa, qb, qc, pars[0], pars[1], pars[2], pars[3], pars[4]);
+    #endif
+    #if SASmodel_index == 39
+    // fractal : Iq, with 6 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5]);
+    #endif
     #if SASmodel_index == 40
-      Iq_out = Iqxy(qx, qy, pars[0], pars[1], pars[2], pars[3], pars[4]);
+    // power_law : Iq, with 1 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0]);
     #endif
     #if SASmodel_index == 41
+    // guinier : Iq, with 1 sample parameters and 0 orientation parameters.
       Iq_out = Iq(q, pars[0]);
     #endif
     #if SASmodel_index == 42
-      Iq_out = Iqxy(qx, qy, pars[0]);
+    // two_lorentzian : Iq, with 6 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5]);
     #endif
     #if SASmodel_index == 43
-      Iq_out = Iq(q, pars[0], pars[1], pars[2]);
+    // stickyhardsphere : Iq, with 4 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3]);
     #endif
     #if SASmodel_index == 44
-      Iq_out = Iqxy(qx, qy, pars[0], pars[1], pars[2]);
+    // gauss_lorentz_gel : Iq, with 4 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3]);
     #endif
     #if SASmodel_index == 45
+    // mass_surface_fractal : Iq, with 4 sample parameters and 0 orientation parameters.
       Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3]);
     #endif
     #if SASmodel_index == 46
-      Iq_out = Iqxy(qx, qy, pars[0], pars[1], pars[2], pars[3]);
+    // polymer_micelle : Iq, with 10 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6], pars[7], pars[8], pars[9]);
     #endif
     #if SASmodel_index == 47
+    // flexible_cylinder : Iq, with 5 sample parameters and 0 orientation parameters.
       Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4]);
     #endif
     #if SASmodel_index == 48
-      Iq_out = Iqxy(qx, qy, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6], pars[7]);
+    // parallelepiped : Fq, with 5 sample parameters and 3 orientation parameters.
+      Fq(q, &F1, &F2, pars[0], pars[1], pars[2], pars[3], pars[4]);
+    Iq_out = F2;
     #endif
     #if SASmodel_index == 49
+    // parallelepiped : Iqabc, with 5 sample parameters and 3 orientation parameters.
+      Iq_out = Iqabc(qa, qb, qc, pars[0], pars[1], pars[2], pars[3], pars[4]);
+    #endif
+    #if SASmodel_index == 50
+    // hollow_rectangular_prism : Fq, with 6 sample parameters and 3 orientation parameters.
+      Fq(q, &F1, &F2, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5]);
+    Iq_out = F2;
+    #endif
+    #if SASmodel_index == 51
+    // hollow_rectangular_prism : Iqabc, with 6 sample parameters and 3 orientation parameters.
+      Iq_out = Iqabc(qa, qb, qc, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5]);
+    #endif
+    #if SASmodel_index == 52
+    // rectangular_prism : Iq, with 5 sample parameters and 3 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4]);
+    #endif
+    #if SASmodel_index == 53
+    // rectangular_prism : Iqabc, with 5 sample parameters and 3 orientation parameters.
+      Iq_out = Iqabc(qa, qb, qc, pars[0], pars[1], pars[2], pars[3], pars[4]);
+    #endif
+    #if SASmodel_index == 54
+    // core_shell_parallelepiped : Fq, with 11 sample parameters and 3 orientation parameters.
+      Fq(q, &F1, &F2, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6], pars[7], pars[8], pars[9], pars[10]);
+    Iq_out = F2;
+    #endif
+    #if SASmodel_index == 55
+    // core_shell_parallelepiped : Iqabc, with 11 sample parameters and 3 orientation parameters.
+      Iq_out = Iqabc(qa, qb, qc, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6], pars[7], pars[8], pars[9], pars[10]);
+    #endif
+    #if SASmodel_index == 56
+    // lamellar_hg : Iq, with 5 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4]);
+    #endif
+    #if SASmodel_index == 57
+    // triaxial_ellipsoid : Fq, with 5 sample parameters and 3 orientation parameters.
+      Fq(q, &F1, &F2, pars[0], pars[1], pars[2], pars[3], pars[4]);
+    Iq_out = F2;
+    #endif
+    #if SASmodel_index == 58
+    // triaxial_ellipsoid : Iqabc, with 5 sample parameters and 3 orientation parameters.
+      Iq_out = Iqabc(qa, qb, qc, pars[0], pars[1], pars[2], pars[3], pars[4]);
+    #endif
+    #if SASmodel_index == 59
+    // sc_paracrystal : Iq, with 5 sample parameters and 3 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4]);
+    #endif
+    #if SASmodel_index == 60
+    // sc_paracrystal : Iqabc, with 5 sample parameters and 3 orientation parameters.
+      Iq_out = Iqabc(qa, qb, qc, pars[0], pars[1], pars[2], pars[3], pars[4]);
+    #endif
+    #if SASmodel_index == 61
+    // core_shell_sphere : Fq, with 5 sample parameters and 0 orientation parameters.
+      Fq(q, &F1, &F2, pars[0], pars[1], pars[2], pars[3], pars[4]);
+    Iq_out = F2;
+    #endif
+    #if SASmodel_index == 62
+    // fuzzy_sphere : Fq, with 4 sample parameters and 0 orientation parameters.
+      Fq(q, &F1, &F2, pars[0], pars[1], pars[2], pars[3]);
+    Iq_out = F2;
+    #endif
+    #if SASmodel_index == 63
+    // hollow_cylinder : Fq, with 5 sample parameters and 2 orientation parameters.
+      Fq(q, &F1, &F2, pars[0], pars[1], pars[2], pars[3], pars[4]);
+    Iq_out = F2;
+    #endif
+    #if SASmodel_index == 64
+    // hollow_cylinder : Iqac, with 5 sample parameters and 2 orientation parameters.
+      Iq_out = Iqac(qab, qc, pars[0], pars[1], pars[2], pars[3], pars[4]);
+    #endif
+    #if SASmodel_index == 65
+    // gel_fit : Iq, with 5 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4]);
+    #endif
+    #if SASmodel_index == 66
+    // broad_peak : Iq, with 7 sample parameters and 0 orientation parameters.
       Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6]);
     #endif
-    #if SASmodel_index == 50
-      Iq_out = Iqxy(qx, qy, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6]);
+    #if SASmodel_index == 67
+    // core_shell_ellipsoid : Fq, with 7 sample parameters and 2 orientation parameters.
+      Fq(q, &F1, &F2, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6]);
+    Iq_out = F2;
     #endif
-    #if SASmodel_index == 51
-      Iq_out = Iq(q, pars[0], pars[1], pars[2]);
+    #if SASmodel_index == 68
+    // core_shell_ellipsoid : Iqac, with 7 sample parameters and 2 orientation parameters.
+      Iq_out = Iqac(qab, qc, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6]);
     #endif
-    #if SASmodel_index == 52
-      Iq_out = Iqxy(qx, qy, pars[0], pars[1], pars[2]);
+    #if SASmodel_index == 69
+    // raspberry : Iq, with 9 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6], pars[7], pars[8]);
     #endif
-    #if SASmodel_index == 53
+    #if SASmodel_index == 70
+    // star_polymer : Iq, with 2 sample parameters and 0 orientation parameters.
       Iq_out = Iq(q, pars[0], pars[1]);
     #endif
-    #if SASmodel_index == 54
-      Iq_out = Iqxy(qx, qy, pars[0], pars[1]);
+    #if SASmodel_index == 71
+    // mass_fractal : Iq, with 3 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1], pars[2]);
     #endif
-    #if SASmodel_index == 55
-      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3]);
+    #if SASmodel_index == 72
+    // hayter_msa : Iq, with 6 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5]);
     #endif
-    #if SASmodel_index == 56
-      Iq_out = Iqxy(qx, qy, pars[0], pars[1], pars[2], pars[3]);
-    #endif
-    #if SASmodel_index == 57
+    #if SASmodel_index == 73
+    // bcc_paracrystal : Iq, with 5 sample parameters and 3 orientation parameters.
       Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4]);
     #endif
-    #if SASmodel_index == 58
-      Iq_out = Iqxy(qx, qy, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6], pars[7]);
+    #if SASmodel_index == 74
+    // bcc_paracrystal : Iqabc, with 5 sample parameters and 3 orientation parameters.
+      Iq_out = Iqabc(qa, qb, qc, pars[0], pars[1], pars[2], pars[3], pars[4]);
     #endif
-    return Iq_out;
-  }
+    #if SASmodel_index == 75
+    // barbell : Fq, with 5 sample parameters and 2 orientation parameters.
+      Fq(q, &F1, &F2, pars[0], pars[1], pars[2], pars[3], pars[4]);
+    Iq_out = F2;
+    #endif
+    #if SASmodel_index == 76
+    // barbell : Iqac, with 5 sample parameters and 2 orientation parameters.
+      Iq_out = Iqac(qab, qc, pars[0], pars[1], pars[2], pars[3], pars[4]);
+    #endif
+    #if SASmodel_index == 77
+    // multilayer_vesicle : Fq, with 7 sample parameters and 0 orientation parameters.
+      Fq(q, &F1, &F2, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6]);
+    Iq_out = F2;
+    #endif
+    #if SASmodel_index == 78
+    // squarewell : Iq, with 4 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3]);
+    #endif
+    #if SASmodel_index == 79
+    // core_shell_cylinder : Fq, with 6 sample parameters and 2 orientation parameters.
+      Fq(q, &F1, &F2, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5]);
+    Iq_out = F2;
+    #endif
+    #if SASmodel_index == 80
+    // core_shell_cylinder : Iqac, with 6 sample parameters and 2 orientation parameters.
+      Iq_out = Iqac(qab, qc, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5]);
+    #endif
+    #if SASmodel_index == 81
+    // mono_gauss_coil : Iq, with 2 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1]);
+    #endif
+    #if SASmodel_index == 82
+    // lamellar_stack_paracrystal : Iq, with 6 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5]);
+    #endif
+    #if SASmodel_index == 83
+    // surface_fractal : Iq, with 3 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1], pars[2]);
+    #endif
+    #if SASmodel_index == 84
+    // sphere : Fq, with 3 sample parameters and 0 orientation parameters.
+      Fq(q, &F1, &F2, pars[0], pars[1], pars[2]);
+    Iq_out = F2;
+    #endif
+    #if SASmodel_index == 85
+    // rpa : Iq, with 12 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6], pars[7], pars[8], pars[9], pars[10], pars[11]);
+    #endif
+    #if SASmodel_index == 86
+    // teubner_strey : Iq, with 5 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4]);
+    #endif
+    #if SASmodel_index == 87
+    // two_power_law : Iq, with 4 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3]);
+    #endif
+    #if SASmodel_index == 88
+    // pearl_necklace : Iq, with 7 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6]);
+    #endif
+    #if SASmodel_index == 89
+    // pringle : Iq, with 6 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5]);
+    #endif
+    #if SASmodel_index == 90
+    // core_shell_bicelle_elliptical : Fq, with 9 sample parameters and 3 orientation parameters.
+      Fq(q, &F1, &F2, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6], pars[7], pars[8]);
+    Iq_out = F2;
+    #endif
+    #if SASmodel_index == 91
+    // core_shell_bicelle_elliptical : Iqabc, with 9 sample parameters and 3 orientation parameters.
+      Iq_out = Iqabc(qa, qb, qc, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6], pars[7], pars[8]);
+    #endif
+    #if SASmodel_index == 92
+    // onion : Fq, with 8 sample parameters and 0 orientation parameters.
+      Fq(q, &F1, &F2, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], pars[6], pars[7]);
+    Iq_out = F2;
+    #endif
+    #if SASmodel_index == 93
+    // elliptical_cylinder : Fq, with 5 sample parameters and 3 orientation parameters.
+      Fq(q, &F1, &F2, pars[0], pars[1], pars[2], pars[3], pars[4]);
+    Iq_out = F2;
+    #endif
+    #if SASmodel_index == 94
+    // elliptical_cylinder : Iqabc, with 5 sample parameters and 3 orientation parameters.
+      Iq_out = Iqabc(qa, qb, qc, pars[0], pars[1], pars[2], pars[3], pars[4]);
+    #endif
+    #if SASmodel_index == 95
+    // linear_pearls : Iq, with 5 sample parameters and 0 orientation parameters.
+      Iq_out = Iq(q, pars[0], pars[1], pars[2], pars[3], pars[4]);
+    #endif
+return Iq_out;
+}
 
-  float getFormVol(double pars[8])
-  {
-    float form_vol;
-    #if SASmodel_index == 1
-      form_vol = form_volume(pars[2], pars[3], pars[4]);
-    #endif
+
+float getFormVol(double pars[15])
+{
+  float form_vol=1.0;
     #if SASmodel_index == 2
-      form_vol = form_volume(pars[2], pars[3], pars[4]);
+    // ellipsoid : Fq, with 4 sample parameters and 2 orientation parameters.
+    form_vol = form_volume(pars[2], pars[3]);
     #endif
     #if SASmodel_index == 3
-      form_vol = form_volume(pars[2]);
-    #endif
-    #if SASmodel_index == 4
-      form_vol = form_volume(pars[2]);
-    #endif
-    #if SASmodel_index == 5
-      form_vol = form_volume(pars[2], pars[3], pars[4]);
+    // ellipsoid : Iqac, with 4 sample parameters and 2 orientation parameters.
+    form_vol = form_volume(pars[2], pars[3]);
     #endif
     #if SASmodel_index == 6
-      form_vol = form_volume(pars[2], pars[3], pars[4]);
-    #endif
-    #if SASmodel_index == 7
-      form_vol = form_volume(pars[3], pars[4], pars[5]);
-    #endif
-    #if SASmodel_index == 8
-      form_vol = form_volume(pars[3], pars[4], pars[5]);
+    // fractal_core_shell : Iq, with 8 sample parameters and 0 orientation parameters.
+    form_vol = form_volume(pars[0], pars[1]);
     #endif
     #if SASmodel_index == 9
-      form_vol = form_volume(pars[2], pars[3]);
+    // core_shell_bicelle_elliptical_belt_rough : Fq, with 10 sample parameters and 3 orientation parameters.
+    form_vol = form_volume(pars[0], pars[1], pars[2], pars[3], pars[4]);
     #endif
     #if SASmodel_index == 10
-      form_vol = form_volume(pars[2], pars[3]);
+    // core_shell_bicelle_elliptical_belt_rough : Iqabc, with 10 sample parameters and 3 orientation parameters.
+    form_vol = form_volume(pars[0], pars[1], pars[2], pars[3], pars[4]);
     #endif
     #if SASmodel_index == 11
-      form_vol = 1;
-    #endif
-    #if SASmodel_index == 12
-      form_vol = 1;
+    // binary_hard_sphere : Iq, with 7 sample parameters and 0 orientation parameters.
+    form_vol = form_volume();
     #endif
     #if SASmodel_index == 13
-      form_vol = form_volume(pars[2], pars[3]);
+    // hollow_rectangular_prism_thin_walls : Fq, with 5 sample parameters and 0 orientation parameters.
+    form_vol = form_volume(pars[2], pars[3], pars[4]);
     #endif
     #if SASmodel_index == 14
-      form_vol = form_volume(pars[2], pars[3]);
+    // superball : Fq, with 4 sample parameters and 3 orientation parameters.
+    form_vol = form_volume(pars[2], pars[3]);
     #endif
     #if SASmodel_index == 15
-      form_vol = form_volume(pars[2]);
-    #endif
-    #if SASmodel_index == 16
-      form_vol = form_volume(pars[2]);
+    // superball : Iqabc, with 4 sample parameters and 3 orientation parameters.
+    form_vol = form_volume(pars[2], pars[3]);
     #endif
     #if SASmodel_index == 17
-      form_vol = form_volume(pars[0], pars[1], pars[2]);
+    // vesicle : Fq, with 5 sample parameters and 0 orientation parameters.
+    form_vol = form_volume(pars[3], pars[4]);
     #endif
     #if SASmodel_index == 18
-      form_vol = form_volume(pars[0], pars[1], pars[2]);
-    #endif
-    #if SASmodel_index == 19
-      form_vol = form_volume();
-    #endif
-    #if SASmodel_index == 20
-      form_vol = form_volume();
+    // flexible_cylinder_elliptical : Iq, with 6 sample parameters and 0 orientation parameters.
+    form_vol = form_volume(pars[0], pars[1], pars[2]);
     #endif
     #if SASmodel_index == 21
-      form_vol = 1;
+    // spherical_sld : Iq, with 8 sample parameters and 0 orientation parameters.
+    form_vol = form_volume(pars[0], pars[3], pars[4]);
     #endif
     #if SASmodel_index == 22
-      form_vol = 1;
+    // capped_cylinder : Fq, with 5 sample parameters and 2 orientation parameters.
+    form_vol = form_volume(pars[2], pars[3], pars[4]);
     #endif
     #if SASmodel_index == 23
-      form_vol = form_volume(pars[0]);
-    #endif
-    #if SASmodel_index == 24
-      form_vol = form_volume(pars[0]);
+    // capped_cylinder : Iqac, with 5 sample parameters and 2 orientation parameters.
+    form_vol = form_volume(pars[2], pars[3], pars[4]);
     #endif
     #if SASmodel_index == 25
-      form_vol = form_volume(pars[0]);
-    #endif
-    #if SASmodel_index == 26
-      form_vol = form_volume(pars[0]);
-    #endif
-    #if SASmodel_index == 27
-      form_vol = form_volume(pars[0], pars[1], pars[2]);
+    // core_multi_shell : Fq, with 6 sample parameters and 0 orientation parameters.
+    form_vol = form_volume(pars[3], pars[5]);
     #endif
     #if SASmodel_index == 28
-      form_vol = form_volume(pars[0], pars[1], pars[2]);
+    // stacked_disks : Iq, with 8 sample parameters and 2 orientation parameters.
+    form_vol = form_volume(pars[0], pars[1], pars[2], pars[3]);
     #endif
     #if SASmodel_index == 29
-      form_vol = form_volume(pars[2]);
-    #endif
-    #if SASmodel_index == 30
-      form_vol = form_volume(pars[2]);
-    #endif
-    #if SASmodel_index == 31
-      form_vol = form_volume(pars[0], pars[1]);
+    // stacked_disks : Iqac, with 8 sample parameters and 2 orientation parameters.
+    form_vol = form_volume(pars[0], pars[1], pars[2], pars[3]);
     #endif
     #if SASmodel_index == 32
-      form_vol = form_volume(pars[0], pars[1]);
+    // core_shell_bicelle : Fq, with 8 sample parameters and 2 orientation parameters.
+    form_vol = form_volume(pars[0], pars[1], pars[2], pars[3]);
     #endif
     #if SASmodel_index == 33
-      form_vol = 1;
+    // core_shell_bicelle : Iqac, with 8 sample parameters and 2 orientation parameters.
+    form_vol = form_volume(pars[0], pars[1], pars[2], pars[3]);
     #endif
     #if SASmodel_index == 34
-      form_vol = 1;
+    // cylinder : Fq, with 4 sample parameters and 2 orientation parameters.
+    form_vol = form_volume(pars[2], pars[3]);
     #endif
     #if SASmodel_index == 35
-      form_vol = 1;
-    #endif
-    #if SASmodel_index == 36
-      form_vol = 1;
+    // cylinder : Iqac, with 4 sample parameters and 2 orientation parameters.
+    form_vol = form_volume(pars[2], pars[3]);
     #endif
     #if SASmodel_index == 37
-      form_vol = 1;
+    // fcc_paracrystal : Iq, with 5 sample parameters and 3 orientation parameters.
+    form_vol = form_volume(pars[2]);
     #endif
     #if SASmodel_index == 38
-      form_vol = 1;
+    // fcc_paracrystal : Iqabc, with 5 sample parameters and 3 orientation parameters.
+    form_vol = form_volume(pars[2]);
     #endif
     #if SASmodel_index == 39
-      form_vol = form_volume(pars[0], pars[2]);
-    #endif
-    #if SASmodel_index == 40
-      form_vol = form_volume(pars[0], pars[2]);
-    #endif
-    #if SASmodel_index == 41
-      form_vol = 1;
-    #endif
-    #if SASmodel_index == 42
-      form_vol = 1;
-    #endif
-    #if SASmodel_index == 43
-      form_vol = form_volume(pars[0]);
-    #endif
-    #if SASmodel_index == 44
-      form_vol = form_volume(pars[0]);
-    #endif
-    #if SASmodel_index == 45
-      form_vol = 1;
-    #endif
-    #if SASmodel_index == 46
-      form_vol = 1;
+    // fractal : Iq, with 6 sample parameters and 0 orientation parameters.
+    form_vol = form_volume(pars[1]);
     #endif
     #if SASmodel_index == 47
-      form_vol = form_volume(pars[2], pars[3], pars[4]);
+    // flexible_cylinder : Iq, with 5 sample parameters and 0 orientation parameters.
+    form_vol = form_volume(pars[0], pars[1], pars[2]);
     #endif
     #if SASmodel_index == 48
-      form_vol = form_volume(pars[2], pars[3], pars[4]);
+    // parallelepiped : Fq, with 5 sample parameters and 3 orientation parameters.
+    form_vol = form_volume(pars[2], pars[3], pars[4]);
     #endif
     #if SASmodel_index == 49
-      form_vol = form_volume(pars[0], pars[1], pars[2], pars[3]);
+    // parallelepiped : Iqabc, with 5 sample parameters and 3 orientation parameters.
+    form_vol = form_volume(pars[2], pars[3], pars[4]);
     #endif
     #if SASmodel_index == 50
-      form_vol = form_volume(pars[0], pars[1], pars[2], pars[3]);
+    // hollow_rectangular_prism : Fq, with 6 sample parameters and 3 orientation parameters.
+    form_vol = form_volume(pars[2], pars[3], pars[4], pars[5]);
     #endif
     #if SASmodel_index == 51
-      form_vol = form_volume(pars[2]);
+    // hollow_rectangular_prism : Iqabc, with 6 sample parameters and 3 orientation parameters.
+    form_vol = form_volume(pars[2], pars[3], pars[4], pars[5]);
     #endif
     #if SASmodel_index == 52
-      form_vol = form_volume(pars[2]);
+    // rectangular_prism : Iq, with 5 sample parameters and 3 orientation parameters.
+    form_vol = form_volume(pars[2], pars[3], pars[4]);
     #endif
     #if SASmodel_index == 53
-      form_vol = form_volume();
+    // rectangular_prism : Iqabc, with 5 sample parameters and 3 orientation parameters.
+    form_vol = form_volume(pars[2], pars[3], pars[4]);
     #endif
     #if SASmodel_index == 54
-      form_vol = form_volume();
+    // core_shell_parallelepiped : Fq, with 11 sample parameters and 3 orientation parameters.
+    form_vol = form_volume(pars[5], pars[6], pars[7], pars[8], pars[9], pars[10]);
     #endif
     #if SASmodel_index == 55
-      form_vol = form_volume(pars[0]);
-    #endif
-    #if SASmodel_index == 56
-      form_vol = form_volume(pars[0]);
+    // core_shell_parallelepiped : Iqabc, with 11 sample parameters and 3 orientation parameters.
+    form_vol = form_volume(pars[5], pars[6], pars[7], pars[8], pars[9], pars[10]);
     #endif
     #if SASmodel_index == 57
-      form_vol = form_volume(pars[2], pars[3], pars[4]);
+    // triaxial_ellipsoid : Fq, with 5 sample parameters and 3 orientation parameters.
+    form_vol = form_volume(pars[2], pars[3], pars[4]);
     #endif
     #if SASmodel_index == 58
-      form_vol = form_volume(pars[2], pars[3], pars[4]);
+    // triaxial_ellipsoid : Iqabc, with 5 sample parameters and 3 orientation parameters.
+    form_vol = form_volume(pars[2], pars[3], pars[4]);
     #endif
-    return form_vol;
-  }
+    #if SASmodel_index == 59
+    // sc_paracrystal : Iq, with 5 sample parameters and 3 orientation parameters.
+    form_vol = form_volume(pars[2]);
+    #endif
+    #if SASmodel_index == 60
+    // sc_paracrystal : Iqabc, with 5 sample parameters and 3 orientation parameters.
+    form_vol = form_volume(pars[2]);
+    #endif
+    #if SASmodel_index == 61
+    // core_shell_sphere : Fq, with 5 sample parameters and 0 orientation parameters.
+    form_vol = form_volume(pars[0], pars[1]);
+    #endif
+    #if SASmodel_index == 62
+    // fuzzy_sphere : Fq, with 4 sample parameters and 0 orientation parameters.
+    form_vol = form_volume(pars[2], pars[3]);
+    #endif
+    #if SASmodel_index == 63
+    // hollow_cylinder : Fq, with 5 sample parameters and 2 orientation parameters.
+    form_vol = form_volume(pars[0], pars[1], pars[2]);
+    #endif
+    #if SASmodel_index == 64
+    // hollow_cylinder : Iqac, with 5 sample parameters and 2 orientation parameters.
+    form_vol = form_volume(pars[0], pars[1], pars[2]);
+    #endif
+    #if SASmodel_index == 67
+    // core_shell_ellipsoid : Fq, with 7 sample parameters and 2 orientation parameters.
+    form_vol = form_volume(pars[0], pars[1], pars[2], pars[3]);
+    #endif
+    #if SASmodel_index == 68
+    // core_shell_ellipsoid : Iqac, with 7 sample parameters and 2 orientation parameters.
+    form_vol = form_volume(pars[0], pars[1], pars[2], pars[3]);
+    #endif
+    #if SASmodel_index == 69
+    // raspberry : Iq, with 9 sample parameters and 0 orientation parameters.
+    form_vol = form_volume(pars[6], pars[7], pars[8]);
+    #endif
+    #if SASmodel_index == 70
+    // star_polymer : Iq, with 2 sample parameters and 0 orientation parameters.
+    form_vol = form_volume();
+    #endif
+    #if SASmodel_index == 73
+    // bcc_paracrystal : Iq, with 5 sample parameters and 3 orientation parameters.
+    form_vol = form_volume(pars[2]);
+    #endif
+    #if SASmodel_index == 74
+    // bcc_paracrystal : Iqabc, with 5 sample parameters and 3 orientation parameters.
+    form_vol = form_volume(pars[2]);
+    #endif
+    #if SASmodel_index == 75
+    // barbell : Fq, with 5 sample parameters and 2 orientation parameters.
+    form_vol = form_volume(pars[2], pars[3], pars[4]);
+    #endif
+    #if SASmodel_index == 76
+    // barbell : Iqac, with 5 sample parameters and 2 orientation parameters.
+    form_vol = form_volume(pars[2], pars[3], pars[4]);
+    #endif
+    #if SASmodel_index == 77
+    // multilayer_vesicle : Fq, with 7 sample parameters and 0 orientation parameters.
+    form_vol = form_volume(pars[1], pars[2], pars[3], pars[6]);
+    #endif
+    #if SASmodel_index == 79
+    // core_shell_cylinder : Fq, with 6 sample parameters and 2 orientation parameters.
+    form_vol = form_volume(pars[3], pars[4], pars[5]);
+    #endif
+    #if SASmodel_index == 80
+    // core_shell_cylinder : Iqac, with 6 sample parameters and 2 orientation parameters.
+    form_vol = form_volume(pars[3], pars[4], pars[5]);
+    #endif
+    #if SASmodel_index == 81
+    // mono_gauss_coil : Iq, with 2 sample parameters and 0 orientation parameters.
+    form_vol = form_volume(pars[1]);
+    #endif
+    #if SASmodel_index == 83
+    // surface_fractal : Iq, with 3 sample parameters and 0 orientation parameters.
+    form_vol = form_volume(pars[0]);
+    #endif
+    #if SASmodel_index == 84
+    // sphere : Fq, with 3 sample parameters and 0 orientation parameters.
+    form_vol = form_volume(pars[2]);
+    #endif
+    #if SASmodel_index == 88
+    // pearl_necklace : Iq, with 7 sample parameters and 0 orientation parameters.
+    form_vol = form_volume(pars[0], pars[1], pars[2], pars[3]);
+    #endif
+    #if SASmodel_index == 89
+    // pringle : Iq, with 6 sample parameters and 0 orientation parameters.
+    form_vol = form_volume(pars[0], pars[1], pars[2], pars[3]);
+    #endif
+    #if SASmodel_index == 90
+    // core_shell_bicelle_elliptical : Fq, with 9 sample parameters and 3 orientation parameters.
+    form_vol = form_volume(pars[0], pars[1], pars[2], pars[3], pars[4]);
+    #endif
+    #if SASmodel_index == 91
+    // core_shell_bicelle_elliptical : Iqabc, with 9 sample parameters and 3 orientation parameters.
+    form_vol = form_volume(pars[0], pars[1], pars[2], pars[3], pars[4]);
+    #endif
+    #if SASmodel_index == 92
+    // onion : Fq, with 8 sample parameters and 0 orientation parameters.
+    form_vol = form_volume(pars[1], pars[3], pars[6]);
+    #endif
+    #if SASmodel_index == 93
+    // elliptical_cylinder : Fq, with 5 sample parameters and 3 orientation parameters.
+    form_vol = form_volume(pars[0], pars[1], pars[2]);
+    #endif
+    #if SASmodel_index == 94
+    // elliptical_cylinder : Iqabc, with 5 sample parameters and 3 orientation parameters.
+    form_vol = form_volume(pars[0], pars[1], pars[2]);
+    #endif
+    #if SASmodel_index == 95
+    // linear_pearls : Iq, with 5 sample parameters and 0 orientation parameters.
+    form_vol = form_volume(pars[0], pars[2]);
+    #endif
+
+return form_vol;}
+


### PR DESCRIPTION
Updated existing models and added new models that are available at [sasmodels.models](https://github.com/SasView/sasmodels/tree/master/sasmodels/models). OpenACC compatibility was included, therefore all models may be deployed to GPU.

There are a few models that need to have an array as input parameter, like `sas_spherical_sld.c`, `sas_core_multi_shell.c`, `sas_onion.c`, that are still not available since the `sasview_proxy.c` file is not compatible with this type of input and they need a different logical implementation.