### PR TITLE
Remove NCrystal_sample.comp possible out-of-bounds memory access

### DIFF
--- a/mcstas-comps/contrib/NCrystal_sample.comp
+++ b/mcstas-comps/contrib/NCrystal_sample.comp
@@ -204,7 +204,7 @@ INITIALIZE
 
   //for our sanity, zero-initialise all instance-specific data:
   memset(&params,0,sizeof(params));
-  memset(&params,0,sizeof(geoparams));
+  memset(&geoparams,0,sizeof(geoparams));
 
   ncrystalsample_initgeom(&geoparams, NAME_CURRENT_COMP, xwidth, yheight, zdepth, radius);
 


### PR DESCRIPTION
`memset(&params,0,sizeof(geoparams))` would cause an out-of-bounds memory error if `sizeof(geoparams)` > `sizeof(params)`; and anyway does not appear to do what is intended.