### PR TITLE
[Add] optional instrument parameter units

### DIFF
--- a/common/lib/share/mccode-r.c
+++ b/common/lib/share/mccode-r.c
@@ -3933,6 +3933,7 @@ mchelp(char *pgmname)
 "  --no-output-files          Do not write any data files.\n"
 "  -h        --help           Show this help message.\n"
 "  -i        --info           Detailed instrument information.\n"
+"  --list-parameters          Print the instrument parameters to standard out\n"
 "  --source                   Show the instrument code which was compiled.\n"
 #ifdef OPENACC
 "\n"
@@ -4181,7 +4182,7 @@ mcparseoptions(int argc, char *argv[])
     }
     else if(!strcmp("--info", argv[i]))
       mcinfo();
-    else if (!strcmp("-p", argv[i]) || !strcmp("--params", argv[i]))
+    else if (!strcmp("--list-parameters", argv[i]))
       mcparameterinfo();
     else if(!strcmp("-t", argv[i]))
       mcenabletrace();

--- a/common/lib/share/mccode-r.h.in
+++ b/common/lib/share/mccode-r.h.in
@@ -191,6 +191,7 @@ struct mcinputtable_struct { /* defines instrument parameters */
   void *par;  /* pointer to instrument parameter (variable) */
   enum instr_formal_types type;
   char *val;  /* default value */
+  char *unit; /* expected unit for parameter; informational only */
 };
 
 #ifndef MCCODE_BASE_TYPES

--- a/mcstas/src/cogen.c.in
+++ b/mcstas/src/cogen.c.in
@@ -1166,13 +1166,15 @@ int cogen_decls(struct instr_def *instr)
     if (strlen(i_formal->id)) {
       if (i_formal->isoptional  // needed to avoid double quotes in strings
           && !strcmp(instr_formal_type_names[i_formal->type],"instr_type_string"))
-        coutf("  \"%s\", &(_instrument_var._parameters.%s), %s, %s, ", i_formal->id,
+        coutf("  \"%s\", &(_instrument_var._parameters.%s), %s, %s, \"%s\",", i_formal->id,
               i_formal->id, instr_formal_type_names[i_formal->type],
-              exp_tostring(i_formal->default_value));
+              exp_tostring(i_formal->default_value),
+              i_formal->hasunit ? i_formal->unit : "");
       else
-        coutf("  \"%s\", &(_instrument_var._parameters.%s), %s, \"%s\", ", i_formal->id,
+        coutf("  \"%s\", &(_instrument_var._parameters.%s), %s, \"%s\", \"%s\",", i_formal->id,
               i_formal->id, instr_formal_type_names[i_formal->type],
-              i_formal->isoptional ? exp_tostring(i_formal->default_value) : "");
+              i_formal->isoptional ? exp_tostring(i_formal->default_value) : "",
+              i_formal->hasunit ? i_formal->unit : "");
     }
   }
   list_iterate_end(liter);

--- a/mcstas/src/instrument.y
+++ b/mcstas/src/instrument.y
@@ -770,6 +770,7 @@ instr_formal:   TOK_ID TOK_ID
           formal->type = instr_type_double;
         }
         formal->id = $2;
+        formal->hasunit = 0;
         $$ = formal;
       }
     | TOK_ID '*' TOK_ID
@@ -786,6 +787,7 @@ instr_formal:   TOK_ID TOK_ID
           formal->type = instr_type_double;
         }
         formal->id = $3;
+        formal->hasunit = 0;
         $$ = formal;
       }
     | TOK_ID  /* Default type is "double" */
@@ -795,6 +797,7 @@ instr_formal:   TOK_ID TOK_ID
         formal->type = instr_type_double;
         formal->id = $1;
         formal->isoptional = 0; /* No default value */
+        formal->hasunit = 0;
         $$ = formal;
       }
     | TOK_ID '=' exp
@@ -805,6 +808,7 @@ instr_formal:   TOK_ID TOK_ID
         formal->isoptional = 1; /* Default value available */
         formal->default_value = $3;
         formal->type = instr_type_double;
+        formal->hasunit = 0;
         $$ = formal;
       }
     | TOK_ID TOK_ID '=' exp
@@ -825,6 +829,7 @@ instr_formal:   TOK_ID TOK_ID
         formal->id = $2;
         formal->isoptional = 1; /* Default value available */
         formal->default_value = $4;
+        formal->hasunit = 0;
         $$ = formal;
       }
     | TOK_ID '*' TOK_ID '=' exp
@@ -842,7 +847,112 @@ instr_formal:   TOK_ID TOK_ID
           print_error("ERROR: Illegal type %s* for instrument "
           "parameter %s at line %s:%d.\n", $1, $3, instr_current_filename, instr_current_line);
           formal->type = instr_type_double;
+          formal->hasunit = 0;
         }
+        $$ = formal;
+      }
+    |
+   TOK_ID TOK_ID '(' TOK_STRING ')'
+      {
+        struct instr_formal *formal;
+        palloc(formal);
+        if(!strcmp($1, "double")) {
+          formal->type = instr_type_double;
+        } else if(!strcmp($1, "int")) {
+          formal->type = instr_type_int;
+        } else if(!strcmp($1, "string")) {
+          formal->type = instr_type_string;
+        } else {
+          print_error("ERROR: Illegal type %s for instrument "
+          "parameter %s at line %s:%d.\n", $1, $2, instr_current_filename, instr_current_line);
+          formal->type = instr_type_double;
+        }
+        formal->id = $2;
+        formal->hasunit = 1;
+        formal->unit = $4;
+        $$ = formal;
+      }
+    | TOK_ID '*' TOK_ID '(' TOK_STRING ')'
+      {
+        struct instr_formal *formal;
+        palloc(formal);
+        if(!strcmp($1, "char")) {
+          formal->type = instr_type_string;
+        } else if(!strcmp($1, "double")) {
+          formal->type = instr_type_vector;
+        } else {
+          print_error("ERROR: Illegal type $s* for instrument "
+          "parameter %s at line %s:%d.\n", $1, $3, instr_current_filename, instr_current_line);
+          formal->type = instr_type_double;
+        }
+        formal->id = $3;
+        formal->hasunit = 1;
+        formal->unit = $5;
+        $$ = formal;
+      }
+    | TOK_ID '(' TOK_STRING ')'
+      {
+        struct instr_formal *formal;
+        palloc(formal);
+        formal->type = instr_type_double;
+        formal->id = $1;
+        formal->isoptional = 0; /* No default value */
+        formal->hasunit = 1;
+        formal->unit = $3;
+        $$ = formal;
+      }
+    | TOK_ID '(' TOK_STRING ')' '=' exp
+      {
+        struct instr_formal *formal;
+        palloc(formal);
+        formal->id = $1;
+        formal->isoptional = 1; /* Default value available */
+        formal->default_value = $6;
+        formal->type = instr_type_double;
+        formal->hasunit = 1;
+        formal->unit = $3;
+        $$ = formal;
+      }
+    | TOK_ID TOK_ID '(' TOK_STRING ')' '=' exp
+      {
+        struct instr_formal *formal;
+        palloc(formal);
+        if(!strcmp($1, "double")) {
+          formal->type = instr_type_double;
+        } else if(!strcmp($1, "int")) {
+          formal->type = instr_type_int;
+        } else if(!strcmp($1, "string")) {
+          formal->type = instr_type_string;
+        } else {
+          print_error("ERROR: Illegal type %s for instrument "
+          "parameter %s at line %s:%d.\n", $1, $2, instr_current_filename, instr_current_line);
+          formal->type = instr_type_double;
+        }
+        formal->id = $2;
+        formal->isoptional = 1; /* Default value available */
+        formal->default_value = $7;
+        formal->hasunit = 1;
+        formal->unit = $4;
+        $$ = formal;
+      }
+    | TOK_ID '*' TOK_ID '(' TOK_STRING ')' '=' exp
+      {
+        struct instr_formal *formal;
+        palloc(formal);
+        formal->id = $3;
+        formal->isoptional = 1; /* Default value available */
+        formal->default_value = $8;
+        if(!strcmp($1, "char")) {
+          formal->type = instr_type_string;
+        } else if(!strcmp($1, "double")) {
+          formal->type = instr_type_vector;
+        } else {
+          print_error("ERROR: Illegal type %s* for instrument "
+          "parameter %s at line %s:%d.\n", $1, $3, instr_current_filename, instr_current_line);
+          formal->type = instr_type_double;
+        }
+        formal->hasunit = 1;
+        formal->unit = $5;
         $$ = formal;
       }
 ;

--- a/mcstas/src/mccode.h.in
+++ b/mcstas/src/mccode.h.in
@@ -494,6 +494,8 @@ struct instr_formal
     char *id;                     /* Parameter name */
     int isoptional;               /* True if default value is available */
     CExp default_value;           /* Default value if isoptional is true */
+    int hasunit;                  /* Flag to indicate if unit was provided */
+    char *unit;                   /* (Informational) parameter unit */
   };
 
 /* Instrument definition. */

--- a/mcxtrace/src/cogen.c.in
+++ b/mcxtrace/src/cogen.c.in
@@ -1168,13 +1168,15 @@ int cogen_decls(struct instr_def *instr)
     if (strlen(i_formal->id)) {
       if (i_formal->isoptional  // needed to avoid double quotes in strings
           && !strcmp(instr_formal_type_names[i_formal->type],"instr_type_string"))
-        coutf("  \"%s\", &(_instrument_var._parameters.%s), %s, %s, ", i_formal->id,
+        coutf("  \"%s\", &(_instrument_var._parameters.%s), %s, %s, \"%s\",", i_formal->id,
               i_formal->id, instr_formal_type_names[i_formal->type],
-              exp_tostring(i_formal->default_value));
+              exp_tostring(i_formal->default_value),
+              i_formal->hasunit ? i_formal->unit : "");
       else
-        coutf("  \"%s\", &(_instrument_var._parameters.%s), %s, \"%s\", ", i_formal->id,
+        coutf("  \"%s\", &(_instrument_var._parameters.%s), %s, \"%s\", \"%s\",", i_formal->id,
               i_formal->id, instr_formal_type_names[i_formal->type],
-              i_formal->isoptional ? exp_tostring(i_formal->default_value) : "");
+              i_formal->isoptional ? exp_tostring(i_formal->default_value) : "",
+              i_formal->hasunit ? i_formal->unit : "");
     }
   }
   list_iterate_end(liter);

--- a/mcxtrace/src/instrument.y
+++ b/mcxtrace/src/instrument.y
@@ -770,6 +770,7 @@ instr_formal:   TOK_ID TOK_ID
           formal->type = instr_type_double;
         }
         formal->id = $2;
+        formal->hasunit = 0;
         $$ = formal;
       }
     | TOK_ID '*' TOK_ID
@@ -786,6 +787,7 @@ instr_formal:   TOK_ID TOK_ID
           formal->type = instr_type_double;
         }
         formal->id = $3;
+        formal->hasunit = 0;
         $$ = formal;
       }
     | TOK_ID  /* Default type is "double" */
@@ -795,6 +797,7 @@ instr_formal:   TOK_ID TOK_ID
         formal->type = instr_type_double;
         formal->id = $1;
         formal->isoptional = 0; /* No default value */
+        formal->hasunit = 0;
         $$ = formal;
       }
     | TOK_ID '=' exp
@@ -805,6 +808,7 @@ instr_formal:   TOK_ID TOK_ID
         formal->isoptional = 1; /* Default value available */
         formal->default_value = $3;
         formal->type = instr_type_double;
+        formal->hasunit = 0;
         $$ = formal;
       }
     | TOK_ID TOK_ID '=' exp
@@ -825,6 +829,7 @@ instr_formal:   TOK_ID TOK_ID
         formal->id = $2;
         formal->isoptional = 1; /* Default value available */
         formal->default_value = $4;
+        formal->hasunit = 0;
         $$ = formal;
       }
     | TOK_ID '*' TOK_ID '=' exp
@@ -842,7 +847,112 @@ instr_formal:   TOK_ID TOK_ID
           print_error("ERROR: Illegal type %s* for instrument "
           "parameter %s at line %s:%d.\n", $1, $3, instr_current_filename, instr_current_line);
           formal->type = instr_type_double;
+          formal->hasunit = 0;
         }
+        $$ = formal;
+      }
+    |
+   TOK_ID TOK_ID '(' TOK_STRING ')'
+      {
+        struct instr_formal *formal;
+        palloc(formal);
+        if(!strcmp($1, "double")) {
+          formal->type = instr_type_double;
+        } else if(!strcmp($1, "int")) {
+          formal->type = instr_type_int;
+        } else if(!strcmp($1, "string")) {
+          formal->type = instr_type_string;
+        } else {
+          print_error("ERROR: Illegal type %s for instrument "
+          "parameter %s at line %s:%d.\n", $1, $2, instr_current_filename, instr_current_line);
+          formal->type = instr_type_double;
+        }
+        formal->id = $2;
+        formal->hasunit = 1;
+        formal->unit = $4;
+        $$ = formal;
+      }
+    | TOK_ID '*' TOK_ID '(' TOK_STRING ')'
+      {
+        struct instr_formal *formal;
+        palloc(formal);
+        if(!strcmp($1, "char")) {
+          formal->type = instr_type_string;
+        } else if(!strcmp($1, "double")) {
+          formal->type = instr_type_vector;
+        } else {
+          print_error("ERROR: Illegal type $s* for instrument "
+          "parameter %s at line %s:%d.\n", $1, $3, instr_current_filename, instr_current_line);
+          formal->type = instr_type_double;
+        }
+        formal->id = $3;
+        formal->hasunit = 1;
+        formal->unit = $5;
+        $$ = formal;
+      }
+    | TOK_ID '(' TOK_STRING ')'
+      {
+        struct instr_formal *formal;
+        palloc(formal);
+        formal->type = instr_type_double;
+        formal->id = $1;
+        formal->isoptional = 0; /* No default value */
+        formal->hasunit = 1;
+        formal->unit = $3;
+        $$ = formal;
+      }
+    | TOK_ID '(' TOK_STRING ')' '=' exp
+      {
+        struct instr_formal *formal;
+        palloc(formal);
+        formal->id = $1;
+        formal->isoptional = 1; /* Default value available */
+        formal->default_value = $6;
+        formal->type = instr_type_double;
+        formal->hasunit = 1;
+        formal->unit = $3;
+        $$ = formal;
+      }
+    | TOK_ID TOK_ID '(' TOK_STRING ')' '=' exp
+      {
+        struct instr_formal *formal;
+        palloc(formal);
+        if(!strcmp($1, "double")) {
+          formal->type = instr_type_double;
+        } else if(!strcmp($1, "int")) {
+          formal->type = instr_type_int;
+        } else if(!strcmp($1, "string")) {
+          formal->type = instr_type_string;
+        } else {
+          print_error("ERROR: Illegal type %s for instrument "
+          "parameter %s at line %s:%d.\n", $1, $2, instr_current_filename, instr_current_line);
+          formal->type = instr_type_double;
+        }
+        formal->id = $2;
+        formal->isoptional = 1; /* Default value available */
+        formal->default_value = $7;
+        formal->hasunit = 1;
+        formal->unit = $4;
+        $$ = formal;
+      }
+    | TOK_ID '*' TOK_ID '(' TOK_STRING ')' '=' exp
+      {
+        struct instr_formal *formal;
+        palloc(formal);
+        formal->id = $3;
+        formal->isoptional = 1; /* Default value available */
+        formal->default_value = $8;
+        if(!strcmp($1, "char")) {
+          formal->type = instr_type_string;
+        } else if(!strcmp($1, "double")) {
+          formal->type = instr_type_vector;
+        } else {
+          print_error("ERROR: Illegal type %s* for instrument "
+          "parameter %s at line %s:%d.\n", $1, $3, instr_current_filename, instr_current_line);
+          formal->type = instr_type_double;
+        }
+        formal->hasunit = 1;
+        formal->unit = $5;
         $$ = formal;
       }
 ;

--- a/mcxtrace/src/mccode.h.in
+++ b/mcxtrace/src/mccode.h.in
@@ -494,6 +494,8 @@ struct instr_formal
     char *id;                     /* Parameter name */
     int isoptional;               /* True if default value is available */
     CExp default_value;           /* Default value if isoptional is true */
+    int hasunit;                  /* Flag to indicate if unit was provided */
+    char *unit;                   /* (Informational) parameter unit */
   };
 
 /* Instrument definition. */

--- a/tools/Python/mcrun/mccode.py
+++ b/tools/Python/mcrun/mccode.py
@@ -245,7 +245,7 @@ class McStas:
                 args.extend(['--%s' % opt, str(val)])
 
         # Handle proxy options without values (flags)
-        proxy_opts_flags = ['trace', 'no-output-files', 'info']
+        proxy_opts_flags = ['trace', 'no-output-files', 'info', 'list-parameters']
         if (mccode_config.configuration["MCCODE"]=='mcstas'):
            proxy_opts_flags.append('gravitation')
 

--- a/tools/Python/mcrun/mcrun.py
+++ b/tools/Python/mcrun/mcrun.py
@@ -283,6 +283,9 @@ def add_mcstas_options(parser):
         action='store_true', default=False,
         help='Detailed instrument information')
 
+    add('--list-parameters', action='store_true', default=False,
+        help='Print the instrument parameters to standard out')
+
     parser.add_option_group(opt)
 
 
@@ -449,7 +452,7 @@ def main():
     # Indicate end of setup / start of computations
     LOG.info('===')
 
-    if options.info:
+    if options.info or options.list_parameters:
         mcstas.run(override_mpi=False)
         exit()
 
@@ -530,6 +533,7 @@ def main():
 
 if __name__ == '__main__':
     try:
+
         mccode_config.load_config("user")
         mccode_config.check_env_vars()
         


### PR DESCRIPTION
# Current status
## Split definition of a parameter and its units
Instrument parameters must be specified in the instrument file following the name of the instrument, enclosed in parentheses.
Often a comment block precedes the `DEFINE` statement, which can be used to indicate the units of the parameters:

```
/********************************************************************
*
* Instrument: InstrumentName
*
* %Parameters
* parameter1: [m]    a length used in the instrument
* parameter2: [1]    a flag indicating some choice in the instrument setup
* parameter3: [rad]  the local value of pi
*
************************************************************************/
DEFINE INSTRUMENT InstrumentName(
            parameter1,          // required at run-time, double valued
    type    parameter2,          // required at run-time, type one of int, double, or string
    double parameter3 = 3.14159  // optional at run-time
)
...
```
The comment blocks and instrument definitions can be parsed to produce useful user documentation with `mcdoc`.

## Parameter units not available from binary
While there is an easy way to extract parameter types and default values (via `instrument_binary --info`), there is no equivalent way to extract the parameter units from the compiled instrument.

While not strictly necessary to use a compiled instrument, it would be nice to provide a means by which to convey the _intended_ units of a parameter to a user.

# Changes in this pull request
## Additional McCode grammar
The McCode grammar is extended to support optional string valued unit names for all instrument parameter types. 
Under the new syntax the parameters of the instrument above can optionally be made explicit

```
DEFINE INSTRUMENT InstrumentName(
            parameter1 ("m"),            // required at run-time, double valued
    int    parameter2,                  // required at run-time, here int replaces type
    double parameter3 ("rad") = 3.14159  // optional at run-time
    
)
...
```
The unit can be any valid `TOK_STRING` and therefore must be enclosed in double quotes.

## New generated runtime option
The code generator is extended to produce functionality to print complete parameter information from the compiled instrument.
If the above instrument was compiled to a binary, `instrument.out`, then its parameters would be accessible via the flag `-p` or `--params`:

```cmd
$ ./instrument.out -p
  double parameter1 ("m") = NULL
  int parameter2 = NULL
  double parameter3 ("rad") = 3.14159
```


# Possible issues
## Negative effect on `mcformat`?
The code generator appends the provided unit strings to the `mcinputtable_struct` and associated `mcinputtable[]` list.

It appears that `mcformat` also makes use of `mcinputtable[]`, and reads information from files to populate the parameter fields. Since what `mcformat` (presumably) reads is unmodified (the output of `mcinfo()` in the binary) the parsing code will probably still work. Also, since `mcformat` directly assigns members of the struct, it should continue to work with the struct redefined to include an extra `int` and `char *`.
Still,	these modifications might have an effect on the runtime use of `mcformat`, which should be checked.

## Less-than-ideal syntax
Specifying the units of a parameter as a literal string is good, as it can support all types of units likely to appear in an instrument, e.g., `1/m`, `\AA`, `minutes of arc`, etc.

Placing those units, however, within parentheses is not as good as, e.g., separating them from the parameter name by a forward slash. Compare `double parameter3 ("rad") = 3.14159` to `double parameter3/"rad" = 3.14159`, the latter of which makes it clear that the number (`3.14159`) should be interpreted as a number of `"rad"` to know the value of `parameter3`.

For reasons that remain unclear to me, I could not expose `"/"` as a singular token in `instrument.l`. Removing it from the `TOK_CTOK` list and adding a new rule to the 'operators' return and to `topatexp` `instrument.y` did not allow for the singular forward slash to be used in other rules, e.g., `TOK_ID '(' TOK_STRING ')' '=' exp` works but `TOK_ID '/' TOK_STRING '=' exp` does not.
Any help here would be greatly appreciated.