### PR TITLE
Print warning when overwriting COPY EXTEND %{%} block from instance

### DIFF
--- a/mcstas/src/instrument.y
+++ b/mcstas/src/instrument.y
@@ -1279,14 +1279,14 @@ component: removable cpuonly split "COMPONENT" instname '=' instref
 	      fprintf(stderr, "  %s",line);
 	    }
 	    list_iterate_end(liter);
-	    fprintf(stderr, "\n  %%}\n");
+	    fprintf(stderr, "  %%}\n");
 	    fprintf(stderr, "\nwill be been overwritten by:\n");
 	    fprintf(stderr, "\n  EXTEND %%{\n");
 	    while((line2 = list_next(liter2))) {
 	      fprintf(stderr, "  %s",line2);
 	    }
 	    list_iterate_end(liter2);
-	    fprintf(stderr, "\n  %%}\n-----------------------------------------------------------\n");
+	    fprintf(stderr, "  %%}\n-----------------------------------------------------------\n");
 	  }
 	  comp->extend= $13;  /* EXTEND block*/
 	}

--- a/mcstas/src/instrument.y
+++ b/mcstas/src/instrument.y
@@ -1270,18 +1270,18 @@ component: removable cpuonly split "COMPONENT" instname '=' instref
         if ($13->linenum) {
 	  if (comp->extend->linenum>0) {
 	    fprintf(stderr, "\n-----------------------------------------------------------\n");
-	    fprintf(stderr, "WARNING (COMPONENT %s): Existing (COPY) EXTEND block:\n", comp->name);
+	    fprintf(stderr, "WARNING: Existing (COPY) EXTEND block in COMPONENT %s:\n", comp->name);
 	    List_handle liter = list_iterate(comp->extend->lines);
 	    List_handle liter2 = list_iterate($13->lines);
 	    char *line, *line2;
-	    fprintf(stderr, "\n  EXTEND %%{\n");
+	    fprintf(stderr, "  EXTEND %%{\n");
 	    while((line = list_next(liter))) {
 	      fprintf(stderr, "  %s",line);
 	    }
 	    list_iterate_end(liter);
 	    fprintf(stderr, "  %%}\n");
-	    fprintf(stderr, "\nwill be been overwritten by:\n");
-	    fprintf(stderr, "\n  EXTEND %%{\n");
+	    fprintf(stderr, "\nis overwritten by:\n");
+	    fprintf(stderr, "  EXTEND %%{\n");
 	    while((line2 = list_next(liter2))) {
 	      fprintf(stderr, "  %s",line2);
 	    }

--- a/mcstas/src/instrument.y
+++ b/mcstas/src/instrument.y
@@ -1267,7 +1267,29 @@ component: removable cpuonly split "COMPONENT" instname '=' instref
 	    }
 	  }
         }
-        if ($13->linenum)   comp->extend= $13;  /* EXTEND block*/
+        if ($13->linenum) {
+	  if (comp->extend->linenum>0) {
+	    fprintf(stderr, "\n-----------------------------------------------------------\n");
+	    fprintf(stderr, "WARNING (COMPONENT %s): Existing (COPY) EXTEND block:\n", comp->name);
+	    List_handle liter = list_iterate(comp->extend->lines);
+	    List_handle liter2 = list_iterate($13->lines);
+	    char *line, *line2;
+	    fprintf(stderr, "\n  EXTEND %%{\n");
+	    while((line = list_next(liter))) {
+	      fprintf(stderr, "  %s",line);
+	    }
+	    list_iterate_end(liter);
+	    fprintf(stderr, "\n  %%}\n");
+	    fprintf(stderr, "\nwill be been overwritten by:\n");
+	    fprintf(stderr, "\n  EXTEND %%{\n");
+	    while((line2 = list_next(liter2))) {
+	      fprintf(stderr, "  %s",line2);
+	    }
+	    list_iterate_end(liter2);
+	    fprintf(stderr, "\n  %%}\n-----------------------------------------------------------\n");
+	  }
+	  comp->extend= $13;  /* EXTEND block*/
+	}
         if (list_len($14))  comp->jump  = $14;
 
         /* one or more metadata statements -- the Component definition *can also* add to this list */


### PR DESCRIPTION
Candidate solution to https://github.com/McStasMcXtrace/McCode/issues/1785

The attached instrument [`COPY_EXTEND_1`](https://github.com/user-attachments/files/17997589/COPY_EXTEND_1.instr.txt) has a `COMPONENT comp2=COPY(comp1)` instance with an `EXTEND %{%}` block, which thus overwrites the `EXTEND %{%}` that arrives via the `COPY(comp1)` clause:

```
mcstas COPY_EXTEND_1.instr 

-----------------------------------------------------------
WARNING (COMPONENT comp2): Existing (COPY) EXTEND block:

  EXTEND %{
    // An extend block
    dummy=_comp->index;
  %}

will be been overwritten by:

  EXTEND %{
    // An other extend block
    dummy=2*_comp->index;
  %}
-----------------------------------------------------------

-----------------------------------------------------------

Generating single GPU kernel or single CPU section layout: 

-----------------------------------------------------------

Generating GPU/CPU -DFUNNEL layout:

-----------------------------------------------------------
CFLAGS=
```

I further attach [`COPY_EXTEND_2`](https://github.com/user-attachments/files/17997534/COPY_EXTEND_2.instr.txt) which has a `COMPONENT comp2=COPY(comp1)` with an `EXTEND %{%}` block,  but where `COPY(comp1)` includes no `EXTEND` block:

```
mcstas COPY_EXTEND_2.instr 

-----------------------------------------------------------

Generating single GPU kernel or single CPU section layout: 

-----------------------------------------------------------

Generating GPU/CPU -DFUNNEL layout:

-----------------------------------------------------------
CFLAGS=

```

