### PR TITLE
[Add] Configure-time age check to overwrite out-of-date files

### DIFF
--- a/cmake/Modules/InstallMCCODE.cmake
+++ b/cmake/Modules/InstallMCCODE.cmake
@@ -197,7 +197,7 @@ macro(installMCCODE)
           )
       else()
         # do not overwrite files created by configure
-        if(NOT (EXISTS "${OUT_DIR}/${filename}"))
+        if(NOT (EXISTS "${OUT_DIR}/${filename}") OR ("${file_in}" IS_NEWER_THAN "${OUT_DIR}/${filename}"))
           file(
             COPY "${file_in}"
             DESTINATION "${OUT_DIR}")


### PR DESCRIPTION
- The current build system relies on copying files from their source directories *into* the build directory. This means that subsequent changes to the source files are not included in builds, which is a problem for easy development. At present the 'best' option is to delete the copies of the changed files in the build directory, then reconfigure the project to allow CMake to make new copies of the modified sources.
- As a stop-gap the file copy is modified to allow *newer* source files to overwrite their copies in the build directory. This check is still only performed at configure time.
- To capture any changes in the source files between last build-time and now, a developer *must* reconfigure the project with CMake. This will typically be faster than a fresh build.
- A better solution would not copy *any* files from their source directories. It would use per-source folder CMakeList.txt files and would allow for real CMake dependency tracking such that only changed files must be recompiled, typically without needing to re-configure the project.