### PR TITLE
mcrun: optimisation: better choice for missing dX/dY

### DIFF
--- a/tools/Python/mcrun/mccode.py
+++ b/tools/Python/mcrun/mccode.py
@@ -408,9 +408,12 @@ class Detector(object):
         self.Y0 = float(d['Y0'])
         self.dY = float(d['dY'])
         if not self.dX:
-          self.dX = 1e-10
+          self.dX = 1
         if not self.dY:
-          self.dY = 1e-10
+          if self.dX:
+            self.dY = self.dX
+          else:
+            self.dY = 1
 
 
 class McStasInfo:

--- a/tools/Python/mcrun/mcrun.py
+++ b/tools/Python/mcrun/mcrun.py
@@ -197,8 +197,7 @@ def add_mcrun_options(parser):
              '"d.X0 d.Y0"   Center of signal (1st moment);\n' +
              '"d.dX d.dY"   Width  of signal (2nd moment).\n' +
              'Default is "d.intensity". Examples are: \n' +
-             '"d.intensity/d.dX" for 1D;\n' +
-             '"d.intensity/d.dX/d.dY" for 2D',
+             '"d.intensity/d.dX" and "d.intensity/d.dX/d.dY"',
         nargs=1,
         default=None,
     )


### PR DESCRIPTION
Just an edit to use `dY = dX` so that a 2D criteria such as `intensity/dX/dY` has a meaning on 1D detectors. When nothing defined, the widths are set to 1 so that we have per default the intensity.