### PR TITLE
meta-pkgs:deb:mcxtrace: add libgsl-dev as dependency

### DIFF
--- a/meta-pkgs/deb/control.mcxtrace-suite-python
+++ b/meta-pkgs/deb/control.mcxtrace-suite-python
@@ -3,7 +3,7 @@ Version: @VERSION@
 Section: main
 Priority: optional
 Architecture: all
-Depends: mcxtrace, mcxtrace-comps, mcxtrace-tools-python-mxplot-pyqtgraph, mcxtrace-tools-python-mxplot-matplotlib, mcxtrace-tools-python-mxdisplay-pyqtgraph, mcxtrace-tools-python-mxdisplay-webgl, mcxtrace-tools-python-mxrun, mcxtrace-tools-python-mxdoc, mcxtrace-tools-python-mccodelib, mcxtrace-tools-python-mxgui, mcxtrace-manuals, mcxtrace-tools-python-mxtest, mcpl, libxrl-dev
+Depends: mcxtrace, mcxtrace-comps, mcxtrace-tools-python-mxplot-pyqtgraph, mcxtrace-tools-python-mxplot-matplotlib, mcxtrace-tools-python-mxdisplay-pyqtgraph, mcxtrace-tools-python-mxdisplay-webgl, mcxtrace-tools-python-mxrun, mcxtrace-tools-python-mxdoc, mcxtrace-tools-python-mccodelib, mcxtrace-tools-python-mxgui, mcxtrace-manuals, mcxtrace-tools-python-mxtest, mcpl, libxrl-dev, libgsl-dev
 Installed-Size:
 Maintainer: Peter Willendrup <pkwi@fysik.dtu.dk>
 Description: A metapackage for McXtrace + python tools


### PR DESCRIPTION
Add dependency on libgsl for debian packages.