### PR TITLE
[Add] C macro integer version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,13 @@
 cmake_minimum_required(VERSION 3.17.0)
 cmake_policy(VERSION 3.17.0)
 
+
+if ( "x${MCVERSION}" STREQUAL "x" )
+    message(FATAL_ERROR "Build version was unset. Define using e.g. -DMCVERSION=3.9.0.1")
+endif()
+
 # This file will build McStas and/or McXtrace
-project(mccode LANGUAGES C VERSION 3.5.0)
+project(mccode LANGUAGES C VERSION "${MCVERSION}")
 set(CMAKE_C_STANDARD 99)
 # Stash the project version for use in C macro comparisons
 math(EXPR MCCODE_VERSION_MACRO "(${CMAKE_PROJECT_VERSION_MAJOR} * 100 + ${CMAKE_PROJECT_VERSION_MINOR}) * 1000 + ${CMAKE_PROJECT_VERSION_PATCH}" OUTPUT_FORMAT DECIMAL)
@@ -25,11 +30,6 @@ if ( BUILD_MCSTAS AND BUILD_MCXTRACE )
     message(WARNING "Configuration requests building both McStas and McXtrace which is likely to fail.")
 elseif( NOT BUILD_MCSTAS AND NOT BUILD_MCXTRACE )
     message(FATAL_ERROR "Configuration requires building one of McStas or McXtrace via -DBUILD_MCXTRACE=ON or -DBUILD_MCSTAS=ON")
-endif()
-
-if ( "x${MCVERSION}" STREQUAL "x" )
-    set(MCVERSION "${CMAKE_PROJECT_VERSION}")
-    message(INFO "Build version was unset. Define using e.g. -DMCVERSION=3.9a; using project McCode version ${MCVERSION}")
 endif()
 
 # Setup McCode values (from mkdist or defaults)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 3.17.0)
 cmake_policy(VERSION 3.17.0)
 
-
 if ( "x${MCVERSION}" STREQUAL "x" )
-    message(FATAL_ERROR "Build version was unset. Define using e.g. -DMCVERSION=3.9.0.1")
+    set(MCVERSION 3.99.999)
+    message(WARNING "Build version was unset. Define using e.g. -DMCVERSION=${MCVERSION}")
 endif()
 
 # This file will build McStas and/or McXtrace

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,10 @@ cmake_minimum_required(VERSION 3.17.0)
 cmake_policy(VERSION 3.17.0)
 
 # This file will build McStas and/or McXtrace
-project(mccode C)
+project(mccode LANGUAGES C VERSION 3.5.0)
 set(CMAKE_C_STANDARD 99)
+# Stash the project version for use in C macro comparisons
+math(EXPR MCCODE_VERSION_MACRO "(${CMAKE_PROJECT_VERSION_MAJOR} * 100 + ${CMAKE_PROJECT_VERSION_MINOR}) * 1000 + ${CMAKE_PROJECT_VERSION_PATCH}" OUTPUT_FORMAT DECIMAL)
 
 # Set module path
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
@@ -26,7 +28,8 @@ elseif( NOT BUILD_MCSTAS AND NOT BUILD_MCXTRACE )
 endif()
 
 if ( "x${MCVERSION}" STREQUAL "x" )
-    message(WARNING "Build version is unset. Define using e.g.  -DMCVERSION=3.9a")
+    set(MCVERSION "${CMAKE_PROJECT_VERSION}")
+    message(INFO "Build version was unset. Define using e.g. -DMCVERSION=3.9a; using project McCode version ${MCVERSION}")
 endif()
 
 # Setup McCode values (from mkdist or defaults)

--- a/common/lib/share/mccode-r.h.in
+++ b/common/lib/share/mccode-r.h.in
@@ -187,6 +187,10 @@ clock_t times (struct tms *__buffer) {
 #  define MCCODE_VERSION "@MCCODE_VERSION@"
 #endif
 
+#ifndef __MCCODE_VERSION__
+#define __MCCODE_VERSION__ @MCCODE_VERSION_MACRO@L
+#endif
+
 #ifndef MCCODE_NAME
 #  define MCCODE_NAME "@MCCODE_NAME@"
 #endif
@@ -261,6 +265,7 @@ typedef struct metadata_table_struct metadata_table_t;
 char * metadata_table_key_component(char* key);
 char * metadata_table_key_literal(char * key);
 int metadata_table_defined(int, metadata_table_t *, char *);
+char * metadata_table_name(int, metadata_table_t *, char *);
 char * metadata_table_type(int, metadata_table_t *, char *);
 char * metadata_table_literal(int, metadata_table_t *, char *);
 void metadata_table_print_all_keys(int no, metadata_table_t * tab);

--- a/common/lib/share/mccode-r.h.in
+++ b/common/lib/share/mccode-r.h.in
@@ -265,7 +265,6 @@ typedef struct metadata_table_struct metadata_table_t;
 char * metadata_table_key_component(char* key);
 char * metadata_table_key_literal(char * key);
 int metadata_table_defined(int, metadata_table_t *, char *);
-char * metadata_table_name(int, metadata_table_t *, char *);
 char * metadata_table_type(int, metadata_table_t *, char *);
 char * metadata_table_literal(int, metadata_table_t *, char *);
 void metadata_table_print_all_keys(int no, metadata_table_t * tab);


### PR DESCRIPTION
Implementing the fix proposed in #1595 (and mistakenly including part of #1593)

The CMake project version information is used to build an integer valued C macro, with the exact value inserted at configure time.

This could lead to a disconnect between package version and built version due to the use of the `MCVERSION` variable.
@willend How would you prefer this be resolved?