### PR TITLE
Single crystal PG powder fix

### DIFF
--- a/mcstas-comps/samples/Single_crystal.comp
+++ b/mcstas-comps/samples/Single_crystal.comp
@@ -1396,10 +1396,10 @@ TRACE
         && fabs(kiz - hkl_info.kiz) < deltak) {
         hkl_info.nb_reuses++;
 
-	    /* Restore in case of matching event (e.g. SPLIT) */
-	    coh_refl = hkl_info.coh_refl;
+	/* Restore in case of matching event (e.g. SPLIT) */
+	coh_refl = hkl_info.coh_refl;
         coh_xsect = hkl_info.coh_xsect;
-	    tau_count = hkl_info.tau_count;
+	tau_count = hkl_info.tau_count;
 
       } else {
 #endif
@@ -1457,10 +1457,10 @@ TRACE
       }
 
       if (force_transmit) {
-	    /* Exit due to truncated order, weight with relevant cross-sections to distance l_full */
-	    p*=exp(-abs_xlen*l_full);
+	/* Exit due to truncated order, weight with relevant cross-sections to distance l_full */
+	p*=exp(-abs_xlen*l_full);
         intersect=0; 
-	    break;
+	break;
       }
       
       /* (5). Transmission */
@@ -1553,10 +1553,10 @@ TRACE
         vy = kiy;
         vz = kiz; /* Go for next scattering event */
 	
-	    type = 'i';
-	    if (!itype) itype = 2;
+	type = 'i';
+	if (!itype) itype = 2;
 #ifndef OPENACC
-         hkl_info.type = type;
+        hkl_info.type = type;
 #endif
       } else {
         /* 7. Coherent scattering. Select reciprocal lattice point. */
@@ -1632,7 +1632,7 @@ TRACE
         randderotate(&vx, &vy, &vz, Alpha, Beta, Gamma);
       }
       if (PG) { /* orientation of crystallite is longer random */
-	    PGderotate(&vx, &vy, &vz, Alpha, hkl_info.csx, hkl_info.csy, hkl_info.csz);
+	PGderotate(&vx, &vy, &vz, Alpha, hkl_info.csx, hkl_info.csy, hkl_info.csz);
       }
       /* exit if multiple scattering order has been reached */
       if (order && event_counter >= order) { force_transmit=1; }

--- a/mcstas-comps/samples/Single_crystal.comp
+++ b/mcstas-comps/samples/Single_crystal.comp
@@ -1337,11 +1337,11 @@ TRACE
         randrotate(&vx, &vy, &vz, Alpha, Beta, Gamma);
       }
       if (PG) { /* orientation of crystallite is random along <c> axis */
-	    Alpha = randpm1()*PI*PG;
+	Alpha = randpm1()*PI*PG;
         component_vx = vx;
         component_vy = vy;
         component_vz = vz;
-	    PGrotate(&vx, &vy, &vz, Alpha, hkl_info.csx, hkl_info.csy, hkl_info.csz);
+	PGrotate(&vx, &vy, &vz, Alpha, hkl_info.csx, hkl_info.csy, hkl_info.csz);
       }
 
 
@@ -1555,9 +1555,9 @@ TRACE
 	
 	    type = 'i';
 	    if (!itype) itype = 2;
-        #ifndef OPENACC
+#ifndef OPENACC
          hkl_info.type = type;
-        #endif
+#endif
       } else {
         /* 7. Coherent scattering. Select reciprocal lattice point. */
         if(coh_refl <= 0){
@@ -1567,12 +1567,12 @@ TRACE
         j = hkl_select(T, tau_count, coh_refl, &sum,_particle);
         if(j >= tau_count)
         {
-        #ifndef OPENACC
+#ifndef OPENACC
           if (hkl_info.flag_warning < 100)
             fprintf(stderr, "Single_crystal: Error: Illegal tau search "
               "(sum=%g, j=%i, tau_count=%i).\n", sum, j , tau_count);
           hkl_info.flag_warning++;
-        #endif
+#endif
           j = tau_count - 1;
         }
         i = T[j].index;

--- a/mcstas-comps/samples/Single_crystal.comp
+++ b/mcstas-comps/samples/Single_crystal.comp
@@ -1237,6 +1237,11 @@ TRACE
   double _vy;
   double _vz;
 
+  double component_vx;          /* velocities not rotated by Powder / PG for non-rotated propagation*/
+  double component_vy;
+  double component_vz;
+    
+
   char   type;      /* type of last event: t=transmit,c=coherent or i=incoherent */
   int    itype;     /* type of last event: t=1,c=2 or i=3 */
 
@@ -1326,11 +1331,17 @@ TRACE
         Alpha = randpm1()*PI*powder;
         Beta  = randpm1()*PI/2;
         Gamma = randpm1()*PI;
+        component_vx = vx;
+        component_vy = vy;
+        component_vz = vz;
         randrotate(&vx, &vy, &vz, Alpha, Beta, Gamma);
       }
       if (PG) { /* orientation of crystallite is random along <c> axis */
-	Alpha = randpm1()*PI*PG;
-	PGrotate(&vx, &vy, &vz, Alpha, hkl_info.csx, hkl_info.csy, hkl_info.csz);
+	    Alpha = randpm1()*PI*PG;
+        component_vx = vx;
+        component_vy = vy;
+        component_vz = vz;
+	    PGrotate(&vx, &vy, &vz, Alpha, hkl_info.csx, hkl_info.csy, hkl_info.csz);
       }
 
 
@@ -1385,10 +1396,10 @@ TRACE
         && fabs(kiz - hkl_info.kiz) < deltak) {
         hkl_info.nb_reuses++;
 
-	/* Restore in case of matching event (e.g. SPLIT) */
-	coh_refl = hkl_info.coh_refl;
+	    /* Restore in case of matching event (e.g. SPLIT) */
+	    coh_refl = hkl_info.coh_refl;
         coh_xsect = hkl_info.coh_xsect;
-	tau_count = hkl_info.tau_count;
+	    tau_count = hkl_info.tau_count;
 
       } else {
 #endif
@@ -1446,10 +1457,10 @@ TRACE
       }
 
       if (force_transmit) {
-	/* Exit due to truncated order, weight with relevant cross-sections to distance l_full */
-	 p*=exp(-abs_xlen*l_full);
+	    /* Exit due to truncated order, weight with relevant cross-sections to distance l_full */
+	    p*=exp(-abs_xlen*l_full);
         intersect=0; 
-	 break;
+	    break;
       }
       
       /* (5). Transmission */
@@ -1471,10 +1482,10 @@ TRACE
           PGderotate(&vx, &vy, &vz, Alpha, hkl_info.csx, hkl_info.csy, hkl_info.csz);
         }
 
-	type = 't';
-	if (!itype) itype = 1;
+        type = 't';
+	    if (!itype) itype = 1;
         #ifndef OPENACC
-	hkl_info.type = type;
+	      hkl_info.type = type;
         #endif
 
         break; 
@@ -1510,9 +1521,26 @@ TRACE
       else
         l = -log(1 - rand0max((1 - exp(-tot_xlen*l_full))))/tot_xlen;
  
+      if (PG || powder) {
+        /* If PG or powder mode, we need to propagate the neutron in the component frame instead of the crystalite frame*/
+        _vx = vx;
+        _vy = vy;
+        _vz = vz;
+        vx = component_vx;
+        vy = component_vy;
+        vz = component_vz;
+      }
+    
       /* Propagate to scattering point */
       PROP_DT(l/v);
       event_counter++;
+    
+      if (PG || powder) {
+        /* In case of PG or powder return to crystalite frame after propagation */
+        vx = _vx;
+        vy = _vy;
+        vz = _vz;
+      }
 
       /* (4). Account for the probability of sigma_abs */
       p *= (coh_xlen + inc_xlen)/tot_xlen;
@@ -1525,11 +1553,11 @@ TRACE
         vy = kiy;
         vz = kiz; /* Go for next scattering event */
 	
-	type = 'i';
-	if (!itype) itype = 2;
-#ifndef OPENACC
-        hkl_info.type = type;
-#endif
+	    type = 'i';
+	    if (!itype) itype = 2;
+        #ifndef OPENACC
+         hkl_info.type = type;
+        #endif
       } else {
         /* 7. Coherent scattering. Select reciprocal lattice point. */
         if(coh_refl <= 0){
@@ -1539,12 +1567,12 @@ TRACE
         j = hkl_select(T, tau_count, coh_refl, &sum,_particle);
         if(j >= tau_count)
         {
-#ifndef OPENACC
+        #ifndef OPENACC
           if (hkl_info.flag_warning < 100)
             fprintf(stderr, "Single_crystal: Error: Illegal tau search "
               "(sum=%g, j=%i, tau_count=%i).\n", sum, j , tau_count);
           hkl_info.flag_warning++;
-#endif
+        #endif
           j = tau_count - 1;
         }
         i = T[j].index;
@@ -1604,7 +1632,7 @@ TRACE
         randderotate(&vx, &vy, &vz, Alpha, Beta, Gamma);
       }
       if (PG) { /* orientation of crystallite is longer random */
-	PGderotate(&vx, &vy, &vz, Alpha, hkl_info.csx, hkl_info.csy, hkl_info.csz);
+	    PGderotate(&vx, &vy, &vz, Alpha, hkl_info.csx, hkl_info.csy, hkl_info.csz);
       }
       /* exit if multiple scattering order has been reached */
       if (order && event_counter >= order) { force_transmit=1; }

--- a/mcstas-comps/union/Single_crystal_process.comp
+++ b/mcstas-comps/union/Single_crystal_process.comp
@@ -719,16 +719,18 @@ SHARE
 
     /* Functions for "reorientation", powder and PG modes */
     /* Powder, forward */
-    void randrotate_union(double *nx, double *ny, double *nz, double a, double b) {
-      double nvx, nvy, nvz;
-      rotate(nvx,nvy,nvz, *nx, *ny, *nz, a, 1, 0, 0);
-      rotate(*nx,*ny,*nz, nvx,nvy,nvz, b, 0, 1, 0);
+    void randrotate_union(double *nx, double *ny, double *nz, double a, double b, double c) {
+      double x1, y1, z1, x2, y2, z2;
+      rotate(x1, y1, z1, *nx,*ny,*nz, a, 1, 0, 0); /* <1> = rot(<n>,a) */
+      rotate(x2, y2, z2,  x1, y1, z1, b, 0, 1, 0); /* <2> = rot(<1>,b) */
+      rotate(*nx,*ny,*nz, x2, y2, z2, c, 0, 0, 1); /* <n> = rot(<2>,c) */
     }
     /* Powder, back */
-    void randderotate_union(double *nx, double *ny, double *nz, double a, double b) {
-      double nvx, nvy, nvz;
-      rotate(nvx,nvy,nvz,*nx,*ny,*nz, -b, 0, 1, 0);
-      rotate(*nx, *ny, *nz, nvx,nvy,nvz, -a, 1, 0, 0);
+    void randderotate_union(double *nx, double *ny, double *nz, double a, double b, double c) {
+      double x1, y1, z1, x2, y2, z2;
+      rotate(x1, y1, z1, *nx,*ny,*nz, -c, 0,0,1);
+      rotate(x2, y2, z2,  x1, y1, z1, -b, 0,1,0);
+      rotate(*nx,*ny,*nz, x2, y2, z2, -a, 1,0,0);
     }
     /* PG, forward */
     void PGrotate_union(double *nx, double *ny, double *nz, double a, double csx, double csy, double csz) {
@@ -760,6 +762,7 @@ struct Single_crystal_physics_storage_struct{
     double powder_setting; // 0 if powder mode is disabled, 1 if enabled. Values between approximates texture?
     double Alpha;          // random angle between 0 and 2*Pi*powder
     double Beta;           // random angle between -Pi/2 and Pi/2
+    double Gamma;           // random angle between -Pi and Pi
     
     struct hkl_info_struct_union *hkl_info_storage; // struct containing all necessary info for SC
     double pack; // packing factor
@@ -775,8 +778,6 @@ int Single_crystal_physics_my(double *my, double *k_initial, union data_transfer
     
     struct hkl_info_struct_union *hkl_info = data_transfer.pointer_to_a_Single_crystal_physics_storage_struct->hkl_info_storage;
     
-    // Need the Powder/PG/curvature mode rotate added here
-    
     // Taken from Single_crystal and changed hkl_info to a pointer.
     // The split optimization is less useful here than normally
     
@@ -784,10 +785,12 @@ int Single_crystal_physics_my(double *my, double *k_initial, union data_transfer
       //orientation of crystallite is random
 	  data_transfer.pointer_to_a_Single_crystal_physics_storage_struct->Alpha = randpm1()*PI*data_transfer.pointer_to_a_Single_crystal_physics_storage_struct->powder_setting;
 	  data_transfer.pointer_to_a_Single_crystal_physics_storage_struct->Beta = randpm1()*PI/2;
+      data_transfer.pointer_to_a_Single_crystal_physics_storage_struct->Gamma = randpm1()*PI;
       
 	  randrotate_union(&kix, &kiy, &kiz,
         data_transfer.pointer_to_a_Single_crystal_physics_storage_struct->Alpha,
-        data_transfer.pointer_to_a_Single_crystal_physics_storage_struct->Beta);
+        data_transfer.pointer_to_a_Single_crystal_physics_storage_struct->Beta,
+        data_transfer.pointer_to_a_Single_crystal_physics_storage_struct->Gamma);
     }
     if (data_transfer.pointer_to_a_Single_crystal_physics_storage_struct->PG_setting) {
       // orientation of crystallite is random
@@ -831,8 +834,6 @@ int Single_crystal_physics_my(double *my, double *k_initial, union data_transfer
         hkl_info->coh_xsect = coh_xsect;
         hkl_info->nb_refl += hkl_info->tau_count;
         hkl_info->nb_refl_count++;
-        
-        
       }
 
       /* (3). Probabilities of the different possible interactions. */
@@ -925,7 +926,10 @@ int Single_crystal_physics_scattering(double *k_final, double *k_initial, double
     
     if (data_transfer.pointer_to_a_Single_crystal_physics_storage_struct->powder_setting) {
       // orientation of crystallite is no longer random
-	  randderotate_union(&k_final[0], &k_final[1], &k_final[2], data_transfer.pointer_to_a_Single_crystal_physics_storage_struct->Alpha, data_transfer.pointer_to_a_Single_crystal_physics_storage_struct->Beta);
+	  randderotate_union(&k_final[0], &k_final[1], &k_final[2],
+                         data_transfer.pointer_to_a_Single_crystal_physics_storage_struct->Alpha,
+                         data_transfer.pointer_to_a_Single_crystal_physics_storage_struct->Beta,
+                         data_transfer.pointer_to_a_Single_crystal_physics_storage_struct->Gamma);
     }
     if (data_transfer.pointer_to_a_Single_crystal_physics_storage_struct->PG_setting) {
       // orientation of crystallite is longer random


### PR DESCRIPTION
The PG and powder mode for the Single_crystal component rotates the neutron velocities randomly to simulate the random orientation of crystallites. This change of coordinate system was not reverted when propagating the neutron to the scattering position inside of the crystal, and it could thus happen the ray was moved outside of the crystal.

The code was fixed by storing and using the velocity in the component frame and using that just for the propagation when one of the two modes are used.

The Single_crystal_process in Union was checked for the same problem, it was not relevant in that implementation, but other updates the powder system was moved to the Union equivalent, as it now rotates around three directions instead of just two, which is necessary to make a completely random crystal orientation in the powder.