### PR TITLE
More robust NCrystal DEPENDENCY to ensure libNCrystal.so is ignored during the compilation step

### DIFF
--- a/mcstas-comps/contrib/NCrystal_sample.comp
+++ b/mcstas-comps/contrib/NCrystal_sample.comp
@@ -67,7 +67,7 @@
 DEFINE COMPONENT NCrystal_sample
 SETTING PARAMETERS (string cfg="void", absorptionmode=1, multscat=1, xwidth=0, yheight=0, zdepth=0, radius=0 )
 OUTPUT PARAMETERS (params, geoparams)/*not really intended for output, but here for multi-instance support*/
-DEPENDENCY "-Wl,-rpath,CMD(ncrystal-config --show libdir) CMD(ncrystal-config --show libpath) -ICMD(ncrystal-config --show includedir)"
+DEPENDENCY "-Wl,-rpath,CMD(ncrystal-config --show libdir) -Wl,CMD(ncrystal-config --show libpath) -ICMD(ncrystal-config --show includedir)"
 NOACC /* Notice: you must remove this line if using the legacy McStas 2.x branch. */
 
 SHARE

--- a/mcstas-comps/parked/Union_plus_NCrystal/NCrystal_process.comp
+++ b/mcstas-comps/parked/Union_plus_NCrystal/NCrystal_process.comp
@@ -95,7 +95,7 @@ DEFINE COMPONENT NCrystal_process // Remember to change the name of process here
 DEFINITION PARAMETERS ()
 SETTING PARAMETERS(string cfg = "", packing_factor=1, interact_fraction=-1)
 OUTPUT PARAMETERS (This_process, NCrystal_storage, effective_my_scattering, params)
-DEPENDENCY "-Wl,-rpath,CMD(ncrystal-config --show libdir) CMD(ncrystal-config --show libpath) -ICMD(ncrystal-config --show includedir)"
+DEPENDENCY "-Wl,-rpath,CMD(ncrystal-config --show libdir) -Wl,CMD(ncrystal-config --show libpath) -ICMD(ncrystal-config --show includedir)"
 
 SHARE
 %{

--- a/mcstas-comps/union/NCrystal_process.comp
+++ b/mcstas-comps/union/NCrystal_process.comp
@@ -96,7 +96,7 @@ DEFINE COMPONENT NCrystal_process // Remember to change the name of process here
 DEFINITION PARAMETERS ()
 SETTING PARAMETERS(string cfg = "", packing_factor=1, interact_fraction=-1, string init="init")
 OUTPUT PARAMETERS (This_process, NCrystal_storage, effective_my_scattering, params)
-DEPENDENCY "-Wl,-rpath,CMD(ncrystal-config --show libdir) CMD(ncrystal-config --show libpath) -ICMD(ncrystal-config --show includedir)"
+DEPENDENCY "-Wl,-rpath,CMD(ncrystal-config --show libdir) -Wl,CMD(ncrystal-config --show libpath) -ICMD(ncrystal-config --show includedir)"
 
 SHARE
 %{


### PR DESCRIPTION
As seen in https://github.com/McStasMcXtrace/mccode-antlr/issues/54, the current NCrystal DEPENDENCY line puts out a library name like `/some/where/libNCrystal.so` which in the antlr context ends up being misunderstood by gcc which goes on to compile that as a source file. This PR simple adds `-Wl,` in from of `/some/where/libNCrystal.so` which should hopefully prevent this.