### PR TITLE
Consequence-edit from earlier PowderN

### DIFF
--- a/mcstas-comps/examples/ESS/ESS_BEER_MCPL/ESS_BEER_MCPL.instr
+++ b/mcstas-comps/examples/ESS/ESS_BEER_MCPL/ESS_BEER_MCPL.instr
@@ -46,8 +46,8 @@
 *  ESS_BEER_MCPL input=BEER_MCB.mcpl repetition=50 pwdfile=duplex.laz lc=9.35 lam0=2 dlam=1.8 omega=45 chi=90 colw=1 modul=1 mod_frq=2240 mod_twidth=0.0029 mod_shift=0 only_event=-1 pinc=0.1 ptra=0 strain=0 ustrain=0 
 *  Detector: psdtof_I=98.3885
 *
-* %Example: input=BEER_MR.mcpl repetition=50 lc=6.65 modul=0 mod_twidth=0.0029 Detector: psdtof_I=276.842
-* Example: input=BEER_MCB.mcpl repetition=50 lc=9.35 modul=1 mod_twidth=0.0029 Detector: psdtof_I=98.3885
+* %Example: input=BEER_MR.mcpl repetition=50 lc=6.65 modul=0 mod_twidth=0.0029 Detector: psdtof_I=138.421
+* Example: input=BEER_MCB.mcpl repetition=50 lc=9.35 modul=1 mod_twidth=0.0029 Detector: psdtof_I=49.1942
 *
 * %Parameters
 *

--- a/mcstas-comps/examples/Tests_MCPL_etc/Test_MCPL_input_once/Test_MCPL_input_once.instr
+++ b/mcstas-comps/examples/Tests_MCPL_etc/Test_MCPL_input_once/Test_MCPL_input_once.instr
@@ -33,16 +33,11 @@ DECLARE
 %{
   long long ncount_i;
 %}
-)
-
 
 INITIALIZE
 %{
-
-
-printf("Using the input file: %s\n", MCPLFILE);
-
- ncount_i=0;
+  printf("Using the input file: %s\n", MCPLFILE);
+  ncount_i=0;
 %}
 
 TRACE


### PR DESCRIPTION
Take into account 0.5 scaling in case of `tth_sign` and `d_phi`