### PR TITLE
Add -n in supplement of --ncount, allow match including .instr

### DIFF
--- a/tools/Python/mccodelib/utils.py
+++ b/tools/Python/mccodelib/utils.py
@@ -686,7 +686,7 @@ def get_instr_comp_files(mydir, recursive=True, instrfilter=None, compfilter=Non
             # get instr files
             if splitext(f)[1] == '.instr':
                 if instrfilter is not None:
-                    if instrreg.search(join(dirpath,splitext(f)[0]), re.IGNORECASE):
+                    if instrreg.search(join(dirpath,f), re.IGNORECASE):
                         files_instr.append(join(dirpath, f))
                 else:
                     files_instr.append(join(dirpath, f))
@@ -694,7 +694,7 @@ def get_instr_comp_files(mydir, recursive=True, instrfilter=None, compfilter=Non
             # get comp files
             if os.path.splitext(f)[1] == '.comp':
                 if compfilter is not None:
-                    if compreg.search(splitext(f)[0]):
+                    if compreg.search(f):
                         files_comp.append(join(dirpath, f))
                 else:
                     files_comp.append(join(dirpath, f))

--- a/tools/Python/mctest/mctest.py
+++ b/tools/Python/mctest/mctest.py
@@ -651,6 +651,8 @@ def main(args):
     global ncount, mpi, skipnontest, openacc, nexus
     if args.ncount:
         ncount = args.ncount[0]
+    elif args.n:
+        ncount = args.n[0]
     else:
         ncount = "1e6"
     suffix = '_' + ncount
@@ -693,6 +695,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('testversion', nargs="?", help='mccode version to test')
     parser.add_argument('--ncount', nargs=1, help='ncount sent to %s' % (mccode_config.configuration["MCRUN"]) )
+    parser.add_argument('-n', nargs=1, help='ncount sent to %s' % (mccode_config.configuration["MCRUN"]) )
     parser.add_argument('--mpi', nargs=1, help='mpi nodecount sent to %s' % (mccode_config.configuration["MCRUN"]) )
     parser.add_argument('--openacc', action='store_true', help='openacc flag sent to %s' % (mccode_config.configuration["MCRUN"]))
     parser.add_argument('--config', nargs="?", help='test this specific config only - label name or absolute path')


### PR DESCRIPTION
Usability-improvements for the mctest util