### PR TITLE
Implement richer McStas CI test in a GitHub workflow

### DIFF
--- a/.github/workflows/basictest.yml
+++ b/.github/workflows/basictest.yml
@@ -92,8 +92,12 @@ jobs:
                ${EXTRA_ARGS_FOR_CMAKE}
            cmake --build . --config Release
            cmake --build . --target install --config Release
-           test -f "../install_mcstas/bin/mcstas"
-           test -f "../install_mcstas/bin/mcrun"
+           export MCSTAS_EXECUTABLE="mcstas"
+           if [ "x$(uname | cut -f1 -d_)" == "xMINGW64" ]; then export MCSTAS_EXECUTABLE="mcstas.exe"; fi
+           test -f "../install_mcstas/bin/${MCSTAS_EXECUTABLE}"
+           export MCRUN_EXECUTABLE="mcrun"
+           if [ "x$(uname | cut -f1 -d_)" == "xMINGW64" ]; then export MCRUN_EXECUTABLE="mcrun.bat"; fi
+           test -f "../install_mcstas/bin/${MCRUN_EXECUTABLE}"
            test -f "../install_mcstas/share/mcstas/tools/Python/mccodelib/__init__.py"
            test -d "../install_mcstas/share/mcstas/resources/data"
 
@@ -109,13 +113,13 @@ jobs:
            set -e
            set -u
            set -x
-           test -f ./install_mcstas/bin/mcstas
+           test -f ./install_mcstas/bin/${MCSTAS_EXECUTABLE}
            ./install_mcstas/bin/mcstas --version
            mkdir run_BNL_H8 && cd run_BNL_H8
            cp ../install_mcstas/share/mcstas/resources/examples/BNL_H8.instr .
            #Not a final solution!!!:
            if [ "x$(uname)" == "xDarwin" ]; then export MCSTAS_CC_OVERRIDE=/usr/bin/clang; fi
-           ../install_mcstas/bin/mcrun BNL_H8.instr lambda=2.36
+           ../install_mcstas/bin/${MCRUN_EXECUTABLE} BNL_H8.instr lambda=2.36
 
     - name: Setup tmate session for manual debugging
       uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/basictest.yml
+++ b/.github/workflows/basictest.yml
@@ -52,6 +52,7 @@ jobs:
       run: |
            if [ "x$(uname)" == "xDarwin" ]; then brew install bison flex; fi
            if [ "x$(uname | cut -f1 -d_)" == "xMINGW64" ]; then choco install winflexbison; fi
+
     - name: Check versions
       run: |
            which python3
@@ -86,7 +87,7 @@ jobs:
                -DMCCODE_USE_LEGACY_DESTINATIONS=OFF \
                -DBUILD_TOOLS=ON \
                -DENABLE_COMPONENTS=ON \
-               -DENSURE_MCPL=OFF \
+               -DENSURE_MCPL=ON \
                -DENSURE_NCRYSTAL=OFF \
                -DENABLE_CIF2HKL=OFF \
                -DENABLE_NEUTRONICS=OFF \
@@ -111,7 +112,6 @@ jobs:
            set -u
            set -x
            python3 -mpip install PyYAML
-           python3 -mpip install mcpl
            if [ "x$(uname | cut -f1 -d_)" != "xMINGW64" ];
            then
              python3 -mpip install ncrystal
@@ -124,6 +124,9 @@ jobs:
            set -x
            export MCSTAS_EXECUTABLE="mcstas"
            export MCRUN_EXECUTABLE="mcrun"
+           export PATH=${PATH}:${PWD}/install_mcstas/bin/:${PWD}/install_mcstas/mcstas/3.99.99/bin/
+           which mcpl-config
+           find . -name mcpl-config
            if [ "x$(uname | cut -f1 -d_)" == "xMINGW64" ];
            then
              export MCSTAS_EXECUTABLE="mcstas.exe"
@@ -140,8 +143,8 @@ jobs:
            ../install_mcstas/bin/${MCRUN_EXECUTABLE} BNL_H8.instr lambda=2.36
            if [ "x$(uname | cut -f1 -d_)" != "xMINGW64" ];
            then
-             #../install_mcstas/bin/${MCRUN_EXECUTABLE} ESS_BEER_MCPL.instr repetition=50
-            ../install_mcstas/bin/${MCRUN_EXECUTABLE} NCrystal_example.instr sample_cfg=""Y2O3_sg206_Yttrium_Oxide.ncmat\;density=0.6x"
+            ../install_mcstas/bin/${MCRUN_EXECUTABLE} ESS_BEER_MCPL.instr repetition=50
+            ../install_mcstas/bin/${MCRUN_EXECUTABLE} NCrystal_example.instr sample_cfg="Y2O3_sg206_Yttrium_Oxide.ncmat\;density=0.6x"
            fi
 
     - name: Setup tmate session for manual debugging

--- a/.github/workflows/basictest.yml
+++ b/.github/workflows/basictest.yml
@@ -105,12 +105,17 @@ jobs:
            test -f "../install_mcstas/share/mcstas/tools/Python/mccodelib/__init__.py"
            test -d "../install_mcstas/share/mcstas/resources/data"
 
-    - name: Pip install PyYAML
+    - name: Pip install various
       run: |
            set -e
            set -u
            set -x
            python3 -mpip install PyYAML
+           python3 -mpip install mcpl
+           if [ "x$(uname | cut -f1 -d_)" != "xMINGW64" ];
+           then
+             python3 -mpip install ncrystal
+           fi
 
     - name: Launch test instrument
       run: |
@@ -128,9 +133,16 @@ jobs:
            ./install_mcstas/bin/${MCSTAS_EXECUTABLE} --version
            mkdir run_BNL_H8 && cd run_BNL_H8
            cp ../install_mcstas/share/mcstas/resources/examples/BNL_H8.instr .
+           cp ../install_mcstas/share/mcstas/resources/examples/ESS_BEER_MCPL.instr .
+           cp ../install_mcstas/share/mcstas/resources/examples/NCrystal_example.instr .
            #Not a final solution!!!:
            if [ "x$(uname)" == "xDarwin" ]; then export MCSTAS_CC_OVERRIDE=/usr/bin/clang; fi
            ../install_mcstas/bin/${MCRUN_EXECUTABLE} BNL_H8.instr lambda=2.36
+           if [ "x$(uname | cut -f1 -d_)" != "xMINGW64" ];
+           then
+             #../install_mcstas/bin/${MCRUN_EXECUTABLE} ESS_BEER_MCPL.instr repetition=50
+            ../install_mcstas/bin/${MCRUN_EXECUTABLE} NCrystal_example.instr sample_cfg=""Y2O3_sg206_Yttrium_Oxide.ncmat\;density=0.6x"
+           fi
 
     - name: Setup tmate session for manual debugging
       uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/basictest.yml
+++ b/.github/workflows/basictest.yml
@@ -26,6 +26,7 @@ jobs:
           - { os: macos-12,      CC: clang,    CXX: clang++,    python: "3.11" }
           - { os: macos-13,      CC: clang,    CXX: clang++,    python: "3.11" }
           - { os: windows-latest,  CC: gcc,    CXX: g++,        python: "3.11" }
+          - { os: windows-2019,    CC: gcc,    CXX: g++,        python: "3.11" }
 
     name: ${{ matrix.os }}.${{ matrix.CC }}.python-${{ matrix.python }}
     runs-on: ${{ matrix.os }}
@@ -93,10 +94,13 @@ jobs:
            cmake --build . --config Release
            cmake --build . --target install --config Release
            export MCSTAS_EXECUTABLE="mcstas"
-           if [ "x$(uname | cut -f1 -d_)" == "xMINGW64" ]; then export MCSTAS_EXECUTABLE="mcstas.exe"; fi
-           test -f "../install_mcstas/bin/${MCSTAS_EXECUTABLE}"
            export MCRUN_EXECUTABLE="mcrun"
-           if [ "x$(uname | cut -f1 -d_)" == "xMINGW64" ]; then export MCRUN_EXECUTABLE="mcrun.bat"; fi
+           if [ "x$(uname | cut -f1 -d_)" == "xMINGW64" ];
+           then
+             export MCSTAS_EXECUTABLE="mcstas.exe"
+             export MCRUN_EXECUTABLE="mcrun.bat"
+           fi
+           test -f "../install_mcstas/bin/${MCSTAS_EXECUTABLE}"
            test -f "../install_mcstas/bin/${MCRUN_EXECUTABLE}"
            test -f "../install_mcstas/share/mcstas/tools/Python/mccodelib/__init__.py"
            test -d "../install_mcstas/share/mcstas/resources/data"
@@ -114,16 +118,18 @@ jobs:
            set -u
            set -x
            export MCSTAS_EXECUTABLE="mcstas"
-           if [ "x$(uname | cut -f1 -d_)" == "xMINGW64" ]; then export MCSTAS_EXECUTABLE="mcstas.exe"; fi
+           export MCRUN_EXECUTABLE="mcrun"
+           if [ "x$(uname | cut -f1 -d_)" == "xMINGW64" ];
+           then
+             export MCSTAS_EXECUTABLE="mcstas.exe"
+             export MCRUN_EXECUTABLE="mcrun.bat"
+           fi
            test -f ./install_mcstas/bin/${MCSTAS_EXECUTABLE}
            ./install_mcstas/bin/${MCSTAS_EXECUTABLE} --version
            mkdir run_BNL_H8 && cd run_BNL_H8
            cp ../install_mcstas/share/mcstas/resources/examples/BNL_H8.instr .
            #Not a final solution!!!:
            if [ "x$(uname)" == "xDarwin" ]; then export MCSTAS_CC_OVERRIDE=/usr/bin/clang; fi
-           if [ "x$(uname | cut -f1 -d_)" == "xMINGW64" ]; then export MCSTAS_CC_OVERRIDE=gcc; fi
-           export MCRUN_EXECUTABLE="mcrun"
-           if [ "x$(uname | cut -f1 -d_)" == "xMINGW64" ]; then export MCRUN_EXECUTABLE="mcrun.bat"; fi
            ../install_mcstas/bin/${MCRUN_EXECUTABLE} BNL_H8.instr lambda=2.36
 
     - name: Setup tmate session for manual debugging

--- a/.github/workflows/basictest.yml
+++ b/.github/workflows/basictest.yml
@@ -123,6 +123,7 @@ jobs:
            fi
 
     - name: Launch basic test instrument
+      # Status: Works on Windows + Unixes
       run: |
            set -e
            set -u
@@ -147,6 +148,7 @@ jobs:
            #python3 BNL_H8_generated.py
 
     - name: Launch MCPL test instrument
+      # Status: Works on Unixes ("wrapper batches missing for Windows")
       run: |
            set -e
            set -u
@@ -171,6 +173,7 @@ jobs:
            fi
 
     - name: Launch NCrystal test instrument
+      # Status: Works on Unixes ("ncrystal missing for Windows")
       run: |
            set -e
            set -u
@@ -195,6 +198,7 @@ jobs:
            fi
 
     - name: Launch NeXus test instrument
+      # Status: Works on Linux (NeXus packages w/napi.h missing on mac+Windows)
       run: |
            set -e
            set -u

--- a/.github/workflows/basictest.yml
+++ b/.github/workflows/basictest.yml
@@ -20,7 +20,7 @@ jobs:
           - { os: ubuntu-20.04,  CC: gcc-10,   CXX: g++-10,     python: '3.8'  }
           - { os: ubuntu-22.04,  CC: gcc,      CXX: g++,        python: '3.9'  }
           - { os: ubuntu-latest, CC: gcc,      CXX: g++,        python: '3.10' }
-          - { os: ubuntu-latest, CC: clang,    CXX: clang++,    python: '3.11' }
+#          - { os: ubuntu-latest, CC: clang,    CXX: clang++,    python: '3.11' }
           - { os: ubuntu-latest, CC: gcc-12,   CXX: g++-12,     python: '3.11' }
           - { os: macos-11,      CC: clang,    CXX: clang++,    python: "3.10" }
           - { os: macos-12,      CC: clang,    CXX: clang++,    python: "3.11" }
@@ -52,6 +52,10 @@ jobs:
       run: |
            if [ "x$(uname)" == "xDarwin" ]; then brew install bison flex; fi
            if [ "x$(uname | cut -f1 -d_)" == "xMINGW64" ]; then choco install winflexbison; fi
+
+    - name: Setup NeXus
+      run: |
+           if [ "x$(uname)" == "xLinux" ]; then sudo apt -y install libnexus-dev python3-ply; fi
 
     - name: Check versions
       run: |
@@ -138,6 +142,7 @@ jobs:
            cp ../install_mcstas/share/mcstas/resources/examples/BNL_H8.instr .
            cp ../install_mcstas/share/mcstas/resources/examples/ESS_BEER_MCPL.instr .
            cp ../install_mcstas/share/mcstas/resources/examples/NCrystal_example.instr .
+           cp ../install_mcstas/share/mcstas/resources/examples/templateSANS_Mantid.instr .
            #Not a final solution!!!:
            if [ "x$(uname)" == "xDarwin" ]; then export MCSTAS_CC_OVERRIDE=/usr/bin/clang; fi
            ../install_mcstas/bin/${MCRUN_EXECUTABLE} BNL_H8.instr lambda=2.36
@@ -145,6 +150,9 @@ jobs:
            then
             ../install_mcstas/bin/${MCRUN_EXECUTABLE} ESS_BEER_MCPL.instr repetition=50
             ../install_mcstas/bin/${MCRUN_EXECUTABLE} NCrystal_example.instr sample_cfg="Y2O3_sg206_Yttrium_Oxide.ncmat\;density=0.6x"
+             if [ "x$(uname)" == "xLinux" ]; then
+               ../install_mcstas/bin/${MCRUN_EXECUTABLE} --format=NeXus --IDF templateSANS_Mantid.instr lambda=6
+             fi
            fi
 
     - name: Setup tmate session for manual debugging

--- a/.github/workflows/basictest.yml
+++ b/.github/workflows/basictest.yml
@@ -116,7 +116,7 @@ jobs:
            set -e
            set -u
            set -x
-           python3 -mpip install PyYAML ply
+           python3 -mpip install PyYAML ply McStasscript
            if [ "x$(uname | cut -f1 -d_)" != "xMINGW64" ];
            then
              python3 -mpip install ncrystal
@@ -128,10 +128,12 @@ jobs:
            set -u
            set -x
            export MCSTAS_EXECUTABLE="mcstas"
+           export MCSTAS_PYGEN_EXECUTABLE="mcstas-pygen"
            export MCRUN_EXECUTABLE="mcrun"
            if [ "x$(uname | cut -f1 -d_)" == "xMINGW64" ];
            then
              export MCSTAS_EXECUTABLE="mcstas.exe"
+             export MCSTAS_PYGEN_EXECUTABLE="mcstas-pygen.exe"
              export MCRUN_EXECUTABLE="mcrun.bat"
            fi
            test -f ./install_mcstas/bin/${MCSTAS_EXECUTABLE}
@@ -141,6 +143,8 @@ jobs:
            #Not a final solution!!!:
            if [ "x$(uname)" == "xDarwin" ]; then export MCSTAS_CC_OVERRIDE=/usr/bin/clang; fi
            ../install_mcstas/bin/${MCRUN_EXECUTABLE} BNL_H8.instr lambda=2.36
+           ../install_mcstas/bin/${MCSTAS_PYGEN_EXECUTABLE} BNL_H8.instr
+           #python3 BNL_H8_generated.py
 
     - name: Launch MCPL test instrument
       run: |

--- a/.github/workflows/basictest.yml
+++ b/.github/workflows/basictest.yml
@@ -32,17 +32,15 @@ jobs:
     env:
       CC: ${{ matrix.CC }}
       CXX: ${{ matrix.CXX }}
+    defaults:
+      run:
+        shell: bash -el {0}
 
     steps:
     - name: Checkout
       uses: actions/checkout@v4
       with:
         path: src
-
-    - name: Windoze setup
-      if: matrix.os == 'windows-latest'
-        run: echo "::add-path::/c/msys64/mingw64/bin:/c/msys64/usr/bin"
-        shell: bash
 
     - name: Setup python
       uses: actions/setup-python@v4

--- a/.github/workflows/basictest.yml
+++ b/.github/workflows/basictest.yml
@@ -20,7 +20,7 @@ jobs:
           - { os: ubuntu-20.04,  CC: gcc-10,   CXX: g++-10,     python: '3.8'  }
           - { os: ubuntu-22.04,  CC: gcc,      CXX: g++,        python: '3.9'  }
           - { os: ubuntu-latest, CC: gcc,      CXX: g++,        python: '3.10' }
-#          - { os: ubuntu-latest, CC: clang,    CXX: clang++,    python: '3.11' }
+          - { os: ubuntu-latest, CC: clang,    CXX: clang++,    python: '3.11' }
           - { os: ubuntu-latest, CC: gcc-12,   CXX: g++-12,     python: '3.11' }
           - { os: macos-11,      CC: clang,    CXX: clang++,    python: "3.10" }
           - { os: macos-12,      CC: clang,    CXX: clang++,    python: "3.11" }
@@ -78,6 +78,7 @@ jobs:
            cd build_mcstas
            export EXTRA_ARGS_FOR_CMAKE=""
            if [ "x$(uname)" == "xDarwin" ]; then export EXTRA_ARGS_FOR_CMAKE="-DBISON_EXECUTABLE=/usr/local/opt/bison/bin/bison -DFLEX_EXECUTABLE=/usr/local/opt/flex/bin/flex"; fi
+           if [ "x$(uname)" == "xLinux" ]; then export EXTRA_ARGS_FOR_CMAKE="-DNEXUSLIB=/usr/lib -DNEXUSINCLUDE=/usr/include/nexus"; fi
            cmake \
                -DCMAKE_INSTALL_PREFIX=../install_mcstas \
                -S ../src \

--- a/.github/workflows/basictest.yml
+++ b/.github/workflows/basictest.yml
@@ -122,16 +122,13 @@ jobs:
              python3 -mpip install ncrystal
            fi
 
-    - name: Launch test instrument
+    - name: Launch basic test instrument
       run: |
            set -e
            set -u
            set -x
            export MCSTAS_EXECUTABLE="mcstas"
            export MCRUN_EXECUTABLE="mcrun"
-           export PATH=${PATH}:${PWD}/install_mcstas/bin/:${PWD}/install_mcstas/mcstas/3.99.99/bin/
-           which mcpl-config
-           find . -name mcpl-config
            if [ "x$(uname | cut -f1 -d_)" == "xMINGW64" ];
            then
              export MCSTAS_EXECUTABLE="mcstas.exe"
@@ -141,19 +138,79 @@ jobs:
            ./install_mcstas/bin/${MCSTAS_EXECUTABLE} --version
            mkdir run_BNL_H8 && cd run_BNL_H8
            cp ../install_mcstas/share/mcstas/resources/examples/BNL_H8.instr .
-           cp ../install_mcstas/share/mcstas/resources/examples/ESS_BEER_MCPL.instr .
-           cp ../install_mcstas/share/mcstas/resources/examples/NCrystal_example.instr .
-           cp ../install_mcstas/share/mcstas/resources/examples/templateSANS_Mantid.instr .
            #Not a final solution!!!:
            if [ "x$(uname)" == "xDarwin" ]; then export MCSTAS_CC_OVERRIDE=/usr/bin/clang; fi
            ../install_mcstas/bin/${MCRUN_EXECUTABLE} BNL_H8.instr lambda=2.36
+
+    - name: Launch MCPL test instrument
+      run: |
+           set -e
+           set -u
+           set -x
+           export MCSTAS_EXECUTABLE="mcstas"
+           export MCRUN_EXECUTABLE="mcrun"
+           export PATH=${PATH}:${PWD}/install_mcstas/bin/:${PWD}/install_mcstas/mcstas/3.99.99/bin/
+           if [ "x$(uname | cut -f1 -d_)" == "xMINGW64" ];
+           then
+             export MCSTAS_EXECUTABLE="mcstas.exe"
+             export MCRUN_EXECUTABLE="mcrun.bat"
+           fi
+           test -f ./install_mcstas/bin/${MCSTAS_EXECUTABLE}
+           ./install_mcstas/bin/${MCSTAS_EXECUTABLE} --version
+           mkdir run_ESS_BEER_MCPL && cd run_ESS_BEER_MCPL
+           cp ../install_mcstas/share/mcstas/resources/examples/ESS_BEER_MCPL.instr .
+           #Not a final solution!!!:
+           if [ "x$(uname)" == "xDarwin" ]; then export MCSTAS_CC_OVERRIDE=/usr/bin/clang; fi
            if [ "x$(uname | cut -f1 -d_)" != "xMINGW64" ];
            then
             ../install_mcstas/bin/${MCRUN_EXECUTABLE} ESS_BEER_MCPL.instr repetition=50
+           fi
+
+    - name: Launch NCrystal test instrument
+      run: |
+           set -e
+           set -u
+           set -x
+           export MCSTAS_EXECUTABLE="mcstas"
+           export MCRUN_EXECUTABLE="mcrun"
+           export PATH=${PATH}:${PWD}/install_mcstas/bin/:${PWD}/install_mcstas/mcstas/3.99.99/bin/
+           if [ "x$(uname | cut -f1 -d_)" == "xMINGW64" ];
+           then
+             export MCSTAS_EXECUTABLE="mcstas.exe"
+             export MCRUN_EXECUTABLE="mcrun.bat"
+           fi
+           test -f ./install_mcstas/bin/${MCSTAS_EXECUTABLE}
+           ./install_mcstas/bin/${MCSTAS_EXECUTABLE} --version
+           mkdir run_NCrystal_example && cd run_NCrystal_example
+           cp ../install_mcstas/share/mcstas/resources/examples/NCrystal_example.instr .
+           #Not a final solution!!!:
+           if [ "x$(uname)" == "xDarwin" ]; then export MCSTAS_CC_OVERRIDE=/usr/bin/clang; fi
+           if [ "x$(uname | cut -f1 -d_)" != "xMINGW64" ];
+           then
             ../install_mcstas/bin/${MCRUN_EXECUTABLE} NCrystal_example.instr sample_cfg="Y2O3_sg206_Yttrium_Oxide.ncmat\;density=0.6x"
-             if [ "x$(uname)" == "xLinux" ]; then
-               ../install_mcstas/bin/${MCRUN_EXECUTABLE} --format=NeXus --IDF templateSANS_Mantid.instr lambda=6
-             fi
+           fi
+
+    - name: Launch NeXus test instrument
+      run: |
+           set -e
+           set -u
+           set -x
+           export MCSTAS_EXECUTABLE="mcstas"
+           export MCRUN_EXECUTABLE="mcrun"
+           export PATH=${PATH}:${PWD}/install_mcstas/bin/:${PWD}/install_mcstas/mcstas/3.99.99/bin/
+           if [ "x$(uname | cut -f1 -d_)" == "xMINGW64" ];
+           then
+             export MCSTAS_EXECUTABLE="mcstas.exe"
+             export MCRUN_EXECUTABLE="mcrun.bat"
+           fi
+           test -f ./install_mcstas/bin/${MCSTAS_EXECUTABLE}
+           ./install_mcstas/bin/${MCSTAS_EXECUTABLE} --version
+           mkdir run_templateSANS_Mantid && cd run_templateSANS_Mantid
+           cp ../install_mcstas/share/mcstas/resources/examples/templateSANS_Mantid.instr .
+           #Not a final solution!!!:
+           if [ "x$(uname)" == "xDarwin" ]; then export MCSTAS_CC_OVERRIDE=/usr/bin/clang; fi
+           if [ "x$(uname)" == "xLinux" ]; then
+             ../install_mcstas/bin/${MCRUN_EXECUTABLE} --format=NeXus --IDF templateSANS_Mantid.instr lambda=6
            fi
 
     - name: Setup tmate session for manual debugging

--- a/.github/workflows/basictest.yml
+++ b/.github/workflows/basictest.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Setup Bison
       run: |
            if [ "x$(uname)" == "xDarwin" ]; then brew install bison flex; fi
-
+           if [ "x$(uname | cut -f1 -d_)" == "xMINGW64" ]; then choco install winflexbison; fi
     - name: Check versions
       run: |
            which python3

--- a/.github/workflows/basictest.yml
+++ b/.github/workflows/basictest.yml
@@ -113,12 +113,17 @@ jobs:
            set -e
            set -u
            set -x
+           export MCSTAS_EXECUTABLE="mcstas"
+           if [ "x$(uname | cut -f1 -d_)" == "xMINGW64" ]; then export MCSTAS_EXECUTABLE="mcstas.exe"; fi
            test -f ./install_mcstas/bin/${MCSTAS_EXECUTABLE}
-           ./install_mcstas/bin/mcstas --version
+           ./install_mcstas/bin/${MCSTAS_EXECUTABLE} --version
            mkdir run_BNL_H8 && cd run_BNL_H8
            cp ../install_mcstas/share/mcstas/resources/examples/BNL_H8.instr .
            #Not a final solution!!!:
            if [ "x$(uname)" == "xDarwin" ]; then export MCSTAS_CC_OVERRIDE=/usr/bin/clang; fi
+           if [ "x$(uname | cut -f1 -d_)" == "xMINGW64" ]; then export MCSTAS_CC_OVERRIDE=gcc; fi
+           export MCRUN_EXECUTABLE="mcrun"
+           if [ "x$(uname | cut -f1 -d_)" == "xMINGW64" ]; then export MCRUN_EXECUTABLE="mcrun.bat"; fi
            ../install_mcstas/bin/${MCRUN_EXECUTABLE} BNL_H8.instr lambda=2.36
 
     - name: Setup tmate session for manual debugging

--- a/.github/workflows/basictest.yml
+++ b/.github/workflows/basictest.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Setup NeXus
       run: |
-           if [ "x$(uname)" == "xLinux" ]; then sudo apt -y install libnexus-dev python3-ply; fi
+           if [ "x$(uname)" == "xLinux" ]; then sudo apt -y install libnexus-dev; fi
 
     - name: Check versions
       run: |
@@ -116,7 +116,7 @@ jobs:
            set -e
            set -u
            set -x
-           python3 -mpip install PyYAML
+           python3 -mpip install PyYAML ply
            if [ "x$(uname | cut -f1 -d_)" != "xMINGW64" ];
            then
              python3 -mpip install ncrystal

--- a/.github/workflows/basictest.yml
+++ b/.github/workflows/basictest.yml
@@ -1,5 +1,16 @@
 name: basictest
-on: push
+on:
+  push:
+  
+  schedule:
+    - cron: '30 23 * * 0'  # 23:30 every Sunday
+
+  workflow_dispatch:
+    inputs:
+      manual-debugging:
+        type: boolean
+        description: Launch manual debugging tmate session on failure
+        default: false
 
 jobs:
   build:
@@ -14,6 +25,8 @@ jobs:
           - { os: macos-11,      CC: clang,    CXX: clang++,    python: "3.10" }
           - { os: macos-12,      CC: clang,    CXX: clang++,    python: "3.11" }
           - { os: macos-13,      CC: clang,    CXX: clang++,    python: "3.11" }
+          - { os: windows-latest,  CC: gcc,    CXX: g++,        python: "3.11" }
+
     name: ${{ matrix.os }}.${{ matrix.CC }}.python-${{ matrix.python }}
     runs-on: ${{ matrix.os }}
     env:
@@ -25,6 +38,11 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: src
+
+    - name: Windoze setup
+      if: matrix.os == 'windows-latest'
+        run: echo "::add-path::/c/msys64/mingw64/bin:/c/msys64/usr/bin"
+        shell: bash
 
     - name: Setup python
       uses: actions/setup-python@v4
@@ -100,3 +118,9 @@ jobs:
            #Not a final solution!!!:
            if [ "x$(uname)" == "xDarwin" ]; then export MCSTAS_CC_OVERRIDE=/usr/bin/clang; fi
            ../install_mcstas/bin/mcrun BNL_H8.instr lambda=2.36
+
+    - name: Setup tmate session for manual debugging
+      uses: mxschmitt/action-tmate@v3
+      if: always() && inputs.manual-debugging == true && (steps.build-and-test-release-mode.outcome != 'success' || steps.build-and-test-debug-mode.outcome != 'success')
+      with:
+        limit-access-to-actor: true

--- a/cmake/Modules/InstallMCCODE.cmake
+++ b/cmake/Modules/InstallMCCODE.cmake
@@ -407,6 +407,22 @@ macro(installMCCODE)
       PROGRAMS "${PROJECT_BINARY_DIR}/${FLAVOR}-pygen${DOT_EXE_SUFFIX}"
       DESTINATION ${DEST_BINDIR}
     )
+    if ( MCCODE_USE_LEGACY_DESTINATIONS )
+      install(PROGRAMS
+        cmake/support/run-scripts/mpirun.bat
+        DESTINATION "${DEST_BINDIR}"
+      )
+
+      configure_file(
+        cmake/support/run-scripts/mpicc.bat.in
+        work/support/mpicc.bat
+      )
+
+      install(PROGRAMS
+        ${CMAKE_CURRENT_SOURCE_DIR}/work/support/mpicc.bat
+        DESTINATION "${DEST_BINDIR}"
+      )
+    endif()
 
   endif()
 

--- a/cmake/Modules/InstallMCCODE.cmake
+++ b/cmake/Modules/InstallMCCODE.cmake
@@ -408,21 +408,6 @@ macro(installMCCODE)
       DESTINATION ${DEST_BINDIR}
     )
 
-    install(PROGRAMS
-      cmake/support/run-scripts/mpirun.bat
-      DESTINATION "${DEST_BINDIR}"
-      )
-
-    configure_file(
-      cmake/support/run-scripts/mpicc.bat.in
-      work/support/mpicc.bat
-      )
-
-    install(PROGRAMS
-      ${CMAKE_CURRENT_SOURCE_DIR}/work/support/mpicc.bat
-      DESTINATION "${DEST_BINDIR}"
-      )
-
   endif()
 
 

--- a/cmake/Modules/MCUtil.cmake
+++ b/cmake/Modules/MCUtil.cmake
@@ -162,9 +162,6 @@ macro(setupMCCODE FLAVOR)
     if ( MCCODE_USE_LEGACY_DESTINATIONS )
       set(CMAKE_INSTALL_PREFIX "${FLAVOR}-${MCCODE_VERSION}")
       set(CPACK_NSIS_INSTALL_ROOT "C:\\\\${FLAVOR}-${MCCODE_VERSION}")
-    else()
-      set(CMAKE_INSTALL_PREFIX "${FLAVOR}\\\\${MCCODE_VERSION}")
-      set(CPACK_NSIS_INSTALL_ROOT "C:\\\\${FLAVOR}\\\\${MCCODE_VERSION}")
     endif()
 
     set(CPACK_NSIS_UNINSTALL_NAME "${CMAKE_PROJECT_NAME}-uninstall")
@@ -215,86 +212,85 @@ macro(setupMCCODE FLAVOR)
 
   # Add some special Windows/Unix CPACK configuration
   if(WINDOWS)
+    if ( MCCODE_USE_LEGACY_DESTINATIONS )
+      # Fix installation folder (installs to ${ROOT}\${DIRECTORY})
+      set(CPACK_PACKAGE_INSTALL_DIRECTORY "")
 
-    # Fix installation folder (installs to ${ROOT}\${DIRECTORY})
-    set(CPACK_PACKAGE_INSTALL_DIRECTORY "")
+      # Windows program files do not have any version-suffix
+      set(PROGRAM_SUFFIX "")
 
-    # Windows program files do not have any version-suffix
-    set(PROGRAM_SUFFIX "")
-
-    # Create desktop links for mcgui py/pl and mccodego batch files
-    set(CPACK_NSIS_CREATE_ICONS "CreateShortCut '$DESKTOP\\\\${MCCODE_PREFIX}gui-${MCCODE_VERSION}.lnk' '${CPACK_NSIS_INSTALL_ROOT}\\\\${DEST_BINDIR}\\\\${MCCODE_PREFIX}guistart.bat' ")
-    set(CPACK_NSIS_CREATE_ICONS_EXTRA "CreateShortCut '$DESKTOP\\\\${FLAVOR}-shell-${MCCODE_VERSION}.lnk' '${CPACK_NSIS_INSTALL_ROOT}\\\\${DEST_BINDIR}\\\\mccodego.bat' ")
-
-  else()
-
-    # Have CMake respect install prefix
-    message(STATUS "Install prefix -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}")
-    set(CPACK_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
-    set(CPACK_PACKAGING_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
-
-    set(CPACK_RPM_PACKAGE_RELOCATABLE TRUE)
-
-    # Avoid e.g. /usr/local being "part" of the RPMs
-    set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST
-      ${CMAKE_INSTALL_PREFIX}
-      ${CMAKE_INSTALL_PREFIX}/${FLAVOR}
-      ${CMAKE_INSTALL_PREFIX}/${FLAVOR}/${MCCODE_VERSION}
-      ${DEST_BINDIR}
-      ${DEST_TOOLDIR}
-      ${DEST_DATADIR_LIBDIR}
-      ${DEST_DATADIR_CODEFILES}
-      )
-
-    # Add "-VERSION" to all program files (executables)
-    set(PROGRAM_SUFFIX "-${MCCODE_VERSION}")
-
-    # Run postinst and postrm scripts for various platforms
-    set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "work/support/postinst;work/support/postrm")
-    set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE "${PROJECT_BINARY_DIR}/work/support/postinst;")
-    set(CPACK_RPM_POST_UNINSTALL_SCRIPT_FILE "${PROJECT_BINARY_DIR}/work/support/postrm;")
-    
-    # Define dependencies for gcc and the like
-    set(CPACK_DEBIAN_PACKAGE_DEPENDS "build-essential, libopenmpi-dev")
-    set(CPACK_RPM_PACKAGE_REQUIRES "gcc, openmpi-devel")
-
-    # Generate postinst and postrm scripts
-    configure_file(
-      cmake/support/install-scripts/postinst.in
-      work/support/${FLAVOR}-postinst
-      @ONLY)
-    configure_file(
-      cmake/support/install-scripts/postrm.in
-      work/support/${FLAVOR}-postrm
-      @ONLY)
-    configure_file(
-      cmake/support/install-scripts/postinst.in
-      work/support/postinst
-      @ONLY)
-    configure_file(
-      cmake/support/install-scripts/postrm.in
-      work/support/postrm
-      @ONLY)
-
-    # Generate the console-errormessage wrapper
-    configure_file(
-      cmake/support/run-scripts/mccode_errmsg.in
-      "work/support/${FLAVOR}_errmsg"
-      @ONLY)
-
-    # Set architecture
-    if(ARCH EQUAL "amd64")
-      set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
-      set(CPACK_RPM_PACKAGE_ARCHITECTURE    "x86_64")
-    elseif(ARCH EQUAL "i386")
-      set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "i386")
-      set(CPACK_RPM_PACKAGE_ARCHITECTURE    "i686")
-    else()
-      set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "${ARCH}")
-      set(CPACK_RPM_PACKAGE_ARCHITECTURE    "${ARCH}")
+      # Create desktop links for mcgui py/pl and mccodego batch files
+      set(CPACK_NSIS_CREATE_ICONS "CreateShortCut '$DESKTOP\\\\${MCCODE_PREFIX}gui-${MCCODE_VERSION}.lnk' '${CPACK_NSIS_INSTALL_ROOT}\\\\${DEST_BINDIR}\\\\${MCCODE_PREFIX}guistart.bat' ")
+     set(CPACK_NSIS_CREATE_ICONS_EXTRA "CreateShortCut '$DESKTOP\\\\${FLAVOR}-shell-${MCCODE_VERSION}.lnk' '${CPACK_NSIS_INSTALL_ROOT}\\\\${DEST_BINDIR}\\\\mccodego.bat' ")
     endif()
-
   endif()
+  
+  # Have CMake respect install prefix
+  message(STATUS "Install prefix -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}")
+  set(CPACK_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
+  set(CPACK_PACKAGING_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
+
+  set(CPACK_RPM_PACKAGE_RELOCATABLE TRUE)
+
+  # Avoid e.g. /usr/local being "part" of the RPMs
+  set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST
+    ${CMAKE_INSTALL_PREFIX}
+    ${CMAKE_INSTALL_PREFIX}/${FLAVOR}
+    ${CMAKE_INSTALL_PREFIX}/${FLAVOR}/${MCCODE_VERSION}
+    ${DEST_BINDIR}
+    ${DEST_TOOLDIR}
+    ${DEST_DATADIR_LIBDIR}
+    ${DEST_DATADIR_CODEFILES}
+    )
+
+  # Add "-VERSION" to all program files (executables)
+  set(PROGRAM_SUFFIX "-${MCCODE_VERSION}")
+
+  # Run postinst and postrm scripts for various platforms
+  set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "work/support/postinst;work/support/postrm")
+  set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE "${PROJECT_BINARY_DIR}/work/support/postinst;")
+  set(CPACK_RPM_POST_UNINSTALL_SCRIPT_FILE "${PROJECT_BINARY_DIR}/work/support/postrm;")
+    
+  # Define dependencies for gcc and the like
+  set(CPACK_DEBIAN_PACKAGE_DEPENDS "build-essential, libopenmpi-dev")
+  set(CPACK_RPM_PACKAGE_REQUIRES "gcc, openmpi-devel")
+
+  # Generate postinst and postrm scripts
+  configure_file(
+    cmake/support/install-scripts/postinst.in
+    work/support/${FLAVOR}-postinst
+    @ONLY)
+  configure_file(
+    cmake/support/install-scripts/postrm.in
+    work/support/${FLAVOR}-postrm
+    @ONLY)
+  configure_file(
+    cmake/support/install-scripts/postinst.in
+    work/support/postinst
+    @ONLY)
+  configure_file(
+    cmake/support/install-scripts/postrm.in
+    work/support/postrm
+    @ONLY)
+
+  # Generate the console-errormessage wrapper
+  configure_file(
+    cmake/support/run-scripts/mccode_errmsg.in
+    "work/support/${FLAVOR}_errmsg"
+    @ONLY)
+
+  # Set architecture
+  if(ARCH EQUAL "amd64")
+    set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
+    set(CPACK_RPM_PACKAGE_ARCHITECTURE    "x86_64")
+  elseif(ARCH EQUAL "i386")
+    set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "i386")
+    set(CPACK_RPM_PACKAGE_ARCHITECTURE    "i686")
+  else()
+    set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "${ARCH}")
+    set(CPACK_RPM_PACKAGE_ARCHITECTURE    "${ARCH}")
+  endif()
+
 endmacro()
 
 # Helper function which can look for input files. Apparently "file(GLOB ...)" is

--- a/mcstas/src/instrument.y
+++ b/mcstas/src/instrument.y
@@ -52,10 +52,10 @@ void metadata_assign_from_instance(List metadata);
    definitions. */
 // TODO: Select either a) or b) below depending on bison version
 // a) bison v < 3
-// %pure-parser
+%pure-parser
 // b) bison v >= 3
-%define api.pure
-%define parse.trace
+//%define api.pure
+//%define parse.trace
 
 /*******************************************************************************
 * Type definition for semantic values.

--- a/mcstas/src/py-instrument.y
+++ b/mcstas/src/py-instrument.y
@@ -51,10 +51,11 @@ void metadata_assign_from_instance(List metadata);
    definitions. */
 // TODO: Select either a) or b) below depending on bison version
 // a) bison v < 3
-//%pure-parser
+%pure-parser
 // b) bison v >= 3
-%define api.pure
-%define parse.trace
+//%define api.pure
+//%define parse.trace
+
 
 /*******************************************************************************
 * Type definition for semantic values.


### PR DESCRIPTION
Windows:
- Build and install using gcc and bash.
- Test mcstas, mcrun
- Get output from BNL_H8 and run mcstas-pygen
Macos:
- Build and install using gcc or clang.
- Test mcstas, mcrun
- Get output form BNL_H8 and mcstas-pygen
- Test MCPL support (ESS_BEER_MCPL)
- Test NCrystal support (NCrystal_example)
Ubuntu:
- Build and install using gcc or clang.
- Test mcstas, mcrun
- Get output form BNL_H8 and mcstas-pygen
- Test MCPL support (ESS_BEER_MCPL)
- Test NCrystal support (NCrystal_example)
- Get NeXus output form templateSANS_Mantid

Tests are in status "green" at 
https://github.com/willend/McCode/actions/runs/7017779971