### PR TITLE
Issue 1721 fix: Support Scintilla editor on Debian with Qt6

### DIFF
--- a/tools/Python/mcgui/CMakeLists.txt
+++ b/tools/Python/mcgui/CMakeLists.txt
@@ -52,7 +52,7 @@ set(CPACK_NSIS_DISPLAY_NAME "${NSIS_NAME}")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "${NSIS_NAME}")
 
 # Debian
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "${FLAVOR}, ${FLAVOR}-tools-python-${P}doc, ${FLAVOR}-tools-python-mccodelib, python3, python3-pyqt5.qsci")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "${FLAVOR}, ${FLAVOR}-tools-python-${P}doc, ${FLAVOR}-tools-python-mccodelib, python3, python3-pyqt6.qsci")
 set(CPACK_DEBIAN_PACKAGE_REPLACES "${FLAVOR}-tools-python-${P}gui-3.5.1")
 
 # RPM

--- a/tools/Python/mcgui/mcgui.py
+++ b/tools/Python/mcgui/mcgui.py
@@ -18,6 +18,7 @@ try:
     from PyQt6.QtWidgets import QApplication, QWidget
     from PyQt6.QtGui import QFont, QFontDatabase
     import PyQt6 as PyQt
+    print("Importing Qt6 OK")
     try:
         from PyQt6 import Qsci
     except ImportError:
@@ -28,6 +29,7 @@ except ImportError:
     from PyQt5.QtWidgets import QApplication, QWidget
     from PyQt5.QtGui import QFont, QFontDatabase
     import PyQt5 as PyQt
+    print("importing Qt5 OK")
     try:
         from PyQt5 import Qsci
     except ImportError:

--- a/tools/Python/mcgui/mcgui.py
+++ b/tools/Python/mcgui/mcgui.py
@@ -18,7 +18,7 @@ try:
     from PyQt6.QtWidgets import QApplication, QWidget
     from PyQt6.QtGui import QFont, QFontDatabase
     import PyQt6 as PyQt
-    print("Importing Qt6 OK")
+
     try:
         from PyQt6 import Qsci
     except ImportError:
@@ -29,7 +29,7 @@ except ImportError:
     from PyQt5.QtWidgets import QApplication, QWidget
     from PyQt5.QtGui import QFont, QFontDatabase
     import PyQt5 as PyQt
-    print("importing Qt5 OK")
+
     try:
         from PyQt5 import Qsci
     except ImportError:

--- a/tools/Python/mcgui/viewclasses.py
+++ b/tools/Python/mcgui/viewclasses.py
@@ -314,7 +314,7 @@ class McCodeEditorWindow(QtWidgets.QMainWindow):
             edt = QtWidgets.QLineEdit()
             edt = subject
             # handle focus on
-            if event.type() == QtCore.QEvent.FocusIn:
+            if event.type() == QtCore.QEvent.Type.FocusIn:
                 if edt.text() == 'search...':
                     edt.setText('')
                     font = QtGui.QFont()
@@ -323,7 +323,7 @@ class McCodeEditorWindow(QtWidgets.QMainWindow):
                     edt.setStyleSheet("color: black;")
 
             # handle focus off
-            elif event.type() == QtCore.QEvent.FocusOut:
+            elif event.type() == QtCore.QEvent.Type.FocusOut:
                 if edt.text() == '':
                     font = QtGui.QFont()
                     font.setItalic(True)
@@ -332,7 +332,7 @@ class McCodeEditorWindow(QtWidgets.QMainWindow):
                     edt.setText('search...')
 
             # handle enter keypress (search)
-            elif event.type() == QtCore.QEvent.KeyPress:
+            elif event.type() == QtCore.QEvent.Type.KeyPress:
                 # return & enter
                 if event.key() in [0x01000004, 0x01000005]:
                     self.__search(subject.text().casefold())
@@ -503,7 +503,7 @@ class McCodeEditorWindow(QtWidgets.QMainWindow):
         font.setPointSize(int(mccode_config.configuration["GUIFONTSIZE"]))
 
         # brace matching
-        scintilla.setBraceMatching(Qsci.QsciScintilla.SloppyBraceMatch)
+        scintilla.setBraceMatching(Qsci.QsciScintilla.BraceMatch.SloppyBraceMatch)
 
         # set lexer
         lexer = Qsci.QsciLexerCPP()
@@ -518,14 +518,14 @@ class McCodeEditorWindow(QtWidgets.QMainWindow):
         scintilla.__myApi = Qsci.QsciAPIs(lexer)
 
         scintilla.setAutoCompletionThreshold(1)
-        scintilla.setAutoCompletionSource(Qsci.QsciScintilla.AcsAPIs)
+        scintilla.setAutoCompletionSource(Qsci.QsciScintilla.AutoCompletionSource.AcsAPIs)
 
         # remove horizontal scrollbar
         scintilla.SendScintilla(Qsci.QsciScintilla.SCI_SETHSCROLLBAR, 0)
 
         # display default line numbers
         fm = QtGui.QFontMetrics(font)
-        scintilla.setMarginWidth(0, fm.width( "00000" ))
+        scintilla.setMarginWidth(0, fm.horizontalAdvance( "00000" ))
         scintilla.setMarginLineNumbers(0, True)
         ########################
 
@@ -595,7 +595,7 @@ class McCodeEditorWindow(QtWidgets.QMainWindow):
         # TODO: create a ctr-a on a menu to __scintilla.selectAll(bool select)
 
         def __keyEventFilterFct(subject, object, event):
-            if event.type() == QtCore.QEvent.KeyRelease:
+            if event.type() == QtCore.QEvent.Type.KeyRelease:
                 # ctrl-q
                 if event.key() == 81 and int(event.modifiers()) == 67108864:
                     self.close()
@@ -1024,7 +1024,7 @@ class McInsertComponentDialog(QtWidgets.QDialog):
             edt = QtWidgets.QLineEdit()
             edt = subject
             # handle focus on
-            if event.type() == QtCore.QEvent.FocusIn:
+            if event.type() == QtCore.QEvent.Type.FocusIn:
                 if edt.text() == edt.defval:
                     edt.setText('')
                     font = QtGui.QFont()
@@ -1034,7 +1034,7 @@ class McInsertComponentDialog(QtWidgets.QDialog):
                     edt.setCursorPosition(0)
             
             # handle focus off
-            elif event.type() == QtCore.QEvent.FocusOut:
+            elif event.type() == QtCore.QEvent.Type.FocusOut:
                 if edt.text() == '':
                     font = QtGui.QFont()
                     font.setItalic(True)

--- a/tools/Python/mcplot/matplotlib/CMakeLists.txt
+++ b/tools/Python/mcplot/matplotlib/CMakeLists.txt
@@ -52,7 +52,7 @@ set(CPACK_NSIS_DISPLAY_NAME "${NSIS_NAME}")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "${NSIS_NAME}")
 
 # Debian
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "${FLAVOR}, python3-matplotlib, python3-pyqt5, python3-mplexporter, python3-tornado")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "${FLAVOR}, python3-matplotlib, python3-pyqt6, python3-mplexporter, python3-tornado")
 set(CPACK_DEBIAN_PACKAGE_REPLACES "${FLAVOR}-tools-python-${P}plot-matplotlib-3.5.1")
 
 # RPM


### PR DESCRIPTION
These few edits are tested to render the "built-in" QScintilla edtior functional on:
* Ubuntu 24.04 with PyQt6 (from the base system)
* Debian 12 with PyQt6 (from the base system) - something however indicates mixed qt5-6 setup...
* macOS 14 Silicon with PyQt5 (via conda)
* macOS 15 Intel with PyQt5 (via conda)
* Windows 11 with PyQt5 (via conda)

There seems to be no further **direct** pyqt5 dependencies in the CMakeLists.txt - however the mcplot-pyqtgraph package pulls in PyQt5 via python3-qtpy (compatibility layer).

Deemed OK for merge.