### PR TITLE
Allow to build installable packages for linux aarch64 Debian / arm64

### DIFF
--- a/buildscripts/build_debs_mcstas_arm64
+++ b/buildscripts/build_debs_mcstas_arm64
@@ -34,7 +34,7 @@ FLAVOUR=mcstas
 # From 2.1 onwards, let McStas reside in /usr/share on Debian-like systems
 export MCINSTALL_PREFIX=/usr              # Debian standard /usr/bin and /usr/share/$FLAVOUR
 export MCCODE_USE_LEGACY_DESTINATIONS=OFF # install in e.g. /usr/share/$FLAVOUR/resources
-export ENABLE_CIF2HKL=OFF                 # cif2hkl is available as a separate package
+export ENABLE_CIF2HKL=ON                  # cif2hkl is available as a separate package
 
 ./mkdist $FLAVOUR                                         $1 "" "" $MCCODE_ARCH "" -- deb
 ./mkdist $FLAVOUR-comps                                   $1 "" "" $MCCODE_ARCH "" -- deb

--- a/buildscripts/build_debs_mcxtrace_arm64
+++ b/buildscripts/build_debs_mcxtrace_arm64
@@ -34,7 +34,7 @@ FLAVOUR=mcxtrace
 # From 2.1 onwards, let McStas reside in /usr/share on Debian-like systems
 export MCINSTALL_PREFIX=/usr              # Debian standard /usr/bin and /usr/share/$FLAVOUR
 export MCCODE_USE_LEGACY_DESTINATIONS=OFF # install in e.g. /usr/share/$FLAVOUR/resources
-export ENABLE_CIF2HKL=OFF                 # cif2hkl is available as a separate package
+export ENABLE_CIF2HKL=ON                  # cif2hkl is available as a separate package
 
 ./mkdist $FLAVOUR                                         $1 "" "" $MCCODE_ARCH "" -- deb
 ./mkdist $FLAVOUR-comps                                   $1 "" "" $MCCODE_ARCH "" -- deb

--- a/mcstas-comps/CMakeLists.txt
+++ b/mcstas-comps/CMakeLists.txt
@@ -21,10 +21,6 @@ set(CPACK_PACKAGE_VERSION       "1.0")
 set(CPACK_PACKAGE_VERSION_MAJOR "1")
 set(CPACK_PACKAGE_VERSION_MINOR "0")
 
-
-# Debian
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "${FLAVOR}-${MCCODE_VERSION}, libnexus-dev, libgsl-dev, cif2hkl")
-
 # NSIS
 set(CPACK_NSIS_PACKAGE_NAME "${MCCODE_STRING} Components")
 set(CPACK_NSIS_DISPLAY_NAME "${MCCODE_STRING} Components")
@@ -43,6 +39,13 @@ if ( ENABLE_CIF2HKL )
     PROGRAMS "${PROJECT_BINARY_DIR}/cif2hkl${DOT_EXE_SUFFIX}"
     DESTINATION "${DEST_BINDIR}"
     )
+endif()
+
+# Debian
+if ( ENABLE_CIF2HKL )
+  set(CPACK_DEBIAN_PACKAGE_DEPENDS "${FLAVOR}-${MCCODE_VERSION}, libnexus-dev, libgsl-dev")
+else()
+  set(CPACK_DEBIAN_PACKAGE_DEPENDS "${FLAVOR}-${MCCODE_VERSION}, libnexus-dev, libgsl-dev, cif2hkl")
 endif()
 
 option( ENABLE_NEUTRONICS "Build Third Party code neutronics (fortran)" ON )#TODO: Only enable enable Fortran if this is on

--- a/mcxtrace-comps/CMakeLists.txt
+++ b/mcxtrace-comps/CMakeLists.txt
@@ -22,9 +22,6 @@ set(CPACK_PACKAGE_VERSION_MAJOR "1")
 set(CPACK_PACKAGE_VERSION_MINOR "0")
 
 
-# Debian
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "${FLAVOR}-${MCCODE_VERSION}, libnexus-dev, libxrl-dev, libgsl-dev, cif2hkl")
-
 # NSIS
 set(CPACK_NSIS_PACKAGE_NAME "${MCCODE_STRING} Components")
 set(CPACK_NSIS_DISPLAY_NAME "${MCCODE_STRING} Components")
@@ -43,6 +40,13 @@ if ( ENABLE_CIF2HKL )
     PROGRAMS "${PROJECT_BINARY_DIR}/cif2hkl${DOT_EXE_SUFFIX}"
     DESTINATION "${DEST_BINDIR}"
     )
+endif()
+
+# Debian
+if ( ENABLE_CIF2HKL )
+  set(CPACK_DEBIAN_PACKAGE_DEPENDS "${FLAVOR}-${MCCODE_VERSION}, libnexus-dev, libxrl-dev, libgsl-dev")
+else()
+  set(CPACK_DEBIAN_PACKAGE_DEPENDS "${FLAVOR}-${MCCODE_VERSION}, libnexus-dev, libxrl-dev, libgsl-dev, cif2hkl")
 endif()
 
 # System c-code


### PR DESCRIPTION
cif2hkl is not available (currently) for linux64arm
This commit allows to build targeting this platform.

NOTA BENE!
Side-effect: McStas and McXtrace 3.5.1 can not (immediately) be installed to the same machine as they both include /usr/bin/cif2hkl...

(May be forced through of course... e.g.
sudo apt-get -o Dpkg::Options::="--force-overwrite" install mcxtrace-comps-3.5.1)