### PR TITLE
Tools: mcrun: optimization allows to specify criteria expression

### DIFF
--- a/mcxtrace-comps/monitors/EPSD_monitor.comp
+++ b/mcxtrace-comps/monitors/EPSD_monitor.comp
@@ -13,7 +13,7 @@
 * Release: McXtrace 1.5
 * Origin: DTU
 *
-* Position-sensitive monitor.
+* Position-energy-sensitive monitor.
 *
 * %Description
 * An nx times ny pixel energy resolved PSD monitor, which only counts photons with energy in an interval

--- a/mcxtrace-comps/monitors/Monitor.comp
+++ b/mcxtrace-comps/monitors/Monitor.comp
@@ -15,7 +15,7 @@
 * Origin: Risoe
 * Release: McXtrace 0.1
 *
-* Energy-sensitive monitor.
+* Simple monitor.
 *
 * %Description
 * A square single monitor that measures the intergated intensity of the incoming x-rays.

--- a/mcxtrace-comps/monitors/PSD_monitor_coh.comp
+++ b/mcxtrace-comps/monitors/PSD_monitor_coh.comp
@@ -12,7 +12,7 @@
 * Date: March 13, 2010
 * Origin: Risoe
 *
-* Position-sensitive monitor with phase intergration.
+* Position-sensitive monitor with phase integration.
 *
 * %Description
 * An (n times m) pixel PSD monitor taking phase into account.

--- a/mcxtrace-comps/monitors/W_psd_monitor.comp
+++ b/mcxtrace-comps/monitors/W_psd_monitor.comp
@@ -5,7 +5,7 @@
 *         DTU Physics, Kgs. Lyngby, Denmark
 *         Synchrotron SOLEIL, Saint-Aubin, France
 *
-* Component: PSD_monitor
+* Component: W_PSD_monitor
 *
 * %Identification
 * Written by: Erik Knudsen
@@ -20,7 +20,7 @@
 * An n times m pixel PSD wattage monitor. This component may also be used as a beam
 * detector.
 *
-* Example: PSD_monitor(xwidth=0.1, yheight=0.1,
+* Example: W_psd_monitor(xwidth=0.1, yheight=0.1,
 *           nx=90, ny=90, filename="Output.psd")
 *
 * %Parameters

--- a/tools/Python/mcrun/mccode.py
+++ b/tools/Python/mcrun/mccode.py
@@ -15,7 +15,7 @@ from os.path import isfile, dirname, basename, splitext, join
 from decimal import Decimal
 
 # import config
-
+import numpy
 import sys
 
 sys.path.append(join(dirname(__file__), '..'))
@@ -377,14 +377,40 @@ class McStas:
 
 
 class Detector(object):
-    ''' A detector '''
+    ''' A detector representation with its integrated values and statistics.'''
+    # this is used in optimisation.py
 
-    def __init__(self, name, intensity, error, count, path):
-        self.name = name
-        self.intensity = Decimal(intensity)
-        self.error = Decimal(error)
-        self.count = Decimal(count)
-        self.path = path
+    def __init__(self, name, intensity, error, count, path, statistics):
+        self.name  = name
+        self.intensity = float(intensity)
+        self.error = float(error)
+        self.count = float(count)
+        self.path  = path
+        self.values= numpy.array([ intensity, error, count ])
+        # get statistics
+        d = []
+        for sub in statistics.split(';'): # separate the 'name=value;' bits:
+          if '=' in sub:
+            d.append(map(str.strip, sub.split('=',1)))
+        
+        d = dict(d)
+        if not 'X0' in d:
+          d['X0'] = 0
+        if not 'dX' in d:
+          d['dX'] = 1
+        if not 'Y0' in d:
+          d['Y0'] = 0
+        if not 'dY' in d:
+          d['dY'] = 1
+        
+        self.X0 = float(d['X0'])
+        self.dX = float(d['dX'])
+        self.Y0 = float(d['Y0'])
+        self.dY = float(d['dY'])
+        if not self.dX:
+          self.dX = 1e-10
+        if not self.dY:
+          self.dY = 1e-10
 
 
 class McStasInfo:

--- a/tools/Python/mcrun/mcrun.py
+++ b/tools/Python/mcrun/mcrun.py
@@ -191,14 +191,14 @@ def add_mcrun_options(parser):
         metavar='optimize_eval',
         type=str,
         help='Optimization expression to evaluate for each detector "d" structure. You may combine:\n' +
-             '  d.intensity The detector intensity\n' +
-             '  d.error     The detector intensity uncertainty\n' +
-             '  d.values    An array with [intensity, error, counts]\n' +
-             '  d.X0 d.Y0   Center of signal (1st moment)\n' +
-             '  d.dX d.dY   Width  of signal (2nd moment)\n' +
-             'Default is "d.intensity". Suggestions are: \n' +
-             '  "d.intensity/d.dX"      for 1D\n' +
-             '  "d.intensity/d.dX/d.dY" for 2D',
+             '"d.intensity" The detector intensity;\n' +
+             '"d.error"     The detector intensity uncertainty;\n' +
+             '"d.values"    An array with [intensity, error, counts];\n' +
+             '"d.X0 d.Y0"   Center of signal (1st moment);\n' +
+             '"d.dX d.dY"   Width  of signal (2nd moment).\n' +
+             'Default is "d.intensity". Examples are: \n' +
+             '"d.intensity/d.dX" for 1D;\n' +
+             '"d.intensity/d.dX/d.dY" for 2D',
         nargs=1,
         default=None,
     )

--- a/tools/Python/mcrun/mcrun.py
+++ b/tools/Python/mcrun/mcrun.py
@@ -164,8 +164,9 @@ def add_mcrun_options(parser):
         "--optimize-maxiter",
         metavar="optimize_maxiter",
         type=int,
-        help="Maximum number of optimization iterations to perform",
+        help="Maximum number of optimization iterations to perform. Default=1000",
         nargs=1,
+        default=1000,
     )
     add(
         "--optimize-tol",
@@ -184,6 +185,22 @@ def add_mcrun_options(parser):
              'https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html?highlight=minimize',
         nargs=1,
         default=MINIMIZE_METHODS[0],
+    )
+    add(
+        "--optimize-eval",
+        metavar='optimize_eval',
+        type=str,
+        help='Optimization expression to evaluate for each detector "d" structure. You may combine:\n' +
+             '  d.intensity The detector intensity\n' +
+             '  d.error     The detector intensity uncertainty\n' +
+             '  d.values    An array with [intensity, error, counts]\n' +
+             '  d.X0 d.Y0   Center of signal (1st moment)\n' +
+             '  d.dX d.dY   Width  of signal (2nd moment)\n' +
+             'Default is "d.intensity". Suggestions are: \n' +
+             '  "d.intensity/d.dX"      for 1D\n' +
+             '  "d.intensity/d.dX/d.dY" for 2D',
+        nargs=1,
+        default=None,
     )
     add(
         "--optimize-minimize",

--- a/tools/Python/mcrun/optimisation.py
+++ b/tools/Python/mcrun/optimisation.py
@@ -157,7 +157,7 @@ def mcsimdetectors(directory_name: str):
     if not directory.exists() and directory.is_dir():
         raise RuntimeError(f"{directory_name} is not a directory")
     filepath = directory.joinpath('mccode.sim')
-    hdfpath = directory.joinpath('mccode.h5')
+    hdfpath  = directory.joinpath('mccode.h5')
     if not filepath.exists() and hdfpath.exists():
         return
     if not filepath.exists():
@@ -169,7 +169,7 @@ def mcsimdetectors(directory_name: str):
     # with lines of the form "{key}: {value}"
     blocks = [{k.strip(): v.strip() for k, v in [z.split(':', 1) for z in b.split('\n')]} for b in blocks]
     # This object only cares about extracting the (name, I, Err, N, data file) sets for each detector
-    return [Detector(d['component'], *d['values'].split(), d['filename']) for d in blocks]
+    return [Detector(d['component'], *d['values'].split(), d['filename'], d['statistics']) for d in blocks]
 
 
 def point_at(N, key, minmax, step):
@@ -405,11 +405,17 @@ def McCode_runner(x, args):
     # add monitors that match a given name
     for d in detectors:
         if d.name in args.mcstas.options.optimize_monitor:
-            values.append(d.intensity)
+            if args.mcstas.options.optimize_eval:
+              values.append(eval(args.mcstas.options.optimize_eval))
+            else:
+              values.append(d.intensity)
     # in case monitor name is not found, we use all monitor values
     if len(values) == 0:
         for d in detectors:
-            values.append(d.intensity)
+            if args.mcstas.options.optimize_eval:
+              values.append(eval(args.mcstas.options.optimize_eval))
+            else:
+              values.append(d.intensity)
 
     values = [float(d) for d in values]
 


### PR DESCRIPTION
This PR provides the ability to specify an expression with `--optimize-eval="EXPR"` such as:
```
mxrun --optimize --optimize-monitor=psd1 --optimize-eval="d.intensity/d.dX" Test_Mono.instr Mono=1 OMM=14.219,14.223
```
This enables to optimize on existing monitors, and still use some predefined statistics within:
- `d.intensity` The  detector intensity; 
- `d.error`     The detector intensity uncertainty; 
- `d.values`    An array with [intensity, error, counts]; 
- `d.X0 d.Y0`   Center of signal (1st moment); 
- `d.dX d.dY`   Width  of signal (2nd moment). 

Default is `d.intensity`. Examples are:  
- `d.intensity/d.dX` for 1D;
- `d.intensity/d.dX/d.dY` for 2D

This PR avoids to create specific monitors for optimization, as long as the 1st/2nd moments are satisfactory.