### PR TITLE
Param default adj Union_master + mcrun fallback solution for picking up code generator from PATH

### DIFF
--- a/mcstas-comps/union/Union_master.comp
+++ b/mcstas-comps/union/Union_master.comp
@@ -58,7 +58,7 @@ SETTING PARAMETERS(verbal = 1,
                    history_limit=300000,
                    enable_conditionals=1,
                    inherit_number_of_scattering_events=0,
-				   weight_ratio_limit=0.0000001,
+                   weight_ratio_limit=1e-90,
                    string init="init")
 
 NOACC

--- a/tools/Python/mcrun/mccode.py
+++ b/tools/Python/mcrun/mccode.py
@@ -141,6 +141,10 @@ class McStas:
             # Generate C-code (implicit: prepare for --trace mode if not no_main / Vitess)
             LOG.info('Regenerating c-file: %s', basename(self.cpath))
             mccode_bin_abspath = str( pathlib.Path(mccode_config.directories['bindir']) / options.mccode_bin )
+            if not os.path.exists(mccode_bin_abspath):
+                LOG.warning('Full-path code-generator "%s" not found!!', mccode_bin_abspath)
+                mccode_bin_abspath=basename(mccode_bin_abspath)
+                LOG.warning('Attempting replacement by "%s"', mccode_bin_abspath)
 
             if not options.no_main:
                 if self.options.I is not None:


### PR DESCRIPTION
* The changed default parameter for Union_master should rectify test 2+3 for `Conditional_test.instr`
* `mcrun` now attempts to pick up code-generator (`MCCOGEN` e.g. `mcstas` or `mcstas-antlr`) from `PATH` if not found in in the expected location (`mcstas-antlr` sits in `%CONDA_PREFIX%\Scripts` on Windows and could also be installed via e.g. pip)