### PR TITLE
[Fix] memory leak from mcdetector_statistics

### DIFF
--- a/common/lib/share/mccode-r.c
+++ b/common/lib/share/mccode-r.c
@@ -2197,10 +2197,16 @@ MCDETECTOR mcdetector_out_1D(char *t, char *xl, char *yl,
 
 #ifdef USE_NEXUS
   if (strcasestr(detector.format, "NeXus"))
-    return(mcdetector_out_1D_nexus(detector));
+    detector = mcdetector_out_1D_nexus(detector);
   else
 #endif
-    return(mcdetector_out_1D_ascii(detector));
+    detector = mcdetector_out_1D_ascii(detector);
+  if (detector.p1 != p1 && detector.p1) {
+    // mcdetector_statistics allocated memory but it hasn't been freed.
+    free(detector.p1);
+    detector.p1 = p1;
+  }
+  return detector;
 
 } /* mcdetector_out_1D */
 

--- a/common/lib/share/mccode-r.c
+++ b/common/lib/share/mccode-r.c
@@ -2186,6 +2186,9 @@ MCDETECTOR mcdetector_out_1D(char *t, char *xl, char *yl,
         char *c, Coords posa)
 {
   /* import and perform basic detector analysis (and handle MPI_Reduce) */
+  // detector_import calls mcdetector_statistics, which will return different
+  // MCDETECTOR versions for 1-D data based on the value of mcformat.
+  //
   MCDETECTOR detector = detector_import(mcformat,
     c, (t ? t : MCCODE_STRING " 1D data"),
     n, 1, 1,
@@ -2204,7 +2207,13 @@ MCDETECTOR mcdetector_out_1D(char *t, char *xl, char *yl,
   if (detector.p1 != p1 && detector.p1) {
     // mcdetector_statistics allocated memory but it hasn't been freed.
     free(detector.p1);
-    detector.p1 = p1;
+    // plus undo the other damage done there:
+    detector.p0 = p0; // was set to NULL
+    detector.p1 = p1; // was set to this_p1
+    detector.p2 = p2; // was set to NULL
+    detector.m = detector.n; // (e.g., labs(n))
+    detector.n = 1;  // not (n x n)
+    detector.istransposed = n < 0 ? 1 : 0;
   }
   return detector;
 


### PR DESCRIPTION
As discussed in #1461 there is a memory leak in `mcdetector_statistics`, and it appears that only the case where `this_p1` is assigned is a problem. This was not very clear when looking at the code because it looks like the triple-`AND` `if` statement before the assignment is  doubly redundant (if `this_p1` has been assigned, the other two statements must be true).

The fix modifies `mcdetector_out_1D` to verify whether the returned `MCDETECTOR` structure has the same `p1` pointer,
and frees the memory allocated in the call to `mcdetector_statistics` if the pointers do not match.
I _think_ the returned `MCDETECTOR` from `mcdetector_out_1D` is not used anywhere (so that the lost 'statistics' calculation result is not missed), but I can not guarantee that to be true.

The function is used (or defined) in 
```shell
./common/lib/share/read_table-lib.c
./common/lib/share/mccode-r.h.in
./common/lib/share/mccode-r.c
./mcstas-comps/examples/BTsimple.instr
./mcstas-comps/share/monitor_nd-lib.c
./mcstas-comps/share/monitor_nd_noacc-lib.c
./mcstas/src/mcformat.c.in
./mcxtrace-comps/share/monitor_nd-lib.c
./mcxtrace/src/mcformat.c.in
```
which should be checked for use of the `MCDETECTOR` returned from `mcdtector_out_1D` before accepting this PR.