### PR TITLE
[Fix] Metadata issues

### DIFF
--- a/common/lib/share/mccode-r.c
+++ b/common/lib/share/mccode-r.c
@@ -3950,11 +3950,10 @@ mchelp(char *pgmname)
 "  -h        --help           Show this help message.\n"
 "  -i        --info           Detailed instrument information.\n"
 "  --list-parameters          Print the instrument parameters to standard out\n"
-"  --metadata-list            Print names of components which defined metadata\n"
-"  --metadata-defined COMP{::NAME}\n"
-"                             Print component defined metadata text names\n"
-"  --metadata-type COMP::NAME Print metadata text type specified in definition\n"
-"  --metadata COMP::NAME      Print the metadata text\n"
+"  --meta-list                Print names of components which defined metadata\n"
+"  --meta-defined COMP[:NAME] Print component defined metadata names, or (0,1) if NAME provided\n"
+"  --meta-type COMP:NAME      Print metadata format type specified in definition\n"
+"  --meta-data COMP:NAME      Print the metadata text\n"
 "  --source                   Show the instrument code which was compiled.\n"
 #ifdef OPENACC
 "\n"
@@ -4205,19 +4204,20 @@ mcparseoptions(int argc, char *argv[])
       mcinfo();
     else if (!strcmp("--list-parameters", argv[i]))
       mcparameterinfo();
-    else if (!strcmp("--metadata-list", argv[i]) && ((i+1) >= argc || argv[i+1][0] == '-')){
+    else if (!strcmp("--meta-list", argv[i]) && ((i+1) >= argc || argv[i+1][0] == '-')){
+      //printf("Components with metadata defined:\n");
       exit(metadata_table_print_all_components(num_metadata, metadata_table) == 0);
     }
-    else if (!strcmp("--metadata-defined", argv[i]) && (i+1) < argc){
+    else if (!strcmp("--meta-defined", argv[i]) && (i+1) < argc){
       exit(metadata_table_print_component_keys(num_metadata, metadata_table, argv[i+1]) == 0);
     }
-    else if (!strcmp("--metadata-type", argv[i]) && (i+1) < argc){
+    else if (!strcmp("--meta-type", argv[i]) && (i+1) < argc){
       char * literal_type = metadata_table_type(num_metadata, metadata_table, argv[i+1]);
       if (literal_type == NULL) exit(1);
       printf("%s\n", literal_type);
       exit(0);
     }
-    else if (!strcmp("--metadata", argv[i]) && (i+1) < argc){
+    else if (!strcmp("--meta-data", argv[i]) && (i+1) < argc){
       char * literal = metadata_table_literal(num_metadata, metadata_table, argv[i+1]);
       if (literal == NULL) exit(1);
       printf("%s\n", literal);

--- a/common/lib/share/metadata-r.c
+++ b/common/lib/share/metadata-r.c
@@ -8,25 +8,27 @@ char * metadata_table_key_component(char* key){
   if (strlen(key) == 0) return NULL;
   char sep[2] = ":\0"; // matches any number of repeated colons
   // look for the separator in the provided key; strtok is allowed to modify the string, so copy it
-  char * tokkey = strdup(key);
-  char * pch = strtok(tokkey, sep); // this *is* the component name (if provided) -- but we need to move the pointer
+  char * tok = malloc((strlen(key) + 1) * sizeof(char));
+  strcpy(tok, key);
+  char * pch = strtok(tok, sep); // this *is* the component name (if provided) -- but we need to move the pointer
   char * comp = malloc((1 + strlen(pch)) * sizeof(char));
   strcpy(comp, pch);
-  if (tokkey) free(tokkey);
+  if (tok) free(tok);
   return comp;
 }
 char * metadata_table_key_literal(char * key){
   if (strlen(key) == 0) return NULL;
   char sep[3] = ":\0";
-  char * tokkey = strdup(key);
-  char * pch = strtok(tokkey, sep); // this *is* the component name (if provided)
+  char * tok = malloc((strlen(key) + 1 ) * sizeof(char));
+  strcpy(tok, key);
+  char * pch = strtok(tok, sep); // this *is* the component name (if provided)
   if (pch) pch = strtok(NULL, sep); // either NULL or the literal name
   char * name = NULL;
   if (pch) {
     name = malloc((1 + strlen(pch)) * sizeof(char));
     strcpy(name, pch);
   }
-  if (tokkey) free(tokkey);
+  if (tok) free(tok);
   return name;
 }
 int metadata_table_defined(int no, metadata_table_t * tab, char * key){

--- a/common/lib/share/metadata-r.c
+++ b/common/lib/share/metadata-r.c
@@ -95,22 +95,21 @@ void metadata_table_print_all_keys(int no, metadata_table_t * tab){
 }
 int metadata_table_print_all_components(int no, metadata_table_t * tab){
   int count = 0;
-  char ** used = malloc(no + sizeof(char*));
+  char ** known = malloc(no * sizeof(char*));
   for (int i=0; i<no; ++i){
-    int unused = 1;
-    for (int j=0; j<count; ++j){
-      if (!strcmp(tab[i].source, used[j])) {
-        unused = 0;
-        break;
-      }
-    }
-    if (unused) {
-      printf("%s ", tab[i].source);
-      used[count++] = tab[i].source;
-    }
+    int unknown = 1;
+    for (int j=0; j<count; ++j) if (!strcmp(tab[i].source, known[j])) unknown = 0;
+    if (unknown) known[count++] = tab[i].source;
   }
-  printf("\n");
-  if (used) free(used);
+  size_t nchar = 0;
+  for (int i=0; i<count; ++i) nchar += strlen(known[i]) + 1;
+  char * line = malloc((nchar + 1) * sizeof(char));
+  line[0] = '\0';
+  for (int i=0; i<count; ++i) sprintf(line, "%s%s ", line, known[i]);
+  line[strlen(line)] = '\0'; // eat the trailing space
+  printf("%s\n", line);
+  free(line);
+  free(known);
   return count;
 }
 int metadata_table_print_component_keys(int no, metadata_table_t * tab, char * key){

--- a/mcstas/src/list.c
+++ b/mcstas/src/list.c
@@ -218,3 +218,19 @@ struct List_header * list_cat(struct List_header * l1, struct List_header * l2)
   list_iterate_end(liter);
   return(l1);
 }
+
+
+List list_copy(List from, void * (*copier)(void *)){
+  List to = list_create();
+  if (list_len(from)) {
+    List_handle liter;
+    void *list_item;
+    liter = list_iterate(from);
+    while ((list_item = list_next(liter))) {
+      void *copy = copier(list_item);
+      list_add(to, copy);
+    }
+    list_iterate_end(liter);
+  }
+  return to;
+}

--- a/mcstas/src/mccode.h.in
+++ b/mcstas/src/mccode.h.in
@@ -152,6 +152,8 @@ void *list_next(List_handle);       /* Get next element in list. */
 void *list_previous(List_handle);       /* Get previous element in list. */
 void list_iterate_end(List_handle); /* End list traversal. */
 int list_undef(List l);
+List list_cat(List l1, List l2);
+List list_copy(List, void * (*)(void *));
 
 /*******************************************************************************
 * Definitions for cexp.c
@@ -564,5 +566,7 @@ int metadata_construct_table(instr_ptr_t);
 void metadata_assign_source(List, char *);
 void metadata_overwrite_source(List, char *);
 Symtab metadata_separate_by_source(List metadata, int source_type);
+struct metadata_struct * metadata_copy(struct metadata_struct *);
+List metadata_list_copy(List from);
 
 #endif /* MCCODE_H */

--- a/mcstas/src/metadata.c
+++ b/mcstas/src/metadata.c
@@ -126,3 +126,25 @@ Symtab metadata_separate_by_source(List metadata, int source_type){
   }
   return sources;
 }
+
+struct metadata_struct * metadata_copy(struct metadata_struct * from){
+  struct metadata_struct * to;
+  palloc(to);
+  to->instance = from->instance;
+  to->source = from->source == NULL ? NULL : strdup(from->source);
+  to->name = from->name == NULL ? NULL : strdup(from->name);
+  to->type = from->type == NULL ? NULL : strdup(from->type);
+  // No need to *copy* the lines themselves, since they're not modified at any point.
+  to->lines = list_create();
+  if (list_len(from->lines)) list_cat(to->lines, from->lines);
+  return to;
+}
+
+void * _void_metadata_copy_void(void * from){
+  void * to = (void *) metadata_copy((struct metadata_struct *) from);
+  return to;
+}
+
+List metadata_list_copy(List from){
+  return list_copy(from, _void_metadata_copy_void);
+}

--- a/tools/Python/mcrun/mccode.py
+++ b/tools/Python/mcrun/mccode.py
@@ -233,7 +233,7 @@ class McStas:
 
         # Handle proxy options with values
         proxy_opts_val = ['seed', 'ncount', 'dir', 'format','vecsize','numgangs','gpu_innerloop','bufsiz']
-        proxy_opts_val.extend(('metadata-defined', 'metadata-type', 'metadata'))
+        proxy_opts_val.extend(('meta-defined', 'meta-type', 'meta-data'))
         for opt in proxy_opts_val:
             # try extra_opts before options
             default = getattr(options, opt.replace('-', '_'))
@@ -242,7 +242,7 @@ class McStas:
                 args.extend(['--%s' % opt, str(val)])
 
         # Handle proxy options without values (flags)
-        proxy_opts_flags = ['trace', 'no-output-files', 'info', 'list-parameters', 'metadata-list']
+        proxy_opts_flags = ['trace', 'no-output-files', 'info', 'list-parameters', 'meta-list']
         if (mccode_config.configuration["MCCODE"]=='mcstas'):
            proxy_opts_flags.append('gravitation')
 

--- a/tools/Python/mcrun/mcrun.py
+++ b/tools/Python/mcrun/mcrun.py
@@ -458,7 +458,7 @@ def main():
     LOG.info('===')
 
     if options.info or options.list_parameters or\
-            options.metadata_list or options.metadata_defined or options.metadata_type or options.metadata:
+            options.meta_list or options.meta_defined or options.meta_type or options.meta_data:
         mcstas.run(override_mpi=False)
         exit()
 

--- a/tools/Python/mcrun/mcrun.py
+++ b/tools/Python/mcrun/mcrun.py
@@ -286,10 +286,10 @@ def add_mcstas_options(parser):
     add('--list-parameters', action='store_true', default=False,
         help='Print the instrument parameters to standard out')
 
-    add('--metadata-list', action='store_true', default=False, help='Print all metadata defining component names')
-    add('--metadata-defined', default=None, help="Print metadatas for component, or indicate if component:name exists")
-    add('--metadata-type', default=None, help="Print metadata type for component:name")
-    add('--metadata', default=None, help="Print metadata for component:name")
+    add('--meta-list', action='store_true', default=False, help='Print all metadata defining component names')
+    add('--meta-defined', default=None, help="Print metadata names for component, or indicate if component:name exists")
+    add('--meta-type', default=None, help="Print metadata type for component:name")
+    add('--meta-data', default=None, help="Print metadata for component:name")
 
     parser.add_option_group(opt)
 


### PR DESCRIPTION
- Metadata added in the component definition was added to the instances of the component as expected, but only its pointer was copied. This meant that all instances *shared* the same underlying data structure and, e.g., printing the metadata names for one of the components would either show multiple copies of the component-defined metadata or none.
- Instantiating or COPYing an instantiated component now *copies* the metadata list, including copying the 'source', 'name', and 'type' strings. The underlying 'List' of metadata `lines` is still shared between instances, which seems like the correct behavior.

- Printing the list of components which defined metadata had a memory allocation error. This could lead to printing of weird characters.
- The correct amount of memory is now allocated to track 'known' component names, and the printing is moved to a single `printf` call.

- Metadata _should_ provide a MIME type (and not just a file extension) this requires allowing the first element following METADATA to be a a string, since MIME types include a forward slash and may include other non-idenifier-allowed characters.
- The name of the metadata may require non-identifier characters in the future, to allow for more-flexible identification of metadata origins or expected use cases.
- To address these uses, a piece of metadata can now be created using METADATA id id, METADATA string id, METADATA id string, or METADATA string string.
- If the name is specified as a string, it will be recorded with its double quotes and escaped to be a valid C char* style string literal. This requires use of the same escaping to retrieve the metadata from the compiled instrument.