### PR TITLE
Expand on Test_Powders from Mads

### DIFF
--- a/mcstas-comps/examples/ILL/ILL_H143_LADI/ILL_H143_LADI.instr
+++ b/mcstas-comps/examples/ILL/ILL_H143_LADI/ILL_H143_LADI.instr
@@ -451,7 +451,7 @@ COMPONENT sample_Phic2 = Monitor_nD(
 
 SPLIT 50 COMPONENT sample = Single_crystal(
   xwidth=0.01, yheight=0.01, zdepth=0.01,
-  mosaic = 5, reflections="leucine.lau")
+  mosaic = 5, reflections=reflections, order=1)
   AT (0,0,0) RELATIVE sample_pos1
   ROTATED (0,5,10) RELATIVE sample_pos1
 EXTEND %{

--- a/mcstas-comps/examples/TRIGA/RTP_Laue/RTP_Laue.instr
+++ b/mcstas-comps/examples/TRIGA/RTP_Laue/RTP_Laue.instr
@@ -21,6 +21,7 @@
 * theta: [deg]         horizontal rotation of the object
 * phi: [deg]           vertical rotation of the object
 * det_rotation: [deg]  detector rotation around the sample
+* reflections:  [str]  sample configuration
 *
 * %Link
 * <a href="http://www.nuclearmalaysia.gov.my/Plant&Facilities/reactor.php">Nuclear Malaysia</a>
@@ -29,7 +30,7 @@
 *
 * %End
 *******************************************************************************/
-DEFINE INSTRUMENT RTP_Laue(theta=0, phi=0, det_rotation=0)
+DEFINE INSTRUMENT RTP_Laue(theta=0, phi=0, det_rotation=0, string reflections="leucine.lau")
 
 /* The DECLARE section allows us to declare variables or  small      */
 /* functions in C syntax. These may be used in the whole instrument. */
@@ -95,7 +96,7 @@ COMPONENT sample_position_rotated = Arm()
   %}
 
 SPLIT COMPONENT sample_outer1 = Single_crystal(xwidth=0.01, yheight=0.05, zdepth=0.01,
-  reflections="leucine.lau", mosaic=5)
+  reflections=reflections, mosaic=5, order=1)
   AT (0,0,0) RELATIVE sample_position_rotated
   EXTEND %{
     if (SCATTERED) sample_scattered+=SCATTERED;

--- a/mcstas-comps/examples/Templates/templateNMX/templateNMX.instr
+++ b/mcstas-comps/examples/Templates/templateNMX/templateNMX.instr
@@ -45,7 +45,7 @@ AT (0,0,5) RELATIVE source
 
 SPLIT REPS COMPONENT sample = Single_crystal(
           xwidth=0.001, yheight=0.001, zdepth=0.001, mosaic=1e-4,
-          reflections=reflections)
+          reflections=reflections, order=1)
 AT (0,0,0.10) RELATIVE slit
 EXTEND %{
   if (!SCATTERED) ABSORB; /* perfect beam stop */

--- a/mcstas-comps/examples/Templates/templateNMX_TOF/templateNMX_TOF.instr
+++ b/mcstas-comps/examples/Templates/templateNMX_TOF/templateNMX_TOF.instr
@@ -69,7 +69,7 @@ AT (0, 0, 0.001) RELATIVE PREVIOUS
 
 SPLIT REPS COMPONENT sample = Single_crystal(
           xwidth=0.001, yheight=0.001, zdepth=0.001, mosaic=1e-4,
-          reflections=reflections)
+          reflections=reflections, order=1)
 AT (0,0,0.10) RELATIVE slit
 EXTEND %{
   if (!SCATTERED) ABSORB; /* perfect beam stop */

--- a/mcstas-comps/examples/Tests_optics/Test_Monochromators/Test_Monochromators.instr
+++ b/mcstas-comps/examples/Tests_optics/Test_Monochromators/Test_Monochromators.instr
@@ -23,8 +23,8 @@
 * %Example: Mono=4 Detector: psd1_I=8.9e-05
 * %Example: Mono=5 Detector: psd1_I=8.9e-05
 * %Example: Mono=6 Detector: psd1_I=1.0e-04
-* %Example: Mono=6 PG=0.15 Detector: psd1_I=2.8e-05
-* %Example: Mono=6 powder=0.15 Detector: psd1_I=3.3e-07
+* %Example: Mono=6 PG=1 Detector: psd1_I=1.3e-04
+* %Example: Mono=6 powder=1 Moz=60 Detector: psd1_I=4.5e-07
 * %Example: Mono=6 ay=2.13389 az=-1.232 bz=2.464 cx=6.711 Detector: psd1_I=1.0e-04
 * %Example: Mono=6 ay=2.94447 by=1.47224 bz=2.54999 cx=0.936252 recip=1 Detector: psd1_I=1.0e-04
 * %Example: Mono=7 ay=2.94447 by=1.47224 bz=2.54999 cx=0.936252 recip=1 Detector: psd1_I=9.6e-05

--- a/mcstas-comps/examples/Tests_samples/Test_Powders/Al.cif
+++ b/mcstas-comps/examples/Tests_samples/Test_Powders/Al.cif
@@ -1,0 +1,264 @@
+#------------------------------------------------------------------------------
+#$Date: 2016-02-18 17:37:37 +0200 (Thu, 18 Feb 2016) $
+#$Revision: 176729 $
+#$URL: svn://www.crystallography.net/cod/cif/1/50/26/1502689.cif $
+#------------------------------------------------------------------------------
+#
+# This file is available in the Crystallography Open Database (COD),
+# http://www.crystallography.net/
+#
+# All data on this site have been placed in the public domain by the
+# contributors.
+#
+data_1502689
+loop_
+_publ_author_name
+'Mulder, Fokko M.'
+'Assfour, Bassem'
+'Huot, Jacques'
+'Dingemans, Theo J.'
+'Wagemaker, Marnix'
+'Ramirez-Cuesta, A. J.'
+_publ_section_title
+;
+ Hydrogen in the Metal&#x2212;Organic Framework Cr MIL-53
+;
+_journal_issue                   23
+_journal_name_full               'The Journal of Physical Chemistry C'
+_journal_page_first              10648
+_journal_paper_doi               10.1021/jp102463p
+_journal_volume                  114
+_journal_year                    2010
+_chemical_formula_sum            Al
+_chemical_formula_weight         26.98
+_chemical_name_systematic        ' ?'
+_space_group_IT_number           225
+_symmetry_cell_setting           cubic
+_symmetry_space_group_name_Hall  '-F 4 2 3'
+_symmetry_space_group_name_H-M   'F m -3 m'
+_cell_angle_alpha                90.0
+_cell_angle_beta                 90.0
+_cell_angle_gamma                90.0
+_cell_formula_units_Z            4
+_cell_length_a                   4.0339(4)
+_cell_length_b                   4.0339
+_cell_length_c                   4.0339
+_cell_volume                     65.641(7)
+_pd_block_id
+2010-05-11T12:36|GEM28422-CIF_phase2|GEM284422||
+_pd_phase_name                   'from C:/gsas/MyWork/GEM28405.EXP'
+_cod_data_source_file            jp102463p_si_002.cif
+_cod_data_source_block           GEM28422-CIF_phase_2
+_cod_original_cell_volume        65.643(21)
+_cod_original_sg_symbol_H-M      'F m 3 m'
+_cod_database_code               1502689
+loop_
+_symmetry_equiv_pos_site_id
+_symmetry_equiv_pos_as_xyz
+1 +x,+y,+z
+2 +z,+x,+y
+3 +y,+z,+x
+4 +x,+y,-z
+5 -z,+x,+y
+6 +y,-z,+x
+7 -z,+x,-y
+8 -y,-z,+x
+9 +y,-z,-x
+10 -x,+y,-z
+11 -z,-x,+y
+12 +x,-y,-z
+13 +y,+x,+z
+14 +z,+y,+x
+15 +x,+z,+y
+16 +y,+x,-z
+17 -z,+y,+x
+18 +x,-z,+y
+19 -z,+y,-x
+20 -x,-z,+y
+21 +x,-z,-y
+22 -y,+x,-z
+23 -z,-y,+x
+24 +y,-x,-z
+-1 -x,-y,-z
+-2 -z,-x,-y
+-3 -y,-z,-x
+-4 -x,-y,+z
+-5 +z,-x,-y
+-6 -y,+z,-x
+-7 +z,-x,+y
+-8 +y,+z,-x
+-9 -y,+z,+x
+-10 +x,-y,+z
+-11 +z,+x,-y
+-12 -x,+y,+z
+-13 -y,-x,-z
+-14 -z,-y,-x
+-15 -x,-z,-y
+-16 -y,-x,+z
+-17 +z,-y,-x
+-18 -x,+z,-y
+-19 +z,-y,+x
+-20 +x,+z,-y
+-21 -x,+z,+y
+-22 +y,-x,+z
+-23 +z,+y,-x
+-24 -y,+x,+z
+101 +x,+y+1/2,+z+1/2
+102 +z,+x+1/2,+y+1/2
+103 +y,+z+1/2,+x+1/2
+104 +x,+y+1/2,-z+1/2
+105 -z,+x+1/2,+y+1/2
+106 +y,-z+1/2,+x+1/2
+107 -z,+x+1/2,-y+1/2
+108 -y,-z+1/2,+x+1/2
+109 +y,-z+1/2,-x+1/2
+110 -x,+y+1/2,-z+1/2
+111 -z,-x+1/2,+y+1/2
+112 +x,-y+1/2,-z+1/2
+113 +y,+x+1/2,+z+1/2
+114 +z,+y+1/2,+x+1/2
+115 +x,+z+1/2,+y+1/2
+116 +y,+x+1/2,-z+1/2
+117 -z,+y+1/2,+x+1/2
+118 +x,-z+1/2,+y+1/2
+119 -z,+y+1/2,-x+1/2
+120 -x,-z+1/2,+y+1/2
+121 +x,-z+1/2,-y+1/2
+122 -y,+x+1/2,-z+1/2
+123 -z,-y+1/2,+x+1/2
+124 +y,-x+1/2,-z+1/2
+-101 -x,-y+1/2,-z+1/2
+-102 -z,-x+1/2,-y+1/2
+-103 -y,-z+1/2,-x+1/2
+-104 -x,-y+1/2,+z+1/2
+-105 +z,-x+1/2,-y+1/2
+-106 -y,+z+1/2,-x+1/2
+-107 +z,-x+1/2,+y+1/2
+-108 +y,+z+1/2,-x+1/2
+-109 -y,+z+1/2,+x+1/2
+-110 +x,-y+1/2,+z+1/2
+-111 +z,+x+1/2,-y+1/2
+-112 -x,+y+1/2,+z+1/2
+-113 -y,-x+1/2,-z+1/2
+-114 -z,-y+1/2,-x+1/2
+-115 -x,-z+1/2,-y+1/2
+-116 -y,-x+1/2,+z+1/2
+-117 +z,-y+1/2,-x+1/2
+-118 -x,+z+1/2,-y+1/2
+-119 +z,-y+1/2,+x+1/2
+-120 +x,+z+1/2,-y+1/2
+-121 -x,+z+1/2,+y+1/2
+-122 +y,-x+1/2,+z+1/2
+-123 +z,+y+1/2,-x+1/2
+-124 -y,+x+1/2,+z+1/2
+201 +x+1/2,+y,+z+1/2
+202 +z+1/2,+x,+y+1/2
+203 +y+1/2,+z,+x+1/2
+204 +x+1/2,+y,-z+1/2
+205 -z+1/2,+x,+y+1/2
+206 +y+1/2,-z,+x+1/2
+207 -z+1/2,+x,-y+1/2
+208 -y+1/2,-z,+x+1/2
+209 +y+1/2,-z,-x+1/2
+210 -x+1/2,+y,-z+1/2
+211 -z+1/2,-x,+y+1/2
+212 +x+1/2,-y,-z+1/2
+213 +y+1/2,+x,+z+1/2
+214 +z+1/2,+y,+x+1/2
+215 +x+1/2,+z,+y+1/2
+216 +y+1/2,+x,-z+1/2
+217 -z+1/2,+y,+x+1/2
+218 +x+1/2,-z,+y+1/2
+219 -z+1/2,+y,-x+1/2
+220 -x+1/2,-z,+y+1/2
+221 +x+1/2,-z,-y+1/2
+222 -y+1/2,+x,-z+1/2
+223 -z+1/2,-y,+x+1/2
+224 +y+1/2,-x,-z+1/2
+-201 -x+1/2,-y,-z+1/2
+-202 -z+1/2,-x,-y+1/2
+-203 -y+1/2,-z,-x+1/2
+-204 -x+1/2,-y,+z+1/2
+-205 +z+1/2,-x,-y+1/2
+-206 -y+1/2,+z,-x+1/2
+-207 +z+1/2,-x,+y+1/2
+-208 +y+1/2,+z,-x+1/2
+-209 -y+1/2,+z,+x+1/2
+-210 +x+1/2,-y,+z+1/2
+-211 +z+1/2,+x,-y+1/2
+-212 -x+1/2,+y,+z+1/2
+-213 -y+1/2,-x,-z+1/2
+-214 -z+1/2,-y,-x+1/2
+-215 -x+1/2,-z,-y+1/2
+-216 -y+1/2,-x,+z+1/2
+-217 +z+1/2,-y,-x+1/2
+-218 -x+1/2,+z,-y+1/2
+-219 +z+1/2,-y,+x+1/2
+-220 +x+1/2,+z,-y+1/2
+-221 -x+1/2,+z,+y+1/2
+-222 +y+1/2,-x,+z+1/2
+-223 +z+1/2,+y,-x+1/2
+-224 -y+1/2,+x,+z+1/2
+301 +x+1/2,+y+1/2,+z
+302 +z+1/2,+x+1/2,+y
+303 +y+1/2,+z+1/2,+x
+304 +x+1/2,+y+1/2,-z
+305 -z+1/2,+x+1/2,+y
+306 +y+1/2,-z+1/2,+x
+307 -z+1/2,+x+1/2,-y
+308 -y+1/2,-z+1/2,+x
+309 +y+1/2,-z+1/2,-x
+310 -x+1/2,+y+1/2,-z
+311 -z+1/2,-x+1/2,+y
+312 +x+1/2,-y+1/2,-z
+313 +y+1/2,+x+1/2,+z
+314 +z+1/2,+y+1/2,+x
+315 +x+1/2,+z+1/2,+y
+316 +y+1/2,+x+1/2,-z
+317 -z+1/2,+y+1/2,+x
+318 +x+1/2,-z+1/2,+y
+319 -z+1/2,+y+1/2,-x
+320 -x+1/2,-z+1/2,+y
+321 +x+1/2,-z+1/2,-y
+322 -y+1/2,+x+1/2,-z
+323 -z+1/2,-y+1/2,+x
+324 +y+1/2,-x+1/2,-z
+-301 -x+1/2,-y+1/2,-z
+-302 -z+1/2,-x+1/2,-y
+-303 -y+1/2,-z+1/2,-x
+-304 -x+1/2,-y+1/2,+z
+-305 +z+1/2,-x+1/2,-y
+-306 -y+1/2,+z+1/2,-x
+-307 +z+1/2,-x+1/2,+y
+-308 +y+1/2,+z+1/2,-x
+-309 -y+1/2,+z+1/2,+x
+-310 +x+1/2,-y+1/2,+z
+-311 +z+1/2,+x+1/2,-y
+-312 -x+1/2,+y+1/2,+z
+-313 -y+1/2,-x+1/2,-z
+-314 -z+1/2,-y+1/2,-x
+-315 -x+1/2,-z+1/2,-y
+-316 -y+1/2,-x+1/2,+z
+-317 +z+1/2,-y+1/2,-x
+-318 -x+1/2,+z+1/2,-y
+-319 +z+1/2,-y+1/2,+x
+-320 +x+1/2,+z+1/2,-y
+-321 -x+1/2,+z+1/2,+y
+-322 +y+1/2,-x+1/2,+z
+-323 +z+1/2,+y+1/2,-x
+-324 -y+1/2,+x+1/2,+z
+loop_
+_atom_site_type_symbol
+_atom_site_label
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_atom_site_thermal_displace_type
+_atom_site_U_iso_or_equiv
+_atom_site_symmetry_multiplicity
+Al AL1 0.0 0.0 0.0 1.0 Uiso 0.001 4
+loop_
+_atom_type_symbol
+_atom_type_number_in_cell
+Al 4.0

--- a/mcstas-comps/examples/Tests_samples/Test_Powders/Ge.cif
+++ b/mcstas-comps/examples/Tests_samples/Test_Powders/Ge.cif
@@ -1,0 +1,255 @@
+#------------------------------------------------------------------------------
+#$Date: 2024-05-09 11:47:05 +0300 (Thu, 09 May 2024) $
+#$Revision: 291792 $
+#$URL: file:///home/coder/svn-repositories/cod/cif/9/01/10/9011050.cif $
+#------------------------------------------------------------------------------
+#
+# This file is available in the Crystallography Open Database (COD),
+# http://www.crystallography.net/. The original data for this entry
+# were provided the American Mineralogist Crystal Structure Database,
+# http://rruff.geo.arizona.edu/AMS/amcsd.php
+#
+# The file may be used within the scientific community so long as
+# proper attribution is given to the journal article from which the
+# data were obtained.
+#
+data_9011050
+loop_
+_publ_author_name
+'Cooper, A. S.'
+_publ_section_title
+;
+ Precise lattice constants of germanium, aluminum, gallium arsenide, uranium,
+ sulphur, quartz and sapphire
+ Sample: at T = 24.6 C
+;
+_journal_name_full               'Acta Crystallographica'
+_journal_page_first              578
+_journal_page_last               582
+_journal_paper_doi               10.1107/S0365110X62001474
+_journal_volume                  15
+_journal_year                    1962
+_chemical_compound_source        Synthetic
+_chemical_formula_sum            Ge
+_chemical_name_mineral           Germanium
+_space_group_IT_number           227
+_symmetry_space_group_name_Hall  'F 4d 2 3 -1d'
+_symmetry_space_group_name_H-M   'F d -3 m :1'
+_cell_angle_alpha                90
+_cell_angle_beta                 90
+_cell_angle_gamma                90
+_cell_length_a                   5.65754
+_cell_length_b                   5.65754
+_cell_length_c                   5.65754
+_cell_formula_units_Z            8
+_cell_volume                     181.085
+_database_code_amcsd             0009269
+_diffrn_ambient_temperature      297.75
+_exptl_crystal_density_diffrn    5.327
+_cod_original_sg_symbol_H-M      'F d 3 m'
+_cod_database_code               9011050
+loop_
+_space_group_symop_operation_xyz
+x,y,z
+x,1/2+y,1/2+z
+1/2+x,y,1/2+z
+1/2+x,1/2+y,z
+3/4+z,3/4-x,1/4+y
+3/4+z,1/4-x,3/4+y
+1/4+z,3/4-x,3/4+y
+1/4+z,1/4-x,1/4+y
+-y,1/2+z,1/2-x
+-y,+z,-x
+1/2-y,1/2+z,-x
+1/2-y,+z,1/2-x
+3/4+x,3/4-y,1/4+z
+3/4+x,1/4-y,3/4+z
+1/4+x,3/4-y,3/4+z
+1/4+x,1/4-y,1/4+z
+-z,1/2+x,1/2-y
+-z,+x,-y
+1/2-z,1/2+x,-y
+1/2-z,+x,1/2-y
+3/4+y,3/4-z,1/4+x
+3/4+y,1/4-z,3/4+x
+1/4+y,3/4-z,3/4+x
+1/4+y,1/4-z,1/4+x
+-x,1/2+y,1/2-z
+-x,+y,-z
+1/2-x,1/2+y,-z
+1/2-x,+y,1/2-z
+1/2+x,-z,1/2-y
+1/2+x,1/2-z,-y
++x,-z,-y
++x,1/2-z,1/2-y
+3/4-z,3/4+y,1/4+x
+3/4-z,1/4+y,3/4+x
+1/4-z,3/4+y,3/4+x
+1/4-z,1/4+y,1/4+x
+1/2+y,-x,1/2-z
+1/2+y,1/2-x,-z
++y,-x,-z
++y,1/2-x,1/2-z
+3/4-x,3/4+z,1/4+y
+3/4-x,1/4+z,3/4+y
+1/4-x,3/4+z,3/4+y
+1/4-x,1/4+z,1/4+y
+1/2+z,-y,1/2-x
+1/2+z,1/2-y,-x
++z,-y,-x
++z,1/2-y,1/2-x
+3/4-y,3/4+x,1/4+z
+3/4-y,1/4+x,3/4+z
+1/4-y,3/4+x,3/4+z
+1/4-y,1/4+x,1/4+z
+x,1/2+z,1/2+y
+x,+z,+y
+1/2+x,1/2+z,+y
+1/2+x,+z,1/2+y
+1/4-z,3/4-y,3/4-x
+1/4-z,1/4-y,1/4-x
+3/4-z,3/4-y,1/4-x
+3/4-z,1/4-y,3/4-x
+y,1/2+x,1/2+z
+y,+x,+z
+1/2+y,1/2+x,+z
+1/2+y,+x,1/2+z
+1/4-x,3/4-z,3/4-y
+1/4-x,1/4-z,1/4-y
+3/4-x,3/4-z,1/4-y
+3/4-x,1/4-z,3/4-y
+z,1/2+y,1/2+x
+z,+y,+x
+1/2+z,1/2+y,+x
+1/2+z,+y,1/2+x
+1/4-y,3/4-x,3/4-z
+1/4-y,1/4-x,1/4-z
+3/4-y,3/4-x,1/4-z
+3/4-y,1/4-x,3/4-z
+3/4+z,1/4+x,3/4-y
+3/4+z,3/4+x,1/4-y
+1/4+z,1/4+x,1/4-y
+1/4+z,3/4+x,3/4-y
+-y,1/2-z,1/2+x
+-y,-z,+x
+1/2-y,1/2-z,+x
+1/2-y,-z,1/2+x
+3/4+x,1/4+y,3/4-z
+3/4+x,3/4+y,1/4-z
+1/4+x,1/4+y,1/4-z
+1/4+x,3/4+y,3/4-z
+-z,1/2-x,1/2+y
+-z,-x,+y
+1/2-z,1/2-x,+y
+1/2-z,-x,1/2+y
+3/4+y,1/4+z,3/4-x
+3/4+y,3/4+z,1/4-x
+1/4+y,1/4+z,1/4-x
+1/4+y,3/4+z,3/4-x
+-x,1/2-y,1/2+z
+-x,-y,+z
+1/2-x,1/2-y,+z
+1/2-x,-y,1/2+z
+1/4-z,3/4+x,3/4+y
+1/4-z,1/4+x,1/4+y
+3/4-z,3/4+x,1/4+y
+3/4-z,1/4+x,3/4+y
+y,-z,-x
+y,1/2-z,1/2-x
+1/2+y,-z,1/2-x
+1/2+y,1/2-z,-x
+1/4-x,3/4+y,3/4+z
+1/4-x,1/4+y,1/4+z
+3/4-x,3/4+y,1/4+z
+3/4-x,1/4+y,3/4+z
+z,-x,-y
+z,1/2-x,1/2-y
+1/2+z,-x,1/2-y
+1/2+z,1/2-x,-y
+1/4-y,3/4+z,3/4+x
+1/4-y,1/4+z,1/4+x
+3/4-y,3/4+z,1/4+x
+3/4-y,1/4+z,3/4+x
+x,-y,-z
+x,1/2-y,1/2-z
+1/2+x,-y,1/2-z
+1/2+x,1/2-y,-z
+1/2-x,1/2+z,-y
+1/2-x,+z,1/2-y
+-x,1/2+z,1/2-y
+-x,+z,-y
+1/4+z,3/4-y,3/4+x
+1/4+z,1/4-y,1/4+x
+3/4+z,3/4-y,1/4+x
+3/4+z,1/4-y,3/4+x
+1/2-y,1/2+x,-z
+1/2-y,+x,1/2-z
+-y,1/2+x,1/2-z
+-y,+x,-z
+1/4+x,3/4-z,3/4+y
+1/4+x,1/4-z,1/4+y
+3/4+x,3/4-z,1/4+y
+3/4+x,1/4-z,3/4+y
+1/2-z,1/2+y,-x
+1/2-z,+y,1/2-x
+-z,1/2+y,1/2-x
+-z,+y,-x
+1/4+y,3/4-x,3/4+z
+1/4+y,1/4-x,1/4+z
+3/4+y,3/4-x,1/4+z
+3/4+y,1/4-x,3/4+z
+-x,-z,y
+-x,1/2-z,1/2+y
+1/2-x,-z,1/2+y
+1/2-x,1/2-z,y
+3/4+z,3/4+y,1/4-x
+3/4+z,1/4+y,3/4-x
+1/4+z,3/4+y,3/4-x
+1/4+z,1/4+y,1/4-x
+-y,-x,z
+-y,1/2-x,1/2+z
+1/2-y,-x,1/2+z
+1/2-y,1/2-x,z
+3/4+x,3/4+z,1/4-y
+3/4+x,1/4+z,3/4-y
+1/4+x,3/4+z,3/4-y
+1/4+x,1/4+z,1/4-y
+-z,-y,x
+-z,1/2-y,1/2+x
+1/2-z,-y,1/2+x
+1/2-z,1/2-y,x
+3/4+y,3/4+x,1/4-z
+3/4+y,1/4+x,3/4-z
+1/4+y,3/4+x,3/4-z
+1/4+y,1/4+x,1/4-z
+1/4-z,1/4-x,1/4-y
+1/4-z,3/4-x,3/4-y
+3/4-z,1/4-x,3/4-y
+3/4-z,3/4-x,1/4-y
+y,z,x
+y,1/2+z,1/2+x
+1/2+y,z,1/2+x
+1/2+y,1/2+z,x
+1/4-x,1/4-y,1/4-z
+1/4-x,3/4-y,3/4-z
+3/4-x,1/4-y,3/4-z
+3/4-x,3/4-y,1/4-z
+z,x,y
+z,1/2+x,1/2+y
+1/2+z,x,1/2+y
+1/2+z,1/2+x,y
+1/4-y,1/4-z,1/4-x
+1/4-y,3/4-z,3/4-x
+3/4-y,1/4-z,3/4-x
+3/4-y,3/4-z,1/4-x
+loop_
+_atom_site_label
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+Ge 0.00000 0.00000 0.00000
+loop_
+_cod_related_entry_id
+_cod_related_entry_database
+_cod_related_entry_code
+1 AMCSD 0009269

--- a/mcstas-comps/examples/Tests_samples/Test_Powders/LaMnO3.cif
+++ b/mcstas-comps/examples/Tests_samples/Test_Powders/LaMnO3.cif
@@ -1,0 +1,85 @@
+#------------------------------------------------------------------------------
+#$Date: 2015-01-27 21:58:39 +0200 (Tue, 27 Jan 2015) $
+#$Revision: 130149 $
+#$URL: svn://www.crystallography.net/cod/cif/1/00/61/1006141.cif $
+#------------------------------------------------------------------------------
+#
+# This file is available in the Crystallography Open Database (COD),
+# http://www.crystallography.net/
+#
+# All data on this site have been placed in the public domain by the
+# contributors.
+#
+data_1006141
+loop_
+_publ_author_name
+'Rodriguez-Carvajal, J'
+'Hennion, M'
+'Moussa, F'
+'Moudden, A H'
+'Pinsard, L'
+'Revcolevschi, A'
+_publ_section_title
+;
+Neutron-diffraction of the Jahn-Teller transition in stoichiometric La
+Mn O3
+;
+_journal_coden_ASTM              PRBMDO
+_journal_name_full
+;
+Physical Review, Serie 3. B - Condensed Matter (18,1978-)
+;
+_journal_page_first              3189
+_journal_page_last               3192
+_journal_volume                  57
+_journal_year                    1998
+_chemical_formula_structural     'La (Mn O3)'
+_chemical_formula_sum            'La Mn O3'
+_chemical_name_systematic        'Lanthanum manganate(III)'
+_space_group_IT_number           62
+_symmetry_cell_setting           orthorhombic
+_symmetry_Int_Tables_number      62
+_symmetry_space_group_name_Hall  '-P 2c 2ab'
+_symmetry_space_group_name_H-M   'P b n m'
+_cell_angle_alpha                90
+_cell_angle_beta                 90
+_cell_angle_gamma                90
+_cell_formula_units_Z            4
+_cell_length_a                   5.5367(1)
+_cell_length_b                   5.7473(1)
+_cell_length_c                   7.6929(2)
+_cell_volume                     244.8
+_diffrn_ambient_temperature      298
+_refine_ls_R_factor_all          0.0898
+_cod_database_code               1006141
+loop_
+_symmetry_equiv_pos_as_xyz
+x,y,z
+1/2-x,1/2+y,1/2-z
+-x,-y,1/2+z
+1/2+x,1/2-y,-z
+-x,-y,-z
+1/2+x,1/2-y,1/2+z
+x,y,1/2-z
+1/2-x,1/2+y,z
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_symmetry_multiplicity
+_atom_site_Wyckoff_symbol
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_atom_site_attached_hydrogens
+_atom_site_calc_flag
+La1 La3+ 4 c -0.0078(3) 0.0490(2) 0.25 1. 0 d
+Mn1 Mn3+ 4 a 0.5 0. 0. 1. 0 d
+O1 O2- 4 c 0.0745(3) 0.4874(3) 0.25 1. 0 d
+O2 O2- 8 d 0.7256(2) 0.3066(2) 0.0384(2) 1. 0 d
+loop_
+_atom_type_symbol
+_atom_type_oxidation_number
+La3+ 3.000
+Mn3+ 3.000
+O2- -2.000

--- a/mcstas-comps/examples/Tests_samples/Test_Powders/NaCl.cif
+++ b/mcstas-comps/examples/Tests_samples/Test_Powders/NaCl.cif
@@ -1,0 +1,259 @@
+#------------------------------------------------------------------------------
+#$Date: 2015-01-27 21:58:39 +0200 (Tue, 27 Jan 2015) $
+#$Revision: 130149 $
+#$URL: svn://www.crystallography.net/cod/cif/1/00/00/1000041.cif $
+#------------------------------------------------------------------------------
+#
+# This file is available in the Crystallography Open Database (COD),
+# http://www.crystallography.net/
+#
+# All data on this site have been placed in the public domain by the
+# contributors.
+#
+data_1000041
+loop_
+_publ_author_name
+'Abrahams, S C'
+'Bernstein, J L'
+_publ_section_title
+;
+Accuracy of an automatic diffractometer. measurement of the sodium
+chloride structure factors
+;
+_journal_coden_ASTM              ACCRA9
+_journal_name_full               'Acta Crystallographica (1,1948-23,1967)'
+_journal_page_first              926
+_journal_page_last               932
+_journal_paper_doi               10.1107/S0365110X65002244
+_journal_volume                  18
+_journal_year                    1965
+_chemical_formula_structural     'Na Cl'
+_chemical_formula_sum            'Cl Na'
+_chemical_name_systematic        'Sodium chloride'
+_space_group_IT_number           225
+_symmetry_cell_setting           cubic
+_symmetry_Int_Tables_number      225
+_symmetry_space_group_name_Hall  '-F 4 2 3'
+_symmetry_space_group_name_H-M   'F m -3 m'
+_cell_angle_alpha                90
+_cell_angle_beta                 90
+_cell_angle_gamma                90
+_cell_formula_units_Z            4
+_cell_length_a                   5.62
+_cell_length_b                   5.62
+_cell_length_c                   5.62
+_cell_volume                     177.5
+_refine_ls_R_factor_all          0.022
+_cod_database_code               1000041
+loop_
+_symmetry_equiv_pos_as_xyz
+x,y,z
+y,z,x
+z,x,y
+x,z,y
+y,x,z
+z,y,x
+x,-y,-z
+y,-z,-x
+z,-x,-y
+x,-z,-y
+y,-x,-z
+z,-y,-x
+-x,y,-z
+-y,z,-x
+-z,x,-y
+-x,z,-y
+-y,x,-z
+-z,y,-x
+-x,-y,z
+-y,-z,x
+-z,-x,y
+-x,-z,y
+-y,-x,z
+-z,-y,x
+-x,-y,-z
+-y,-z,-x
+-z,-x,-y
+-x,-z,-y
+-y,-x,-z
+-z,-y,-x
+-x,y,z
+-y,z,x
+-z,x,y
+-x,z,y
+-y,x,z
+-z,y,x
+x,-y,z
+y,-z,x
+z,-x,y
+x,-z,y
+y,-x,z
+z,-y,x
+x,y,-z
+y,z,-x
+z,x,-y
+x,z,-y
+y,x,-z
+z,y,-x
+x,1/2+y,1/2+z
+1/2+x,y,1/2+z
+1/2+x,1/2+y,z
+y,1/2+z,1/2+x
+1/2+y,z,1/2+x
+1/2+y,1/2+z,x
+z,1/2+x,1/2+y
+1/2+z,x,1/2+y
+1/2+z,1/2+x,y
+x,1/2+z,1/2+y
+1/2+x,z,1/2+y
+1/2+x,1/2+z,y
+y,1/2+x,1/2+z
+1/2+y,x,1/2+z
+1/2+y,1/2+x,z
+z,1/2+y,1/2+x
+1/2+z,y,1/2+x
+1/2+z,1/2+y,x
+x,1/2-y,1/2-z
+1/2+x,-y,1/2-z
+1/2+x,1/2-y,-z
+y,1/2-z,1/2-x
+1/2+y,-z,1/2-x
+1/2+y,1/2-z,-x
+z,1/2-x,1/2-y
+1/2+z,-x,1/2-y
+1/2+z,1/2-x,-y
+x,1/2-z,1/2-y
+1/2+x,-z,1/2-y
+1/2+x,1/2-z,-y
+y,1/2-x,1/2-z
+1/2+y,-x,1/2-z
+1/2+y,1/2-x,-z
+z,1/2-y,1/2-x
+1/2+z,-y,1/2-x
+1/2+z,1/2-y,-x
+-x,1/2+y,1/2-z
+1/2-x,y,1/2-z
+1/2-x,1/2+y,-z
+-y,1/2+z,1/2-x
+1/2-y,z,1/2-x
+1/2-y,1/2+z,-x
+-z,1/2+x,1/2-y
+1/2-z,x,1/2-y
+1/2-z,1/2+x,-y
+-x,1/2+z,1/2-y
+1/2-x,z,1/2-y
+1/2-x,1/2+z,-y
+-y,1/2+x,1/2-z
+1/2-y,x,1/2-z
+1/2-y,1/2+x,-z
+-z,1/2+y,1/2-x
+1/2-z,y,1/2-x
+1/2-z,1/2+y,-x
+-x,1/2-y,1/2+z
+1/2-x,-y,1/2+z
+1/2-x,1/2-y,z
+-y,1/2-z,1/2+x
+1/2-y,-z,1/2+x
+1/2-y,1/2-z,x
+-z,1/2-x,1/2+y
+1/2-z,-x,1/2+y
+1/2-z,1/2-x,y
+-x,1/2-z,1/2+y
+1/2-x,-z,1/2+y
+1/2-x,1/2-z,y
+-y,1/2-x,1/2+z
+1/2-y,-x,1/2+z
+1/2-y,1/2-x,z
+-z,1/2-y,1/2+x
+1/2-z,-y,1/2+x
+1/2-z,1/2-y,x
+-x,1/2-y,1/2-z
+1/2-x,-y,1/2-z
+1/2-x,1/2-y,-z
+-y,1/2-z,1/2-x
+1/2-y,-z,1/2-x
+1/2-y,1/2-z,-x
+-z,1/2-x,1/2-y
+1/2-z,-x,1/2-y
+1/2-z,1/2-x,-y
+-x,1/2-z,1/2-y
+1/2-x,-z,1/2-y
+1/2-x,1/2-z,-y
+-y,1/2-x,1/2-z
+1/2-y,-x,1/2-z
+1/2-y,1/2-x,-z
+-z,1/2-y,1/2-x
+1/2-z,-y,1/2-x
+1/2-z,1/2-y,-x
+-x,1/2+y,1/2+z
+1/2-x,y,1/2+z
+1/2-x,1/2+y,z
+-y,1/2+z,1/2+x
+1/2-y,z,1/2+x
+1/2-y,1/2+z,x
+-z,1/2+x,1/2+y
+1/2-z,x,1/2+y
+1/2-z,1/2+x,y
+-x,1/2+z,1/2+y
+1/2-x,z,1/2+y
+1/2-x,1/2+z,y
+-y,1/2+x,1/2+z
+1/2-y,x,1/2+z
+1/2-y,1/2+x,z
+-z,1/2+y,1/2+x
+1/2-z,y,1/2+x
+1/2-z,1/2+y,x
+x,1/2-y,1/2+z
+1/2+x,-y,1/2+z
+1/2+x,1/2-y,z
+y,1/2-z,1/2+x
+1/2+y,-z,1/2+x
+1/2+y,1/2-z,x
+z,1/2-x,1/2+y
+1/2+z,-x,1/2+y
+1/2+z,1/2-x,y
+x,1/2-z,1/2+y
+1/2+x,-z,1/2+y
+1/2+x,1/2-z,y
+y,1/2-x,1/2+z
+1/2+y,-x,1/2+z
+1/2+y,1/2-x,z
+z,1/2-y,1/2+x
+1/2+z,-y,1/2+x
+1/2+z,1/2-y,x
+x,1/2+y,1/2-z
+1/2+x,y,1/2-z
+1/2+x,1/2+y,-z
+y,1/2+z,1/2-x
+1/2+y,z,1/2-x
+1/2+y,1/2+z,-x
+z,1/2+x,1/2-y
+1/2+z,x,1/2-y
+1/2+z,1/2+x,-y
+x,1/2+z,1/2-y
+1/2+x,z,1/2-y
+1/2+x,1/2+z,-y
+y,1/2+x,1/2-z
+1/2+y,x,1/2-z
+1/2+y,1/2+x,-z
+z,1/2+y,1/2-x
+1/2+z,y,1/2-x
+1/2+z,1/2+y,-x
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_symmetry_multiplicity
+_atom_site_Wyckoff_symbol
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_atom_site_attached_hydrogens
+_atom_site_calc_flag
+Na1 Na1+ 4 a 0. 0. 0. 1. 0 d
+Cl1 Cl1- 4 b 0.5 0.5 0.5 1. 0 d
+loop_
+_atom_type_symbol
+_atom_type_oxidation_number
+Na1+ 1.000
+Cl1- -1.000

--- a/mcstas-comps/examples/Tests_samples/Test_Powders/Test_Powders.instr
+++ b/mcstas-comps/examples/Tests_samples/Test_Powders/Test_Powders.instr
@@ -4,43 +4,80 @@
 * Instrument: Test PowderN output
 *
 * %Identification
-* Written by: M. Bertelsen
-* Date: November 19 2024
+* Written by: M. Bertelsen and P. Willendrup
+* Date: November 2024
 * Origin: ESS DMSC
 * %INSTRUMENT_SITE: Tests_samples
 *
-* Test output of PowderN and Single_crystal on a spherical monitor / PSD.
+* Test output of PowderN, NCrystal and Single_crystal on a spherical monitor / PSD.
 *
 * %Description
 * A test instrument for Powder output from different sample components.
-* Currently does not validate, but Single_crystal should be able to
-* replicate PowderN results.
 *
-* %Example: lambda=2.5 directbeam=0 comp=1 SPLITS=1 Detector: Sph_mon_I=5.67059e+08
-* %Example: lambda=2.5 directbeam=0 comp=1 SPLITS=1 Detector: psd_mon_I=1.46997e+06
-* %Example: lambda=2.5 directbeam=0 comp=2 SPLITS=1 Detector: Sph_mon_I=5.67059e+08
-* %Example: lambda=2.5 directbeam=0 comp=2 SPLITS=1 Detector: psd_mon_I=1.46997e+06
+* %Example: lambda=2.5 directbeam=0 comp=1 material=Ge SPLITS=1 Detector: Sph_mon_I=3.9e+08
+* %Example: lambda=2.5 directbeam=0 comp=1 material=Ge SPLITS=1 Detector: psd_mon_I=8.3e+05
+* %Example: lambda=2.5 directbeam=0 comp=2 material=Ge SPLITS=1 Detector: Sph_mon_I=3.9e+08
+* %Example: lambda=2.5 directbeam=0 comp=2 material=Ge SPLITS=1 Detector: psd_mon_I=8.3e+05
+* %Example: lambda=2.5 directbeam=0 comp=3 material=Ge SPLITS=1 Detector: Sph_mon_I=3.9e+08
+* %Example: lambda=2.5 directbeam=0 comp=3 material=Ge SPLITS=1 Detector: psd_mon_I=8.3e+05
+* %Example: lambda=2.5 directbeam=0 comp=1 material=Al twotheta=76.5 SPLITS=1 Detector: Sph_mon_I=1.1e+08
+* %Example: lambda=2.5 directbeam=0 comp=1 material=Al twotheta=76.5 SPLITS=1 Detector: psd_mon_I=2e+05
+* %Example: lambda=2.5 directbeam=0 comp=2 material=Al twotheta=76.5 SPLITS=1 Detector: Sph_mon_I=1.1e+08
+* %Example: lambda=2.5 directbeam=0 comp=2 material=Al twotheta=76.5 SPLITS=1 Detector: psd_mon_I=2e+05
+* %Example: lambda=2.5 directbeam=0 comp=3 material=Al twotheta=76.5 SPLITS=1 Detector: Sph_mon_I=1.1e+08
+* %Example: lambda=2.5 directbeam=0 comp=3 material=Al twotheta=76.5 SPLITS=1 Detector: psd_mon_I=2e+05
+* %Example: lambda=2.5 directbeam=0 comp=1 material=LaMnO3 twotheta=80 SPLITS=1 Detector: Sph_mon_I=3.1e+08
+* %Example: lambda=2.5 directbeam=0 comp=1 material=LaMnO3 twotheta=80 SPLITS=1 Detector: psd_mon_I=1.9e+05
+* %Example: lambda=2.5 directbeam=0 comp=2 material=LaMnO3 twotheta=80 SPLITS=1 Detector: Sph_mon_I=3.1e+08
+* %Example: lambda=2.5 directbeam=0 comp=2 material=LaMnO3 twotheta=80 SPLITS=1 Detector: psd_mon_I=1.9e+05
+* %Example: lambda=2.5 directbeam=0 comp=3 material=LaMnO3 twotheta=80 SPLITS=1 Detector: Sph_mon_I=3.1e+08
+* %Example: lambda=2.5 directbeam=0 comp=3 material=LaMnO3 twotheta=80 SPLITS=1 Detector: psd_mon_I=1.9e+05
+* %Example: lambda=2.5 directbeam=0 comp=1 material=NaCl twotheta=78 SPLITS=1 Detector: Sph_mon_I=2.5e+08
+* %Example: lambda=2.5 directbeam=0 comp=1 material=NaCl twotheta=78 SPLITS=1 Detector: psd_mon_I=3.4e+05
+* %Example: lambda=2.5 directbeam=0 comp=2 material=NaCl twotheta=78 SPLITS=1 Detector: Sph_mon_I=2.5e+08
+* %Example: lambda=2.5 directbeam=0 comp=2 material=NaCl twotheta=78 SPLITS=1 Detector: psd_mon_I=3.4e+05
+* %Example: lambda=2.5 directbeam=0 comp=3 material=NaCl twotheta=78 SPLITS=1 Detector: Sph_mon_I=2.5e+08
+* %Example: lambda=2.5 directbeam=0 comp=3 material=NaCl twotheta=78 SPLITS=1 Detector: psd_mon_I=3.4e+05
 *
 * %Parameters
 * lambda:     [Angs] Wavelength emitted from source, 1% wl-interval around.
 * L1:            [m] Source-sample distance
 * directbeam:    [1] Suppress direct beam or not
-* reflections_powderN: [str] List of powder reflections for powderN
+* materi: [str] List of powder reflections for powderN
 * reflections_Single_crystal: [str] List of powder reflections for Single_crystal
 * SPLITS:        [1] Number of SPLIT's before sample
 * frac_t:        [1] Fraction of stats assigned to unscattered, "direct beam"
 *
 * %End
 *******************************************************************************/
-DEFINE INSTRUMENT Test_PowderN(int comp=1, lambda=2.5, L1=10, int directbeam=0, string reflections_powderN="Ge.laz", string reflections_Single_crystal="Ge.lau", int SPLITS=1, frac_t=0.1)
+DEFINE INSTRUMENT Test_PowderN(int comp=1, lambda=2.5, L1=10, int directbeam=0, string material="Ge", int SPLITS=1, frac_t=0.1, sxmos=60, twotheta=94)
 	
 DECLARE %{
+  char ciffile[128];
+  char ncmatfile[128];
 %}
 
 /* The INITIALIZE section is executed when the simulation starts     */
 /* (C code). You may use them as component parameter values.         */
 INITIALIZE
 %{
+
+  if (!strcmp("Ge",material)) {
+    sprintf(ciffile,"Ge.cif");
+    sprintf(ncmatfile,"autogen_Ge_sg227_cod9011050.ncmat");
+  } else if (!strcmp("Al",material)) {
+    sprintf(ciffile,"Al.cif");
+    sprintf(ncmatfile,"autogen_Al_sg225_cod1502689.ncmat");
+  } else if (!strcmp("LaMnO3",material)) {
+    sprintf(ciffile,"LaMnO3.cif");
+    sprintf(ncmatfile,"autogen_LaMnO3_sg62_cod1006141.ncmat");
+  } else if (!strcmp("NaCl",material)) {
+    sprintf(ciffile,"NaCl.cif");
+    sprintf(ncmatfile,"autogen_ClNa_sg225_cod1000041.ncmat");
+  } else {
+    fprintf(stderr,"Material %s not supported\n",material);
+    exit(-1);
+  }
 %}
 
 /* Here comes the TRACE section, where the actual      */
@@ -62,36 +99,31 @@ SPLIT SPLITS COMPONENT sample_cradle = Arm()
   AT (0, 0, L1) RELATIVE PREVIOUS
 
 COMPONENT Pow_PowderN = PowderN(
-	radius=0.005, yheight=0.1, reflections=reflections_powderN, p_transmit=frac_t)
+	radius=0.005, yheight=0.1, reflections=ciffile, p_transmit=frac_t)
 WHEN (comp==1)
 AT (0, 0, 0) RELATIVE sample_cradle
-EXTEND %{
-  if(INSTRUMENT_GETPAR(directbeam) == 0) {
-    if (!SCATTERED) {
-      ABSORB;
-    }
-  }
-%}
 
-SPLIT SPLITS COMPONENT Pow_Single_crystal = Single_crystal(
-	radius=0.005, yheight=0.1, reflections=reflections_Single_crystal, p_transmit=frac_t,
-    powder=1, mosaic=5, order=1, barns=0)
+COMPONENT Pow_Single_crystal = Single_crystal(
+    radius=0.005, yheight=0.1, reflections=ciffile, p_transmit=frac_t,
+    powder=1, mosaic=sxmos, order=1, barns=1)
 WHEN (comp==2)
 AT (0, 0, 0) RELATIVE sample_cradle
-EXTEND %{
-  if(INSTRUMENT_GETPAR(directbeam) == 0) {
-    if (!SCATTERED) {
-      ABSORB;
-    }
-  }
-%}
 
+COMPONENT Pow_NCrystal = NCrystal_sample(
+	radius=0.005, yheight=0.1, cfg=ncmatfile)
+WHEN (comp==3)
+AT (0, 0, 0) RELATIVE sample_cradle
+
+  COMPONENT Beamstop = Beamstop(xwidth=0.015, yheight=0.105)
+WHEN (directbeam==0)
+AT (0, 0, 0.1) RELATIVE sample_cradle
+  
 COMPONENT Sph_mon = PSD_monitor_4PI(nx=360,ny=180, radius=1, restore_neutron=1, filename="Sphere")
-  AT (0, 0, 0) RELATIVE PREVIOUS
+  AT (0, 0, 0) RELATIVE sample_cradle
 	  
 COMPONENT peak_dir = Arm()
 AT (0,0,0) RELATIVE sample_cradle
-ROTATED (0, 100, 0) RELATIVE sample_cradle
+ROTATED (0, twotheta, 0) RELATIVE sample_cradle
 	  
 COMPONENT psd_mon = PSD_monitor(xwidth=0.08, yheight=0.05, nx=100, ny=100, restore_neutron=1, filename="PSD")
 AT (0,0,1) RELATIVE peak_dir

--- a/mcstas-comps/examples/Tests_samples/Test_Powders/Test_Powders.instr
+++ b/mcstas-comps/examples/Tests_samples/Test_Powders/Test_Powders.instr
@@ -40,13 +40,15 @@
 * %Example: lambda=2.5 directbeam=0 comp=3 material=NaCl twotheta=78 SPLITS=1 Detector: psd_mon_I=3.4e+05
 *
 * %Parameters
+* comp:          [1] 1=PowderN, 2=Single_crystal, 3=NCrystal
 * lambda:     [Angs] Wavelength emitted from source, 1% wl-interval around.
 * L1:            [m] Source-sample distance
 * directbeam:    [1] Suppress direct beam or not
-* materi: [str] List of powder reflections for powderN
-* reflections_Single_crystal: [str] List of powder reflections for Single_crystal
+* material:    [str] Material string for picking up CIF (PowderN/Single_Crystal) and ncmat (NCrystal)
 * SPLITS:        [1] Number of SPLIT's before sample
 * frac_t:        [1] Fraction of stats assigned to unscattered, "direct beam"
+* sxmos:    [arcmin] Mosaicity to use in Single_crystal case
+* twotheta:    [deg] Angle for 2\theta detector for detailed view
 *
 * %End
 *******************************************************************************/

--- a/mcstas-comps/examples/Tests_samples/Test_Powders/autogen_Al_sg225_cod1502689.ncmat
+++ b/mcstas-comps/examples/Tests_samples/Test_Powders/autogen_Al_sg225_cod1502689.ncmat
@@ -1,0 +1,43 @@
+NCMAT v7
+#
+# Al (cubic, SG-225)
+#
+# Atoms per unit cell: 4xAl
+#
+# Structure converted (with NCrystal.cifutils module) from:
+#
+#   "Hydrogen in the Metal&#x2212;Organic Framework Cr MIL-53"
+#   Mulder, Fokko M., et al. [The Journal of Physical Chemistry C, 2010]
+#   DOI: https://dx.doi.org/10.1021/jp102463p
+#   Crystallography Open Database entry 1502689
+#   https://www.crystallography.net/cod/1502689.html
+#
+# IMPORTANT NOTICE: This is a mostly automatic conversion which has not been
+#                   verified!  In particular the @DYNINFO sections might need
+#                   post-editing. Before distributing this file to other people,
+#                   please review this, amend the comments here to document,
+#                   anything done, and remove this notice.
+#
+# Notice: The following WARNINGS were emitted when loading the CIF data:
+#
+#   NCrystalUserWarning : ignoring uiso info present in CIF input for "Al" since uiso_temperature parameter value is not provided
+#
+# WARNING: Fallback (dummy) Debye temperature value was used for 1 atom!
+#
+# NOTICE: crystal structure was verified with spglib to be self-consistent.
+#
+@CELL
+  cubic 4.0339
+@SPACEGROUP
+  225
+@ATOMPOSITIONS
+  Al 0 0 0
+  Al 0 1/2 1/2
+  Al 1/2 0 1/2
+  Al 1/2 1/2 0
+@DYNINFO
+  # WARNING: Using fallback Debye temperature value!
+  element Al
+  fraction 1
+  type vdosdebye
+  debye_temp 300

--- a/mcstas-comps/examples/Tests_samples/Test_Powders/autogen_ClNa_sg225_cod1000041.ncmat
+++ b/mcstas-comps/examples/Tests_samples/Test_Powders/autogen_ClNa_sg225_cod1000041.ncmat
@@ -1,0 +1,50 @@
+NCMAT v7
+#
+# ClNa (cubic, SG-225)
+#
+# Atoms per unit cell: 4xCl+4xNa
+#
+# Structure converted (with NCrystal.cifutils module) from:
+#
+#   "Accuracy of an automatic diffractometer. measurement of the sodium
+#   chloride structure factors"
+#   Abrahams, S C and Bernstein, J L [Acta Crystallographica (1,1948-23,1967), 1965]
+#   DOI: https://dx.doi.org/10.1107/S0365110X65002244
+#   Crystallography Open Database entry 1000041
+#   https://www.crystallography.net/cod/1000041.html
+#
+# IMPORTANT NOTICE: This is a mostly automatic conversion which has not been
+#                   verified!  In particular the @DYNINFO sections might need
+#                   post-editing. Before distributing this file to other people,
+#                   please review this, amend the comments here to document,
+#                   anything done, and remove this notice.
+#
+# WARNING: Fallback (dummy) Debye temperature values were used for 2 atoms!
+#
+# NOTICE: crystal structure was verified with spglib to be self-consistent.
+#
+@CELL
+  cubic 5.62
+@SPACEGROUP
+  225
+@ATOMPOSITIONS
+  Cl 0 0 1/2
+  Cl 0 1/2 0
+  Cl 1/2 0 0
+  Cl 1/2 1/2 1/2
+  Na 0 0 0
+  Na 0 1/2 1/2
+  Na 1/2 0 1/2
+  Na 1/2 1/2 0
+@DYNINFO
+  # WARNING: Using fallback Debye temperature value!
+  element Cl
+  fraction 1/2
+  type vdosdebye
+  debye_temp 300
+@DYNINFO
+  # WARNING: Using fallback Debye temperature value!
+  element Na
+  fraction 1/2
+  type vdosdebye
+  debye_temp 300

--- a/mcstas-comps/examples/Tests_samples/Test_Powders/autogen_Ge_sg227_cod9011050.ncmat
+++ b/mcstas-comps/examples/Tests_samples/Test_Powders/autogen_Ge_sg227_cod9011050.ncmat
@@ -1,0 +1,49 @@
+NCMAT v7
+#
+# Ge (cubic, SG-227)
+#
+# Atoms per unit cell: 8xGe
+#
+# Structure converted (with NCrystal.cifutils module) from:
+#
+#   "Precise lattice constants of germanium, aluminum, gallium arsenide, uranium,
+#    sulphur, quartz and sapphire
+#    Sample: at T = 24.6 C"
+#   Cooper, A. S. [Acta Crystallographica, 1962]
+#   DOI: https://dx.doi.org/10.1107/S0365110X62001474
+#   Crystallography Open Database entry 9011050
+#   https://www.crystallography.net/cod/9011050.html
+#
+# IMPORTANT NOTICE: This is a mostly automatic conversion which has not been
+#                   verified!  In particular the @DYNINFO sections might need
+#                   post-editing. Before distributing this file to other people,
+#                   please review this, amend the comments here to document,
+#                   anything done, and remove this notice.
+#
+# Notice: The following WARNINGS were emitted when loading the CIF data:
+#
+#   NCrystalUserWarning : SG-227 available in multiple choices ("F d -3 m:1", "F d -3 m:2") and which one was not encoded explicitly in the _space_group_name_H-M_alt CIF field. Consider overriding the space group explicitly when loading this file.
+#
+# WARNING: Fallback (dummy) Debye temperature value was used for 1 atom!
+#
+# NOTICE: crystal structure was verified with spglib to be self-consistent.
+#
+@CELL
+  cubic 5.65754
+@SPACEGROUP
+  227
+@ATOMPOSITIONS
+  Ge 0 0 0
+  Ge 0 1/2 1/2
+  Ge 1/4 1/4 1/4
+  Ge 1/4 3/4 3/4
+  Ge 1/2 0 1/2
+  Ge 1/2 1/2 0
+  Ge 3/4 1/4 3/4
+  Ge 3/4 3/4 1/4
+@DYNINFO
+  # WARNING: Using fallback Debye temperature value!
+  element Ge
+  fraction 1
+  type vdosdebye
+  debye_temp 300

--- a/mcstas-comps/examples/Tests_samples/Test_Powders/autogen_LaMnO3_sg62_cod1006141.ncmat
+++ b/mcstas-comps/examples/Tests_samples/Test_Powders/autogen_LaMnO3_sg62_cod1006141.ncmat
@@ -1,0 +1,72 @@
+NCMAT v7
+#
+# LaMnO3 (orthorombic, SG-62)
+#
+# Atoms per unit cell: 4xLa+4xMn+12xO
+#
+# Structure converted (with NCrystal.cifutils module) from:
+#
+#   "Neutron-diffraction of the Jahn-Teller transition in stoichiometric La
+#   Mn O3"
+#   Rodriguez-Carvajal, J, et al. [Physical Review, Serie 3. B - Condensed Matter (18,1978-), 1998]
+#   Crystallography Open Database entry 1006141
+#   https://www.crystallography.net/cod/1006141.html
+#
+# IMPORTANT NOTICE: This is a mostly automatic conversion which has not been
+#                   verified!  In particular the @DYNINFO sections might need
+#                   post-editing. Before distributing this file to other people,
+#                   please review this, amend the comments here to document,
+#                   anything done, and remove this notice.
+#
+# Notice: The following WARNINGS were emitted when loading the CIF data:
+#
+#   NCrystalUserWarning : Structure received major corrections by spglib (at the 50% level)
+#
+# WARNING: Fallback (dummy) Debye temperature values were used for 3 atoms!
+#
+# NOTICE: crystal structure was verified with spglib to be self-consistent.
+#
+@CELL
+  lengths 5.7473 7.6929 5.5367
+  angles 90 90 90
+@SPACEGROUP
+  62
+@ATOMPOSITIONS
+  La .049 1/4 .9922
+  La .451 3/4 .4922
+  La .549 1/4 .5078
+  La .951 3/4 .0078
+  Mn 0 0 1/2
+  Mn 0 1/2 1/2
+  Mn 1/2 0 0
+  Mn 1/2 1/2 0
+  O .0126 3/4 .5745
+  O .1934 .5384 .2256
+  O .1934 .9616 .2256
+  O .3066 .0384 .7256
+  O .3066 .4616 .7256
+  O .4874 1/4 .0745
+  O .5126 3/4 .9255
+  O .6934 .5384 .2744
+  O .6934 .9616 .2744
+  O .8066 .0384 .7744
+  O .8066 .4616 .7744
+  O .9874 1/4 .4255
+@DYNINFO
+  # WARNING: Using fallback Debye temperature value!
+  element La
+  fraction 1/5
+  type vdosdebye
+  debye_temp 300
+@DYNINFO
+  # WARNING: Using fallback Debye temperature value!
+  element Mn
+  fraction 1/5
+  type vdosdebye
+  debye_temp 300
+@DYNINFO
+  # WARNING: Using fallback Debye temperature value!
+  element O
+  fraction 3/5
+  type vdosdebye
+  debye_temp 300


### PR DESCRIPTION
1) Include NCrystal in the testing
2) Use multiple material definitions
3) Use CIF files (and corresponding ncmatfiles generated via ncrystal_cif2ncmat 
4) Use a "physical" beamstop (the !SCATTERED hack won't work with NCrystal) 
5) All 24(!) tests seem to check out "green" with the current test targets

Caveats, all need further investigation:
* Single_crystal uses barns=1 - we need to clarify why this is so?
* Somewhat arbitrarily, the mosaicity for Single_crystal is set to 60 arcmin
* I saw a discrepancy wrt. the "incoherent background" in NCrystal vs. the other models 
   (See e.g. material="Ge" and use twotheta=100, scan comp=1,3)