### PR TITLE
Protect against pixel min's arriving in "float"/scientific notation

### DIFF
--- a/tools/Python/mcdisplay/mantid_xml/mcdisplay.py
+++ b/tools/Python/mcdisplay/mantid_xml/mcdisplay.py
@@ -497,8 +497,7 @@ class MantidRectangularDetector:
         self.ymax = l[3]
         self.nx = l[4]
         self.ny = l[5]
-        self.pixelmin = l[6]
-
+        self.pixelmin = str(int(float(l[6])))
 
 class MantidBananaDetector:
     def __init__(self, det_line_lst):
@@ -511,7 +510,7 @@ class MantidBananaDetector:
         self.ymax = l[4]
         self.nt = l[5]
         self.ny = l[6]
-        self.pixelmin = l[7]
+        self.pixelmin = str(int(float(l[7])))
 
 
 def debug_load_instr(filename):


### PR DESCRIPTION
Correction for a case where a "Mantid" monitor instance with a high "pixel min" e.g.

```
COMPONENT nD_Mantid_1 = Monitor_nD(
        options ="mantid square x limits=[0 0.512] bins=1280 y limits=[0 0.512] bins=1280, neutron pixel min=2000000 t, list all neutrons",
    xmin = 0,
    xmax = 0.512,
    ymin = 0,
    ymax = 0.512,
    restore_neutron = 1,
    filename = "bank01_events.dat")
  AT (-0.29, -0.25, 0.25) RELATIVE armSample
  ROTATED (0, 90, 0) RELATIVE armSample

```
would arrive in the IDF with idstart="2e6" - would prevent load in Mantid.
```
<component type="MonNDtype-1" name="nD_Mantid_1" idstart="2e6" idfillbyfirst="x" idstepbyrow=" 1280">
	<location x=" 0.242564" y=" -0.25" z=" 157.657"  rot="90.3045938200173" axis-x="0" axis-y="1" axis-z="0" />
</component>
```

This minor correction rectifies the incoming id's to be correctly interpreted / shown in the form

```
<component type="MonNDtype-1" name="nD_Mantid_1" idstart="2000000" idfillbyfirst="x" idstepbyrow=" 1280">
	<location x=" 0.242564" y=" -0.25" z=" 157.657"  rot="90.3045938200173" axis-x="0" axis-y="1" axis-z="0" />
</component>
```