### PR TITLE
Update MCPL_output.comp filename

### DIFF
--- a/mcstas-comps/misc/MCPL_output.comp
+++ b/mcstas-comps/misc/MCPL_output.comp
@@ -37,7 +37,7 @@
 * %P
 * INPUT PARAMETERS
 *
-* filename: [str]         Name of neutron file to write. Default is standard output [string]. If not given, a unique name will be used.
+* filename: [str]         Name of neutron file to write. If not given, the component name will be used.
 * verbose: [1]            If 1) Print summary information for created MCPL file. 2) Also print summary of first 10 particles information stored in the MCPL file. >2) Also print information for first 10 particles as they are being stored by McStas.
 * polarisationuse: [1]    Enable storing the polarisation state of the neutron.
 * doubleprec: [1]         Use double precision storage
@@ -92,6 +92,9 @@ INITIALIZE
 %{
     char extension[128]="";
     char *myfilename;
+    
+    // Use instance name for base output if no input was given
+    if (!strcmp(filename,"\0")) sprintf(filename, NAME_CURRENT_COMP);
 
 #if defined (USE_MPI)
   /* In case of MPI, simply redefine the filename used by each node */


### PR DESCRIPTION
The MCPL_output documentation string indicated that a unique filename would be used if no filename was provided. This was not true, and instead the filename `[output_directory]/.mcpl` would be used. Multiple MCPL_output components would use the same filename if not given a filename value, and either wrote to the same file or overwrote each other depending on implementation details in MCPL. Furthermore, the produced filename is hidden on UNIX-like systems, so a user may never find their output file.

The component has been changed to insert the (unique) component name into the filename string if another value is not supplied. This should produce MCPL output files like `[output_directory]/[component_name].mcpl` which a) are unique and b) are not hidden.

### TODO
If this change is acceptable, the same change is likely necessary in the other MCPL_output components 'noacc' and in `mcxtrace-comps/misc` and could be appended to this pull request.