### PR TITLE
Expose "invcanvas" for pyqtgraph mcplot/mcdisplay in mcgui 

### DIFF
--- a/tools/Python/mccodelib/mccode_config.py.in
+++ b/tools/Python/mccodelib/mccode_config.py.in
@@ -171,7 +171,9 @@ def get_options():
         mcdisplay_lst = [prefix+"display-webgl",
                          prefix+"display-webgl-classic",
                          prefix+"display-pyqtgraph",
+                         prefix+"display-pyqtgraph --invcanvas",
                          prefix+"display-pyqtgraph --tof",
+                         prefix+"display-pyqtgraph --tof --invcanvas",
                          prefix+"display-matplotlib",
                          prefix+"display-matlab",
                          prefix+"display-cad",
@@ -183,6 +185,7 @@ def get_options():
         mcdisplay_lst = [prefix+"display-webgl",
                          prefix+"display-webgl-classic",
                          prefix+"display-pyqtgraph",
+                         prefix+"display-pyqtgraph --invcanvas",
                          prefix+"display-matplotlib",
                          prefix+"display-matlab",
                          prefix+"display-cad"]
@@ -191,6 +194,7 @@ def get_options():
 
 
     mcplot_lst =    [prefix+"plot-pyqtgraph",
+                     prefix+"plot-pyqtgraph --invcanvas",
                      prefix+"plot-matplotlib", 
                      prefix+"plot-matlab",
                      prefix+"plot-svg"]

--- a/tools/Python/mcplot/pyqtgraph/plotfuncs.py
+++ b/tools/Python/mcplot/pyqtgraph/plotfuncs.py
@@ -67,8 +67,8 @@ class ModLegend(pg.LegendItem):
         self.updateSize()
 
     def paint(self, p, *args):
-        p.setPen(pg.functions.mkPen(255,255,255,100))
-        p.setBrush(pg.functions.mkBrush(0,0,0,100))
+        p.setPen(pg.functions.mkPen(255,255,255,225))
+        p.setBrush(pg.functions.mkBrush(255,255,255,255))
         p.drawRect(self.boundingRect())
 
 

--- a/tools/Python/mcrun/mcrun.py
+++ b/tools/Python/mcrun/mcrun.py
@@ -99,6 +99,10 @@ def add_mcrun_options(parser):
         action='store_true',
         help='Open plotter on generated dataset')
 
+    add('--invcanvas',
+        action='store_true',
+        help='Forward request for inverted canvas to plotter')
+
     add('--autoplotter',
         action='store',
         type=str,
@@ -557,8 +561,10 @@ def main():
             autoplotter = options.autoplotter
         if isdir(options.dir):
             LOG.info('Running plotter %s on dataset %s', autoplotter, options.dir)
-            Process(autoplotter).run([options.dir])
-
+            if not options.invcanvas:
+                Process(autoplotter).run([options.dir])
+            else:
+                Process(autoplotter).run([options.dir, '--invcanvas'])
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
Required hook in mcrun for forwarding to the "autoplotter".
Further, enance visibility of legends in both inverted and normal canvas in mcplot.