### PR TITLE
Small fixes in monitors

### DIFF
--- a/mcstas-comps/monitors/Monitor_4PI.comp
+++ b/mcstas-comps/monitors/Monitor_4PI.comp
@@ -71,7 +71,9 @@ TRACE
 
 SAVE
   %{
-    DETECTOR_OUT_0D("4PI monitor " NAME_CURRENT_COMP, Nsum, psum, p2sum);
+    char full_name[1024];
+    sprintf(full_name, "4PI monitor %s", NAME_CURRENT_COMP);
+    DETECTOR_OUT_0D(full_name, Nsum, psum, p2sum);
   %}
 
 MCDISPLAY

--- a/mcstas-comps/monitors/PSD_monitor_psf.comp
+++ b/mcstas-comps/monitors/PSD_monitor_psf.comp
@@ -83,14 +83,6 @@ INITIALIZE
   PSD_p = create_darr2d(nx, ny);
   PSD_p2 = create_darr2d(nx, ny);
 
-  for (i=0; i<nx; i++){
-    for (j=0; j<ny; j++){
-      PSD_N[i][j] = 0;
-      PSD_p[i][j] = 0;
-      PSD_p2[i][j] = 0;
-    }
-  }
-
   // Use instance name for monitor output if no input was given
   if (!strcmp(filename,"\0")) sprintf(filename,"%s",NAME_CURRENT_COMP);
 %}

--- a/mcstas-comps/monitors/PSD_monitor_psf.comp
+++ b/mcstas-comps/monitors/PSD_monitor_psf.comp
@@ -58,10 +58,6 @@ SETTING PARAMETERS (
 
 OUTPUT PARAMETERS ()
 
-STATE PARAMETERS (x, y, z, vx, vy, vz, t, s1, s2, p)
-
-POLARISATION PARAMETERS (sx, sy, sz)
-
 DECLARE
 %{
   DArray2d PSD_N;

--- a/mcstas-comps/monitors/TOFlog_monitor.comp
+++ b/mcstas-comps/monitors/TOFlog_monitor.comp
@@ -93,13 +93,6 @@ INITIALIZE
   TOF_p = create_darr1d(nchan);
   TOF_p2 = create_darr1d(nchan);
 
-  for (i=0; i<nchan; i++)
-  {
-    TOF_N[i] = 0;
-    TOF_p[i] = 0;
-    TOF_p2[i] = 0;
-  }
-
   // Use instance name for monitor output if no input was given
   if (!strcmp(filename,"\0")) sprintf(filename,"%s",NAME_CURRENT_COMP);
 %}

--- a/mcstas-comps/monitors/TOFlog_monitor.comp
+++ b/mcstas-comps/monitors/TOFlog_monitor.comp
@@ -57,11 +57,10 @@ OUTPUT PARAMETERS ()
 
 DECLARE
 %{
-  #define LARGENUMBER
   int nchan;
-  double TOF_N[LARGENUMBER];
-  double TOF_p[LARGENUMBER];
-  double TOF_p2[LARGENUMBER];
+  DArray1d TOF_N;
+  DArray1d TOF_p;
+  DArray1d TOF_p2;
 %}
 
 INITIALIZE
@@ -76,10 +75,23 @@ INITIALIZE
          NAME_CURRENT_COMP);
     exit(0);
   }
+  
+  if (tmin <= 0 || tmax <= 0) {
+      printf("TOFlog_mon: %s: Only supports positive tmin and tmax !\n"
+             "ERROR       (tmin, tmax). Exiting", NAME_CURRENT_COMP);
+      exit(0);
+  }
+    
+  if (tmin >= tmax) {
+      printf("TOFlog_mon: %s: tmin should be smaller than tmax !\n"
+             "ERROR       (tmin, tmax). Exiting", NAME_CURRENT_COMP);
+      exit(0);
+  }
 
   nchan=(int)ceil(ndec*log(tmax/tmin)/log(10.0));
-  if (nchan>LARGENUMBER)
-    printf("FATAL ERROR, too many time channels \n");
+  TOF_N = create_darr1d(nchan);
+  TOF_p = create_darr1d(nchan);
+  TOF_p2 = create_darr1d(nchan);
 
   for (i=0; i<nchan; i++)
   {
@@ -108,6 +120,7 @@ TRACE
       TOF_p[i] = TOF_p[i]+p;
       #pragma acc atomic      
       TOF_p2[i] = TOF_p2[i]+p2;
+      SCATTER;
     }
   }
   if (restore_neutron) {
@@ -127,6 +140,14 @@ if (!nowritefile) {
       filename);
 }
 %}
+
+FINALLY
+%{
+  destroy_darr1d(TOF_N);
+  destroy_darr1d(TOF_p);
+  destroy_darr1d(TOF_p2);
+%}
+
 
 MCDISPLAY
 %{


### PR DESCRIPTION
Monitor_4PI
Wrong use of NAME_CURRENT_COMPONENT in save section fixed

TOFlog_monitor
Used static memory, moved to dynamic and removed static limit on memory

PSD_monitor_psf
Still had state and polarization parameters that would not compile

