### PR TITLE
Elliptical_guide_gravity did not work in GROUPS as it always SCATTERS

### DIFF
--- a/mcstas-comps/optics/Elliptic_guide_gravity.comp
+++ b/mcstas-comps/optics/Elliptic_guide_gravity.comp
@@ -1213,7 +1213,6 @@ TRACE
   latestParticleCollision.collisionType=0;
 
   PROP_Z0;
-  SCATTER;
 
   double Gloc;
   double Gx,Gy,Gz;
@@ -1229,6 +1228,7 @@ TRACE
 		    || fabs(y) > guideInfo.entranceVerticalWidth/2.0 )
 		  ABSORB;
 
+    SCATTER;
 
 	int bounces = 0;
 	for(bounces = 0; bounces <= 1000; bounces++){


### PR DESCRIPTION
regardles of the ray hitting the entrance of the guide or not.

This was fixed by moving the SCATTER to after rays outside the entrance were removed.