### PR TITLE
Fix of Phonon_simple weight factor

### DIFF
--- a/mcstas-comps/examples/Tests_samples/Samples_Phonon/Samples_Phonon.instr
+++ b/mcstas-comps/examples/Tests_samples/Samples_Phonon/Samples_Phonon.instr
@@ -17,7 +17,7 @@
 * Simple test instrument for the Phonon_simple component.
 * Refer to the component documentation for further instructions.
 *
-* %Example: E=10 -n 1e5 Detector: mon1_I=1.80177e-22
+* %Example: E=10 -n 1e5 Detector: mon1_I=2.86265e-25
 *
 * %Parameters
 * E:    [meV] Mean energy at source   

--- a/mcstas-comps/samples/Phonon_simple.comp
+++ b/mcstas-comps/samples/Phonon_simple.comp
@@ -7,6 +7,7 @@
 * Written by: Kim Lefmann
 * Date: 04.02.04
 * Origin: Risoe
+* Modified by: MB,    15.01.24   (removed extra K2V factor in weight, reduced scattered intensity significantly)
 *
 * A sample for phonon scattering based on cross section expressions from Squires, Ch.3.
 * Possibility for adding an (unphysical) bandgap.
@@ -427,7 +428,7 @@ TRACE
       f1=omega_q(parms);
       parms[0]=v_f+DV;
       f2=omega_q(parms);
-      J_factor = fabs(f2-f1)/(2*DV*K2V);
+      J_factor = fabs(f2-f1)/(2*DV);
       omega=VS2E*(v_i*v_i-v_f*v_f);
       vx *= v_f;
       vy *= v_f;


### PR DESCRIPTION
Fixed error in weigth factor calculation of phonon simple, decreasing the intensity significantly.

The example instrument has been rerun with the new version and the decrease is as expected.

The component is also used in RITA-II, though without any example for testing.