### PR TITLE
Handle GROUP syntax in -pygen

### DIFF
--- a/mcstas/src/pygen.c.in
+++ b/mcstas/src/pygen.c.in
@@ -564,6 +564,11 @@ int cogen_raytrace(struct instr_def *instr)
       coutf("%s.set_WHEN('%s')",comp->name, exp_tostring(comp->when));
     }
 
+    if (comp->group) {
+      coutf("# %s is in GROUP %s",comp->name, comp->group->name);
+      coutf("%s.set_GROUP('%s')",comp->name, comp->group->name);
+    }
+
     if (list_len(comp->extend->lines) > 0) {
       coutf("# EXTEND at %s", comp->name);
       coutf("%s.append_EXTEND(r'''",comp->name);

--- a/mcxtrace/src/pygen.c.in
+++ b/mcxtrace/src/pygen.c.in
@@ -564,6 +564,11 @@ int cogen_raytrace(struct instr_def *instr)
       coutf("%s.set_WHEN('%s')",comp->name, exp_tostring(comp->when));
     }
 
+    if (comp->group) {
+      coutf("# %s is in GROUP %s",comp->name, comp->group->name);
+      coutf("%s.set_GROUP('%s')",comp->name, comp->group->name);
+    }
+
     if (list_len(comp->extend->lines) > 0) {
       coutf("# EXTEND at %s", comp->name);
       coutf("%s.append_EXTEND(r'''",comp->name);


### PR DESCRIPTION
Apparently the -pygen code generator(s) did not include support for GROUP earlier.