### PR TITLE
Fix for issue 1763 and related issue propagating --no-output-files

### DIFF
--- a/tools/Python/mcgui/mcgui.py
+++ b/tools/Python/mcgui/mcgui.py
@@ -373,9 +373,9 @@ class McGuiState(QtCore.QObject):
             self.__dataDir = output_dir
         elif simtrace == 1: # trace (mcdisplay)
             if inspect:
-                runstr = mccode_config.configuration["MCDISPLAY"] + ' ' + os.path.basename(self.__instrFile) + ' --no-output-files' + ' --inspect=' + inspect
+                runstr = mccode_config.configuration["MCDISPLAY"] + ' ' + os.path.basename(self.__instrFile) + ' --inspect=' + inspect
             else:
-                runstr = mccode_config.configuration["MCDISPLAY"] + ' ' + os.path.basename(self.__instrFile) + ' --no-output-files'
+                runstr = mccode_config.configuration["MCDISPLAY"] + ' ' + os.path.basename(self.__instrFile)
         else:
             raise Exception('mcgui.run: invalid execution mode (simulate/trace/optimize).')
         
@@ -731,7 +731,7 @@ class McGuiAppController():
             DISPLAY="mxdisplay"
         self.emitter.status('Running ' + DISPLAY + '-webgl...')
         try:
-            cmd = DISPLAY+'-webgl --default --no-output-files -n100 ' + os.path.basename(self.state.getInstrumentFile()) + '&'
+            cmd = DISPLAY+'-webgl --default -n100 ' + os.path.basename(self.state.getInstrumentFile()) + '&'
             self.emitter.message(cmd, gui=True)
             self.emitter.message('', gui=True)
             
@@ -748,7 +748,7 @@ class McGuiAppController():
             DISPLAY="mxdisplay"
         self.emitter.status('Running ' + DISPLAY + '-pyqtgraph...')
         try:
-            cmd = DISPLAY+'-pyqtgraph --default --no-output-files -n100 ' + os.path.basename(self.state.getInstrumentFile()) + '&'
+            cmd = DISPLAY+'-pyqtgraph --default -n100 ' + os.path.basename(self.state.getInstrumentFile()) + '&'
             self.emitter.message(cmd, gui=True)
             self.emitter.message('', gui=True)
             

--- a/tools/Python/mcgui/mcgui.py
+++ b/tools/Python/mcgui/mcgui.py
@@ -725,9 +725,13 @@ class McGuiAppController():
             self.emitter.status('Running plotter ...')        
     
     def handleMcDisplayWeb(self):
-        self.emitter.status('Running mcdisplay-webgl...')
+        if mccode_config.configuration["MCCODE"]=="mcstas":
+            DISPLAY="mcdisplay"
+        else:
+            DISPLAY="mxdisplay"
+        self.emitter.status('Running ' + DISPLAY + '-webgl...')
         try:
-            cmd = 'mcdisplay-webgl --default --no-output-files -n100 ' + os.path.basename(self.state.getInstrumentFile()) + '&'
+            cmd = DISPLAY+'-webgl --default --no-output-files -n100 ' + os.path.basename(self.state.getInstrumentFile()) + '&'
             self.emitter.message(cmd, gui=True)
             self.emitter.message('', gui=True)
             
@@ -738,9 +742,13 @@ class McGuiAppController():
             self.emitter.status('')
     
     def handleMcDisplay2D(self):
-        self.emitter.status('Running mcdisplay-webgl...')
+        if mccode_config.configuration["MCCODE"]=="mcstas":
+            DISPLAY="mcdisplay"
+        else:
+            DISPLAY="mxdisplay"
+        self.emitter.status('Running ' + DISPLAY + '-pyqtgraph...')
         try:
-            cmd = 'mcdisplay-pyqtgraph --default --no-output-files -n100 ' + os.path.basename(self.state.getInstrumentFile()) + '&'
+            cmd = DISPLAY+'-pyqtgraph --default --no-output-files -n100 ' + os.path.basename(self.state.getInstrumentFile()) + '&'
             self.emitter.message(cmd, gui=True)
             self.emitter.message('', gui=True)
             


### PR DESCRIPTION
As observed by @Momsnoodle in https://github.com/McStasMcXtrace/McCode/issues/1763, McXtrace 3.5.1 (and many earlier releases) was shipped configured to launch "mcdisplay-" tools (in place of mcxdisplay-) when using the `Simulation->Display-3D` and `Simulation->Display-2D` menu points.

This PR fixes the above plus a related observation by myself that mc/xdisplay-webgl may wrongly interpret `--no-output-files` as an input (should have been just forwarded to mcrun, this is anyway done internally).