### PR TITLE
[Fix] missing pointer dereferences

### DIFF
--- a/mcstas-comps/optics/Derotator.comp
+++ b/mcstas-comps/optics/Derotator.comp
@@ -45,10 +45,11 @@ TRACE
   Rotation R;
 
   /* Name of Rotation uservar */
-  char* Rot_varptr = COMP_GETPAR3(Rotator, rotator, rot_var);
+  char* Rot_varptr = *COMP_GETPAR3(Rotator, rotator, rot_var);
 
   /* Invert rotation matrix for use in derotation */
-  rot_transpose((Rotation*)particle_getvar_void(_particle, Rot_varptr, NULL),R);
+  rot_transpose(*(Rotation *) particle_getvar_void(_particle, Rot_varptr, NULL), R);
+
   /* apply rotation to centered coordinates */
   Coords tmp = coords_set(x,y,z);
   coords_get(rot_apply(R, tmp), &x, &y, &z);

--- a/mcstas-comps/optics/Rotator.comp
+++ b/mcstas-comps/optics/Rotator.comp
@@ -107,6 +107,7 @@ if (nu != 0 || phase != 0) { /* rotate neutron w/r to position of component */
 
 %}
 
+
 MCDISPLAY
 %{
   int ih;


### PR DESCRIPTION
Fixes #1709 compiler warnings; `Test_DiskChoppers2.instr` compiles and runs (output not verified)