### PR TITLE
Add binder link in the "Docker" / container README

### DIFF
--- a/INSTALL-McStas/Docker/README.md
+++ b/INSTALL-McStas/Docker/README.md
@@ -4,3 +4,5 @@ The container definition is available at [here](https://github.com/willend/jupyt
 
 To run the container locally, use e.g.
 ```podman run -p 8888:8888 -p 5173:5173 docker.io/mccode/mcstas-mcxtrace```
+
+A corresponding container is also availalble on binder: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/McStasMcXtrace/jupyter-remote-desktop-proxy/HEAD?urlpath=desktop)

--- a/INSTALL-McXtrace/Docker/README.md
+++ b/INSTALL-McXtrace/Docker/README.md
@@ -4,3 +4,5 @@ The container definition is available at [here](https://github.com/willend/jupyt
 
 To run the container locally, use e.g.
 ```podman run -p 8888:8888 -p 5173:5173 docker.io/mccode/mcstas-mcxtrace```
+
+A corresponding container is also availalble on binder: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/McStasMcXtrace/jupyter-remote-desktop-proxy/HEAD?urlpath=desktop)


### PR DESCRIPTION
Allows to instantly run McStas / McXtrace on in a web desktop