### PR TITLE
Improvements to deployment of mcdisplay-webgl

### DIFF
--- a/meta-pkgs/windows/docupdate.bat.in
+++ b/meta-pkgs/windows/docupdate.bat.in
@@ -2,5 +2,4 @@
 @REM Script for calling mcdoc -i after installation of McStas/McXtrace
 @set PATH=c:\\@FLAVOR@-@VERSION@\\bin;c:\\@FLAVOR@-@VERSION@\\miniconda3;%PATH%
 @call @P@doc.bat -i
-@cd c:\\@FLAVOR@-@VERSION@\\lib\\tools\\Python\\@P@display\\webgl
-@npm.cmd install
+

--- a/meta-pkgs/windows/environment.yml
+++ b/meta-pkgs/windows/environment.yml
@@ -32,7 +32,6 @@ dependencies:
   - typish
   - jsons
   - nodejs
-  - rsync
   - pip
   - pip:
     - guide_bot

--- a/meta-pkgs/windows/environment.yml
+++ b/meta-pkgs/windows/environment.yml
@@ -32,6 +32,7 @@ dependencies:
   - typish
   - jsons
   - nodejs
+  - rsync
   - pip
   - pip:
     - guide_bot

--- a/tools/Python/mcdisplay/webgl/CMakeLists.txt
+++ b/tools/Python/mcdisplay/webgl/CMakeLists.txt
@@ -51,7 +51,7 @@ set(CPACK_NSIS_DISPLAY_NAME "${NSIS_NAME}")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "${NSIS_NAME}")
 
 # Debian
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "${FLAVOR}-${MCCODE_VERSION}, python3, python3-ply, python3-numpy, nodejs")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "${FLAVOR}-${MCCODE_VERSION}, python3, python3-ply, python3-numpy, nodejs, rsync")
 
 # RPM
 if (RPMPROFILE)

--- a/tools/Python/mcdisplay/webgl/CMakeLists.txt
+++ b/tools/Python/mcdisplay/webgl/CMakeLists.txt
@@ -157,7 +157,6 @@ if (NOT WINDOWS)
     PROGRAMS "${WORK}/npminstall"
     DESTINATION ${DEST_TOOLDIR}/${TOOLS_NAME}
   )
-  install(CODE "execute_process(COMMAND \"${CMAKE_INSTALL_PREFIX}/${DEST_TOOLDIR}/${TOOLS_NAME}/npminstall\")")
 else()
   # Configure fallback script
   configure_file("${CMAKE_CURRENT_SOURCE_DIR}/npminstall.bat.in" "${WORK}/npminstall.bat" @ONLY)
@@ -165,5 +164,4 @@ else()
     PROGRAMS "${WORK}/npminstall.bat"
     DESTINATION ${DEST_TOOLDIR}/${TOOLS_NAME}
   )
-  install(CODE "execute_process(COMMAND \"${CMAKE_INSTALL_PREFIX}/${DEST_TOOLDIR}/${TOOLS_NAME}/npminstall.bat\")")
 endif()

--- a/tools/Python/mcdisplay/webgl/mcdisplay.py
+++ b/tools/Python/mcdisplay/webgl/mcdisplay.py
@@ -98,7 +98,7 @@ def _write_html(instrument, html_filepath, first=None, last=None, invcanvas=Fals
 
 def write_browse(instrument, raybundle, dirname, instrname, timeout, nobrowse=None, first=None, last=None, invcanvas=None, **kwds):
     ''' writes instrument definitions to html/ js '''
-    print("Launching WebGL... - timeout is " + str(timeout))
+    print("Launching WebGL... Once launched, server will run for " + str(timeout) + " s")
     def copy(a, b):
         shutil_copy(str(a), str(b))
 
@@ -218,14 +218,23 @@ def main(instr=None, dirname=None, debug=None, n=None, timeout=None, **kwds):
 
     # Function to run npm commands and capture port
     def run_npminstall():
+        toolpath=str(Path(__file__).absolute().parent)
+        print(toolpath)
         if not os.name == 'nt':
-            npminst = "npminstall"
+            npminst = Path(toolpath + "/npminstall")
         else:
-            npminst = "npminstall.bat"
-        npminst = Path(__file__).absolute().parent.joinpath(npminst)
+            npminst = Path(toolpath + "/npminstall.bat")
+
+        print("Executing " + str(npminst))
         try:
             proc = subprocess.Popen(npminst, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
             print("Installing npm / vite modules")
+            for line in proc.stdout:
+                 print(line.rstrip())
+            print("Installing npm / vite modules - stderr:")  
+            for line in proc.stderr:
+                 print(line.rstrip())            
+            print("Done installing npm / vite modules")
         except subprocess.CalledProcessError as e:
             print(f"npminstall failed: {e}")
             return None

--- a/tools/Python/mcdisplay/webgl/mcdisplay.py
+++ b/tools/Python/mcdisplay/webgl/mcdisplay.py
@@ -112,7 +112,10 @@ def write_browse(instrument, raybundle, dirname, instrname, timeout, nobrowse=No
         raise RuntimeError(f"The specified destination {dirname} already exists!")
 
     # Copy the app files - i.e. creating dest
-    copytree(source.joinpath('dist'), dest)
+    if not os.name=='nt':
+        os.symlink(source.joinpath('dist'), dest)
+    else:
+        _winapi.CreateJunction(str(source.joinpath('dist')), str(dest))
 
     # Copy package.json from source to dest
     package_json_source = source.joinpath('package.json')
@@ -122,13 +125,10 @@ def write_browse(instrument, raybundle, dirname, instrname, timeout, nobrowse=No
     # Copy node_modules from source to destination
     node_modules_source = source.joinpath('node_modules')
     node_modules_dest = dest.joinpath('node_modules')
-    try:
-        if not os.name=='nt':
-            os.symlink(node_modules_source, node_modules_dest)
-        else:
-            _winapi.CreateJunction(node_modules_source, node_modules_dest)
-    except:
-        copytree(node_modules_source, node_modules_dest, dirs_exist_ok=True, ignore=ignore_patterns('*.log', '*.cache'))
+    if not os.name=='nt':
+        os.symlink(node_modules_source, node_modules_dest)
+    else:
+        _winapi.CreateJunction(str(node_modules_source), str(node_modules_dest))
 
     # Ensure execute permissions for vite binary
     vite_bin = node_modules_dest.joinpath('.bin/vite')

--- a/tools/Python/mcdisplay/webgl/mcdisplay.py
+++ b/tools/Python/mcdisplay/webgl/mcdisplay.py
@@ -112,10 +112,7 @@ def write_browse(instrument, raybundle, dirname, instrname, timeout, nobrowse=No
         raise RuntimeError(f"The specified destination {dirname} already exists!")
 
     # Copy the app files - i.e. creating dest
-    if not os.name=='nt':
-        os.symlink(source.joinpath('dist'), dest)
-    else:
-        _winapi.CreateJunction(str(source.joinpath('dist')), str(dest))
+    copytree(source.joinpath('dist'), dest)
 
     # Copy package.json from source to dest
     package_json_source = source.joinpath('package.json')

--- a/tools/Python/mcdisplay/webgl/mcdisplay.py
+++ b/tools/Python/mcdisplay/webgl/mcdisplay.py
@@ -103,9 +103,9 @@ def write_browse(instrument, raybundle, dirname, instrname, timeout, nobrowse=No
         shutil_copy(str(a), str(b))
 
     if os.name == 'nt':
-            source =  os.path.join(os.path.expandvars("$USERPROFILE"),"AppData",configuration['MCCODE'],configuration['MCCODE_VERSION'],'webgl')
+            source =  Path(os.path.join(os.path.expandvars("$USERPROFILE"),"AppData",mccode_config.configuration['MCCODE'],mccode_config.configuration['MCCODE_VERSION'],'webgl'))
     else:
-            source =  os.path.join(os.path.expandvars("$HOME"),"." + configuration['MCCODE'],configuration['MCCODE_VERSION'],'webgl')
+            source =  Path(os.path.join(os.path.expandvars("$HOME"),"." + mccode_config.configuration['MCCODE'],mccode_config.configuration['MCCODE_VERSION'],'webgl'))
 
     dest = Path(dirname)
     if dest.exists():
@@ -224,22 +224,21 @@ def main(instr=None, dirname=None, debug=None, n=None, timeout=None, **kwds):
             npminst = "npminstall.bat"
         npminst = Path(__file__).absolute().parent.joinpath(npminst)
         try:
-            proc = subprocess.Popen(npinst, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-            for line in proc.stdout:
-                print(line)
+            proc = subprocess.Popen(npminst, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+            print("Installing npm / vite modules")
         except subprocess.CalledProcessError as e:
             print(f"npminstall failed: {e}")
             return None
     
     # 1st run setup: Check if the user has a "webgl" folder or not
     if os.name == 'nt':
-            userdir =  os.path.join(os.path.expandvars("$USERPROFILE"),"AppData",configuration['MCCODE'],configuration['MCCODE_VERSION'],'webgl')
+            userdir =  os.path.join(os.path.expandvars("$USERPROFILE"),"AppData",mccode_config.configuration['MCCODE'],mccode_config.configuration['MCCODE_VERSION'],'webgl')
     else:
-            userdir =  os.path.join(os.path.expandvars("$HOME"),"." + configuration['MCCODE'],configuration['MCCODE_VERSION'],'webgl')
+            userdir =  os.path.join(os.path.expandvars("$HOME"),"." + mccode_config.configuration['MCCODE'],mccode_config.configuration['MCCODE_VERSION'],'webgl')
 
     if not os.path.isdir(userdir):
         try:
-            os.mkdir(userdir)
+            run_npminstall()
         except Exception as e:
             print("Local WebGL Directory %s could not be created: %s " % (userdir, e.__str__()))
 

--- a/tools/Python/mcdisplay/webgl/mcdisplay.py
+++ b/tools/Python/mcdisplay/webgl/mcdisplay.py
@@ -102,7 +102,11 @@ def write_browse(instrument, raybundle, dirname, instrname, timeout, nobrowse=No
     def copy(a, b):
         shutil_copy(str(a), str(b))
 
-    source = Path(__file__).absolute().parent
+    if os.name == 'nt':
+            source =  os.path.join(os.path.expandvars("$USERPROFILE"),"AppData",configuration['MCCODE'],configuration['MCCODE_VERSION'],'webgl')
+    else:
+            source =  os.path.join(os.path.expandvars("$HOME"),"." + configuration['MCCODE'],configuration['MCCODE_VERSION'],'webgl')
+
     dest = Path(dirname)
     if dest.exists():
         raise RuntimeError(f"The specified destination {dirname} already exists!")
@@ -211,7 +215,35 @@ def file_save(data, filename):
 
 def main(instr=None, dirname=None, debug=None, n=None, timeout=None, **kwds):
     logging.basicConfig(level=logging.INFO)
+
+    # Function to run npm commands and capture port
+    def run_npminstall():
+        if not os.name == 'nt':
+            npminst = "npminstall"
+        else:
+            npminst = "npminstall.bat"
+        npminst = Path(__file__).absolute().parent.joinpath(npminst)
+        try:
+            proc = subprocess.Popen(npinst, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+            for line in proc.stdout:
+                print(line)
+        except subprocess.CalledProcessError as e:
+            print(f"npminstall failed: {e}")
+            return None
     
+    # 1st run setup: Check if the user has a "webgl" folder or not
+    if os.name == 'nt':
+            userdir =  os.path.join(os.path.expandvars("$USERPROFILE"),"AppData",configuration['MCCODE'],configuration['MCCODE_VERSION'],'webgl')
+    else:
+            userdir =  os.path.join(os.path.expandvars("$HOME"),"." + configuration['MCCODE'],configuration['MCCODE_VERSION'],'webgl')
+
+    if not os.path.isdir(userdir):
+        try:
+            os.mkdir(userdir)
+        except Exception as e:
+            print("Local WebGL Directory %s could not be created: %s " % (userdir, e.__str__()))
+
+
     # output directory
     if dirname is None:
         from datetime import datetime as dt

--- a/tools/Python/mcdisplay/webgl/mcdisplay.py
+++ b/tools/Python/mcdisplay/webgl/mcdisplay.py
@@ -202,11 +202,16 @@ def write_browse(instrument, raybundle, dirname, instrname, timeout, nobrowse=No
         signal.signal(signal.SIGINT, signal_handler)
         signal.signal(signal.SIGUSR1, signal_handler)
         signal.signal(signal.SIGUSR2, signal_handler)
-        print('Press Ctrl+C to exit - otherwise visualisation vill terminate server after ' + str(timeout) + ' s')
-        time.sleep(timeout)
-        print("Sending SIGTERM to npm/vite server")
-        port_container['process'].send_signal(signal.SIGTERM)
-        sys.exit(0)
+        if not os.name == 'nt':
+            print('Press Ctrl+C to exit\n(visualisation server willterminate server after ' + str(timeout) + ' s)')
+            time.sleep(timeout)
+            print("Sending SIGTERM to npm/vite server")
+            port_container['process'].send_signal(signal.SIGTERM)
+            sys.exit(0)
+        else:
+            print('Press Ctrl+C to exit visualisation server')
+            port_container['process'].wait()
+            sys.exit(0)
 
 def file_save(data, filename):
     ''' saves data for debug purposes '''

--- a/tools/Python/mcdisplay/webgl/npminstall.bat.in
+++ b/tools/Python/mcdisplay/webgl/npminstall.bat.in
@@ -1,5 +1,4 @@
 @REM Isn't windows a lovely place???
-@CALL @CPACK_NSIS_INSTALL_ROOT@\bin\@FLAVOR@env.bat
 @set TOOLDIR=%~dp0
 @cd %USERPROFILE%\AppData
 @if not exist "@FLAVOR@\" mkdir @FLAVOR@

--- a/tools/Python/mcdisplay/webgl/npminstall.bat.in
+++ b/tools/Python/mcdisplay/webgl/npminstall.bat.in
@@ -13,10 +13,10 @@
 @copy /Y %TOOLDIR%\index.html .
 @copy /Y %TOOLDIR%\*.js .
 @copy /Y %TOOLDIR%\package.json .
-@rsync -avz %TOOLDIR%\Contexts\ Contexts
-@rsync -avz %TOOLDIR%\utils\ utils
-@rsync -avz %TOOLDIR%\data-utils\ data-utils
-@rsync -avz %TOOLDIR%\components\ components
+@Xcopy %TOOLDIR%\Contexts\ Contexts /c /i /e /h /y
+@xcopy %TOOLDIR%\utils\ utils /c /i /e /h /y
+@xcopy %TOOLDIR%\data-utils\ data-utils /c /i /e /h /y
+@xcopy %TOOLDIR%\components\ components /c /i /e /h /y
 @call npm.cmd install
 @call npm.cmd run build
 

--- a/tools/Python/mcdisplay/webgl/npminstall.bat.in
+++ b/tools/Python/mcdisplay/webgl/npminstall.bat.in
@@ -1,4 +1,5 @@
 @REM Isn't windows a lovely place???
+@set WORKDIR=%cd%
 @set TOOLDIR=%~dp0
 @cd %USERPROFILE%\AppData
 @if not exist "@FLAVOR@\" mkdir @FLAVOR@
@@ -18,4 +19,5 @@
 @xcopy %TOOLDIR%\components\ components /c /i /e /h /y
 @call npm.cmd install
 @call npm.cmd run build
+@cd %WORKDIR%\
 

--- a/tools/Python/mcdisplay/webgl/npminstall.bat.in
+++ b/tools/Python/mcdisplay/webgl/npminstall.bat.in
@@ -1,5 +1,22 @@
-@set PATH=c:\\@FLAVOR@-@VERSION@\\bin;c:\\@FLAVOR@-@VERSION@\\miniconda3;%PATH%
-@cd %~dp0
+@REM Isn't windows a lovely place???
+@CALL @CPACK_NSIS_INSTALL_ROOT@\bin\@FLAVOR@env.bat
+@set TOOLDIR=%~dp0
+@cd %USERPROFILE%\AppData
+@if not exist "@FLAVOR@\" mkdir @FLAVOR@
+@cd @FLAVOR@
+@if not exist "@MCCODE_VERSION@\" mkdir @MCCODE_VERSION@
+@cd @MCCODE_VERSION@
+@if not exist "webgl\" mkdir webgl
+@cd webgl
+@copy /Y %TOOLDIR%\*.tsx .
+@copy /Y %TOOLDIR%\*.css .
+@copy /Y %TOOLDIR%\index.html .
+@copy /Y %TOOLDIR%\*.js .
+@copy /Y %TOOLDIR%\package.json .
+@rsync -avz %TOOLDIR%\Contexts\ Contexts
+@rsync -avz %TOOLDIR%\utils\ utils
+@rsync -avz %TOOLDIR%\data-utils\ data-utils
+@rsync -avz %TOOLDIR%\components\ components
 @call npm.cmd install
 @call npm.cmd run build
 

--- a/tools/Python/mcdisplay/webgl/npminstall.in
+++ b/tools/Python/mcdisplay/webgl/npminstall.in
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+@MCCODE_BASH_STANDARD_PREAMBLE@
 
 set -e
 cd ${HOME} && mkdir -p .@FLAVOR@ && cd .@FLAVOR@ && mkdir -p @MCCODE_VERSION@ && cd @MCCODE_VERSION@ && mkdir -p webgl && cd webgl
@@ -6,8 +7,13 @@ cd ${HOME} && mkdir -p .@FLAVOR@ && cd .@FLAVOR@ && mkdir -p @MCCODE_VERSION@ &&
 FILE=${0}
 TOOLDIR=`dirname $FILE`
 cp ${TOOLDIR}/*.tsx .
+cp ${TOOLDIR}/*.css .
 cp ${TOOLDIR}/index.html .
 cp ${TOOLDIR}/*.js .
 cp ${TOOLDIR}/package.json .
+rsync -avz ${TOOLDIR}/Contexts/ Contexts
+rsync -avz ${TOOLDIR}/utils/ utils
+rsync -avz ${TOOLDIR}/data-utils/ data-utils
+rsync -avz ${TOOLDIR}/components/ components
 npm install
 npm run build

--- a/tools/Python/mcdisplay/webgl/npminstall.in
+++ b/tools/Python/mcdisplay/webgl/npminstall.in
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 
 set -e
+cd ${HOME} && mkdir -p .@FLAVOR@ && cd .@FLAVOR@ && mkdir -p @MCCODE_VERSION@ && cd @MCCODE_VERSION@ && mkdir -p webgl && cd webgl
+
 FILE=${0}
-cd `dirname $FILE`
+TOOLDIR=`dirname $FILE`
+cp ${TOOLDIR}/*.tsx .
+cp ${TOOLDIR}/index.html .
+cp ${TOOLDIR}/*.js .
+cp ${TOOLDIR}/package.json .
 npm install
 npm run build


### PR DESCRIPTION
* Ensure user ownership of js files (stored in Local ".mcstas/.mcxtrace" profile)
* Let mcdisplay-webgl kill node subprocess after a given timeout (defaults to 5 min)
* Use "junctions" on Windows to avoid copytree on the "node_modules" folder
