### PR TITLE
Potential fix for https://github.com/McStasMcXtrace/McCode/issues/1768

### DIFF
--- a/meta-pkgs/windows/environment.yml
+++ b/meta-pkgs/windows/environment.yml
@@ -11,7 +11,6 @@ dependencies:
   - msmpi
   - pyaml
   - ply
-  - matplotlib
   - numpy
   - tornado
   - scipy

--- a/tools/Python/mccodelib/pqtgfrontend.py
+++ b/tools/Python/mccodelib/pqtgfrontend.py
@@ -101,7 +101,11 @@ class McPyqtgraphPlotter():
 
         # start
         if hasattr(self.app, "exec_"):
-            self.isQt6 = False
+            try:
+                import PySide6
+                self.isQt6 = True
+            except:
+                self.isQt6 = False
         else:
             self.isQt6 = True
 


### PR DESCRIPTION
Two-stage solution:
* Avoid dependency on "matplotlib" (that depends on pyside6) in Windows monolithic-installer environment (mcplot-matplotlib itself only seems to pull in matplotlib-core)
* Add workaround if pyside6 is present